### PR TITLE
Add Window settings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4"
 web-sys = { version = "0.3", features = ['Document', 'Element', 'Node', 'HtmlElement', 'HtmlCanvasElement', 'Window', 'CssStyleDeclaration', 'Event', 'MouseEvent', 'EventTarget', 'WheelEvent', 'KeyboardEvent', 'TouchEvent', 'TouchList', 'Touch','WebGlBuffer','WebGlFramebuffer', 'WebGl2RenderingContext', 'WebGlProgram', 'WebGlShader', 'WebGlTexture', 'WebGlUniformLocation', 'WebGlVertexArrayObject', 'WebGlActiveInfo', 'WebGlSync', 'Performance','Headers', 'Request', 'RequestInit', 'RequestMode', 'Response'] }
 gloo-timers = "0.2"
+serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 rand = "0.7"

--- a/src/window.rs
+++ b/src/window.rs
@@ -6,6 +6,9 @@
 //! can be replaced by any other window with similar functionality.
 //!
 
+mod common;
+pub use common::*;
+
 #[doc(hidden)]
 #[cfg(all(feature = "glutin-window", not(target_arch = "wasm32")))]
 pub mod glutin_window;

--- a/src/window/common.rs
+++ b/src/window/common.rs
@@ -1,0 +1,22 @@
+/// Render context settings.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct WindowSettings {
+    /// Whether VSync is enabled.
+    ///
+    /// On WebGL this has no effect since VSync is always on.
+    pub vsync: bool,
+    /// Number of antialiasing samples.
+    ///
+    /// On WebGL, this can only be off (0) or on (>0).
+    /// The actual number of samples depends on browser settings.
+    pub multisamples: u8,
+}
+
+impl Default for WindowSettings {
+    fn default() -> Self {
+        Self {
+            vsync: true,
+            multisamples: 4,
+        }
+    }
+}


### PR DESCRIPTION
Hi !
This is a very interesting project.

I added the possibility to configure the context (currently vsync and multisampling).

### Usage
Instead of
```rust
let window = Window::new("Triangle", Some((1280, 720))).unwrap();`
```
You use
```rust
let settings = WindowSettings { vsync: true, multisamples: 4 }; //These are the defaults by the way, compatible with previous hardcoded values.
// Or WindowSettings { multisamples: 4, ..Default::default() }; if only a subset of settings is needed
let window = Window::new_with_settings("Triangle", Some((1280, 720)), settings).unwrap();
```

### Suggestions
Maybe you should start using `rustfmt` to format code, to keep a consistent style (especially when merging code from others) and allow to reformat code automatically. I tried to keep the existing style.

Also, continuous integration would be great, to check the code at least compiles on main platforms (Windows, Linux, MacOS) and to wasm. It could also enforce te code style. If you are interested, let me know, I could work on it and do a PR.