### PR TITLE
Fix egui viewport dimensions when using a non-integer pixel scaling factor

### DIFF
--- a/src/gui/egui_gui.rs
+++ b/src/gui/egui_gui.rs
@@ -163,8 +163,8 @@ impl GUI {
         let index_buffer = ElementBuffer::new_with_u32(&self.context, &indices)?;
 
         let viewport = Viewport::new_at_origo(
-            width * pixels_per_point as usize,
-            height * pixels_per_point as usize,
+            (width as f32 * pixels_per_point).round() as usize,
+            (height as f32 * pixels_per_point).round() as usize,
         );
 
         let render_states = RenderStates {


### PR DESCRIPTION
So having tested the master branch today, I discovered that egui was still rendering with the wrong viewport dimension size when using a non-integer display scaling factor. So I thought I'd prepare a contribution to try to fix it.

Prior to this fix, it was casting pixels_per_point to a usize, so non-integer scaling factors (for instance, 1.5) resulted in rendering
the gui with the wrong viewport dimensions. This bug could be reproduced by running the lighting example with a display scale of 150%.

The main fix here is to ensure the cast happens after applying the scaling factor, and to make sure the scaling factor multiplication happens in f32.

A more subtle change is that we explicitly round the result to the nearest integer. This is to reduce the potential error in cases where the multiplication does not produce a whole number.