### PR TITLE
Add continuous integration

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,67 @@
+name: Rust
+
+on: [ push, pull_request ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  desktop:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        rust: [ stable, nightly ]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          components: rustfmt, clippy
+          override: true
+
+      - name: Check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+      - name: Rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: -- --check
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build examples
+        run: |
+          for example in `find examples -maxdepth 1 -mindepth 1 -type d -printf "%f\n"` ; do
+            if [ -f "examples/$example/Cargo.toml" ]; then
+              echo "::group::Build $example example"
+              wasm-pack build examples/$example --target web --out-name web --out-dir ../../pkg --dev
+              echo "::endgroup::"
+            fi
+          done
+

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,7 +60,9 @@ jobs:
           for example in `find examples -maxdepth 1 -mindepth 1 -type d -printf "%f\n"` ; do
             if [ -f "examples/$example/Cargo.toml" ]; then
               echo "::group::Build $example example"
-              wasm-pack build examples/$example --target web --out-name web --out-dir ../../pkg --dev
+              pushd examples/$example
+              CARGO_TARGET_DIR=../../target wasm-pack build --target web --out-name web --dev
+              popd
               echo "::endgroup::"
             fi
           done


### PR DESCRIPTION
Hi !
As I said on my previous PR, here is some CI !

It does the following :
- Compiles the examples to wasm using `wasm-pack`
- With Rust stable/nightly on Windows/Linux/MacOS :
  - `cargo check`
  - Check the formatting with `rustfmt`
  - `cargo test` (there are no tests currently but it checks the examples are compilable and it is ready for when tests are added 😃)

An example run is available [here](https://github.com/Mikayex/three-d/actions/runs/680840703).