### PR TITLE
Fix #86

### DIFF
--- a/src/window/glutin_window.rs
+++ b/src/window/glutin_window.rs
@@ -79,7 +79,7 @@ impl Window {
         settings: &WindowSettings,
         event_loop: &EventLoop<()>,
     ) -> Result<WindowedContext<NotCurrent>, WindowError> {
-        if !settings.multisamples.is_power_of_two() {
+        if settings.multisamples > 0 && !settings.multisamples.is_power_of_two() {
             return Err(WindowError::InvalidNumberOfSamples);
         }
         let window_builder = if let Some((width, height)) = size {


### PR DESCRIPTION
Fix issue #86 : when multisamples is 0, `InvalidNumberOfSamples` is returned as an error.

[It seems is_power_of_two() return false for 0...](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=19508d36bd66ae6e8ac918846c58a14b)