### PR TITLE
Allow rendering only when new events occurred

### DIFF
--- a/examples/fog/main.rs
+++ b/examples/fog/main.rs
@@ -164,7 +164,10 @@ fn main() {
                             ..Default::default()
                         }
                     } else {
-                        FrameOutput::default()
+                        FrameOutput {
+                            wait_next_event: true,
+                            ..Default::default()
+                        }
                     }
                 })
                 .unwrap();

--- a/examples/forest/main.rs
+++ b/examples/forest/main.rs
@@ -256,6 +256,7 @@ fn main() {
                     } else {
                         FrameOutput {
                             swap_buffers: redraw,
+                            wait_next_event: true,
                             ..Default::default()
                         }
                     }

--- a/examples/mandelbrot/main.rs
+++ b/examples/mandelbrot/main.rs
@@ -94,6 +94,7 @@ fn main() {
             } else {
                 FrameOutput {
                     swap_buffers: redraw,
+                    wait_next_event: true,
                     ..Default::default()
                 }
             }

--- a/examples/statues/main.rs
+++ b/examples/statues/main.rs
@@ -215,6 +215,7 @@ fn main() {
                     } else {
                         FrameOutput {
                             swap_buffers: redraw,
+                            wait_next_event: true,
                             ..Default::default()
                         }
                     }

--- a/examples/texture/main.rs
+++ b/examples/texture/main.rs
@@ -186,6 +186,7 @@ fn main() {
                     } else {
                         FrameOutput {
                             swap_buffers: redraw,
+                            wait_next_event: true,
                             ..Default::default()
                         }
                     }

--- a/examples/wireframe/main.rs
+++ b/examples/wireframe/main.rs
@@ -254,6 +254,7 @@ fn main() {
                     } else {
                         FrameOutput {
                             swap_buffers: redraw,
+                            wait_next_event: true,
                             ..Default::default()
                         }
                     }

--- a/src/frame/output.rs
+++ b/src/frame/output.rs
@@ -23,6 +23,12 @@ pub struct FrameOutput {
     /// Only works on desktop, will be ignored on web.
     ///
     pub screenshot: Option<std::path::PathBuf>,
+
+    ///
+    /// Whether to stop the render loop until next event.
+    /// Only works on desktop, will be ignored on web.
+    ///
+    pub wait_next_event: bool,
 }
 
 impl Default for FrameOutput {
@@ -31,6 +37,7 @@ impl Default for FrameOutput {
             exit: false,
             swap_buffers: true,
             screenshot: None,
+            wait_next_event: false,
         }
     }
 }

--- a/src/frame/output.rs
+++ b/src/frame/output.rs
@@ -26,7 +26,6 @@ pub struct FrameOutput {
 
     ///
     /// Whether to stop the render loop until next event.
-    /// Only works on desktop, will be ignored on web.
     ///
     pub wait_next_event: bool,
 }

--- a/src/window/glutin_window.rs
+++ b/src/window/glutin_window.rs
@@ -117,12 +117,14 @@ impl Window {
         let mut first_frame = true;
         let context = self.gl.clone();
         self.event_loop.run(move |event, _, control_flow| {
-            *control_flow = ControlFlow::Poll;
             match event {
                 Event::LoopDestroyed => {
                     return;
                 }
                 Event::MainEventsCleared => {
+                    windowed_context.window().request_redraw();
+                }
+                Event::RedrawRequested(_) => {
                     let now = std::time::Instant::now();
                     let duration = now.duration_since(last_time);
                     last_time = now;
@@ -159,6 +161,12 @@ impl Window {
                     }
                     if frame_output.swap_buffers {
                         windowed_context.swap_buffers().unwrap();
+                    }
+                    if frame_output.wait_next_event {
+                        *control_flow = ControlFlow::Wait;
+                    } else {
+                        *control_flow = ControlFlow::Poll;
+                        windowed_context.window().request_redraw();
                     }
                     if let Some(ref path) = frame_output.screenshot {
                         let pixels = crate::Screen::read_color(


### PR DESCRIPTION
On desktop I noticed that on examples that do rendering only when needed (using the `swap_buffers: false` feature), like the texture example, the CPU usage was high when no events. This is due to the tight event/render loop (becoming a busy loop) when there is nothing to render.

I added another FrameOutput argument, `wait_next_event`, to wait until an event occurs before calling the next render_loop. By default its value is false to maintain old behavior (=opt-in). This is especially useful for programs that do not depend on time (no animations) and only need to redraw on user interaction such as model viewers, GUIs, etc...

It allows saving battery time on devices like phone/tablet or laptops and reduce heat/fan noise unnecessarily.

This is implemented for desktop and web platforms (although there was no CPU usage problem on web (chrome), but it's nice to save battery/heat).