### PR TITLE
Add wrapper for tex_image_3d_with_u16_data

### DIFF
--- a/src/core/program.rs
+++ b/src/core/program.rs
@@ -27,18 +27,24 @@ impl Program
         gl.attach_shader(&id, &frag_shader);
         let success = gl.link_program(&id);
 
+        if !success {
+            let mut message = "Failed to compile shader program:\n".to_string();
+            if let Some(log) = gl.get_program_info_log(&id) {
+                message = format!("{}\nLink error: {}", message, log);
+            }
+            if let Some(log) = gl.get_shader_info_log(&vert_shader) {
+                message = format!("{}\nVertex shader error: {}", message, log);
+            }
+            if let Some(log) = gl.get_shader_info_log(&frag_shader) {
+                message = format!("{}\nFragment shader error: {}", message, log);
+            }
+            return Err(Error::FailedToLinkProgram { message });
+        }
+
         gl.detach_shader(&id, &vert_shader);
         gl.detach_shader(&id, &frag_shader);
         gl.delete_shader(Some(&vert_shader));
         gl.delete_shader(Some(&frag_shader));
-
-        if !success {
-            let mut message = "Failed to compile shader program:\n".to_string();
-            if let Some(log) = gl.get_program_info_log(&id) {message = format!("{}\nLink error: {}", message, log);}
-            if let Some(log) = gl.get_shader_info_log(&vert_shader) {message = format!("{}\nVertex shader error: {}", message, log);}
-            if let Some(log) = gl.get_shader_info_log(&frag_shader) {message = format!("{}\nFragment shader error: {}", message, log);}
-            return Err(Error::FailedToLinkProgram {message});
-        }
 
         // Init vertex attributes
         let num_attribs = gl.get_program_parameter(&id, consts::ACTIVE_ATTRIBUTES);

--- a/src/gl/ogl.rs
+++ b/src/gl/ogl.rs
@@ -315,13 +315,6 @@ impl Glstruct {
     pub fn use_program(&self, program: &Program)
     {
         unsafe {
-            let mut current = -1;
-            self.inner.GetIntegerv(consts::CURRENT_PROGRAM, &mut current);
-            if current != 0
-            {
-                println!("{}", current);
-                panic!();
-            }
             self.inner.UseProgram(*program);
         }
     }

--- a/src/gl/ogl.rs
+++ b/src/gl/ogl.rs
@@ -671,6 +671,35 @@ impl Glstruct {
         }
     }
 
+    pub fn tex_image_3d_with_u16_data(
+        &self,
+        target: u32,
+        level: u32,
+        internalformat: u32,
+        width: u32,
+        height: u32,
+        depth: u32,
+        border: u32,
+        format: u32,
+        data_type: u32,
+        pixels: &[u16],
+    ) {
+        unsafe {
+            self.inner.TexImage3D(
+                target,
+                level as i32,
+                internalformat as i32,
+                width as i32,
+                height as i32,
+                depth as i32,
+                border as i32,
+                format,
+                data_type,
+                pixels.as_ptr() as *const consts::types::GLvoid,
+            );
+        }
+    }
+
     pub fn tex_parameteri(&self, target: u32, pname: u32, param: i32)
     {
         unsafe {

--- a/src/gl/wgl2.rs
+++ b/src/gl/wgl2.rs
@@ -221,7 +221,44 @@ impl Glstruct {
                                                                                               format,
                                                                                               data_type,
                                                                                               Some(&array)).unwrap();
+    }
 
+    pub fn tex_image_3d_with_u16_data(
+        &self,
+        target: u32,
+        level: u32,
+        internalformat: u32,
+        width: u32,
+        height: u32,
+        depth: u32,
+        border: u32,
+        format: u32,
+        data_type: u32,
+        pixels: &[u16],
+    ) {
+        use wasm_bindgen::JsCast;
+        let memory_buffer = wasm_bindgen::memory()
+            .dyn_into::<js_sys::WebAssembly::Memory>()
+            .unwrap()
+            .buffer();
+        let data_location = pixels.as_ptr() as u32 / 2;
+        let array = js_sys::Uint16Array::new(&memory_buffer)
+            .subarray(data_location, data_location + pixels.len() as u32);
+
+        self.inner
+            .tex_image_3d_with_opt_array_buffer_view(
+                target,
+                level as i32,
+                internalformat as i32,
+                width as i32,
+                height as i32,
+                depth as i32,
+                border as i32,
+                format,
+                data_type,
+                Some(&array),
+            )
+            .unwrap();
     }
 
     pub fn framebuffer_texture_2d(&self, target: u32, attachment: u32, textarget: u32, texture: &Texture, level: u32)


### PR DESCRIPTION
I've added a function to the gl implementations which allows uploading a 3D 16-bit monochrome texture in my fork.
Maybe it's interesting to integrate it into upstream as well?

Also, I did some other small fixes. If you prefer I could submit separate PRs as well.