### PR TITLE
Event refactoring

### DIFF
--- a/examples/fireworks/main.rs
+++ b/examples/fireworks/main.rs
@@ -53,6 +53,11 @@ fn main() {
     let mut color_index = 0;
     window
         .render_loop(move |frame_input| {
+            // Quit if Cmd-Q/Ctrl-Q pressed.
+            if frame_input.has_key_quit() {
+                return FrameOutput::exit();
+            }
+
             camera.set_aspect(frame_input.viewport.aspect()).unwrap();
 
             for event in frame_input.events.iter() {

--- a/examples/fog/main.rs
+++ b/examples/fog/main.rs
@@ -81,6 +81,11 @@ fn main() {
             let mut depth_texture = None;
             window
                 .render_loop(move |frame_input| {
+                    // Quit if Cmd-Q/Ctrl-Q pressed.
+                    if frame_input.has_key_quit() {
+                        return FrameOutput::exit();
+                    }
+
                     let mut change = frame_input.first_frame;
                     change |= camera.set_aspect(frame_input.viewport.aspect()).unwrap();
                     if change {

--- a/examples/forest/main.rs
+++ b/examples/forest/main.rs
@@ -167,6 +167,11 @@ fn main() {
             let mut rotating = false;
             window
                 .render_loop(move |frame_input| {
+                    // Quit if Cmd-Q/Ctrl-Q pressed.
+                    if frame_input.has_key_quit() {
+                        return FrameOutput::exit();
+                    }
+
                     let mut redraw = frame_input.first_frame;
                     redraw |= camera.set_aspect(frame_input.viewport.aspect()).unwrap();
 

--- a/examples/lighting/main.rs
+++ b/examples/lighting/main.rs
@@ -112,6 +112,11 @@ fn main() {
 
             window
                 .render_loop(move |mut frame_input| {
+                    // Quit if Cmd-Q/Ctrl-Q pressed.
+                    if frame_input.has_key_quit() {
+                        return FrameOutput::exit();
+                    }
+
                     let mut change = frame_input.first_frame;
                     let mut panel_width = frame_input.viewport.width;
                     change |= gui
@@ -247,19 +252,19 @@ fn main() {
 
                     for event in frame_input.events.iter() {
                         match event {
-                            Event::MouseClick {
+                            Event::MouseClick(MouseClickEvent {
                                 state,
                                 button,
                                 handled,
                                 ..
-                            } => {
+                            }) => {
                                 if !handled {
                                     rotating =
                                         *button == MouseButton::Left && *state == State::Pressed;
                                     change = true;
                                 }
                             }
-                            Event::MouseMotion { delta, handled, .. } => {
+                            Event::MouseMotion(MouseMotionEvent { delta, handled, .. }) => {
                                 if !handled && rotating {
                                     camera
                                         .rotate_around_with_fixed_up(
@@ -271,7 +276,7 @@ fn main() {
                                     change = true;
                                 }
                             }
-                            Event::MouseWheel { delta, handled, .. } => {
+                            Event::MouseWheel(MouseWheelEvent { delta, handled, .. }) => {
                                 if !handled {
                                     camera
                                         .zoom_towards(&target, 0.02 * delta.1 as f32, 5.0, 100.0)

--- a/examples/mandelbrot/main.rs
+++ b/examples/mandelbrot/main.rs
@@ -48,6 +48,11 @@ fn main() {
     let mut pick: Option<((f64, f64), Vec3)> = None;
     window
         .render_loop(move |frame_input| {
+            // Quit if Cmd-Q/Ctrl-Q pressed.
+            if frame_input.has_key_quit() {
+                return FrameOutput::exit();
+            }
+
             let mut redraw = frame_input.first_frame;
             redraw |= camera.set_aspect(frame_input.viewport.aspect()).unwrap();
 

--- a/examples/pbr/main.rs
+++ b/examples/pbr/main.rs
@@ -82,6 +82,11 @@ fn main() {
         let mut rotating = false;
         window
             .render_loop(move |frame_input| {
+                // Quit if Cmd-Q/Ctrl-Q pressed.
+                if frame_input.has_key_quit() {
+                    return FrameOutput::exit();
+                }
+
                 camera.set_aspect(frame_input.viewport.aspect()).unwrap();
 
                 for event in frame_input.events.iter() {

--- a/examples/picking/main.rs
+++ b/examples/picking/main.rs
@@ -65,6 +65,11 @@ fn main() {
             let mut rotating = false;
             window
                 .render_loop(move |frame_input| {
+                    // Quit if Cmd-Q/Ctrl-Q pressed.
+                    if frame_input.has_key_quit() {
+                        return FrameOutput::exit();
+                    }
+
                     let mut change = frame_input.first_frame;
                     change |= camera.set_aspect(frame_input.viewport.aspect()).unwrap();
 

--- a/examples/statues/main.rs
+++ b/examples/statues/main.rs
@@ -105,6 +105,11 @@ fn main() {
             let mut is_primary_camera = true;
             window
                 .render_loop(move |frame_input| {
+                    // Quit if Cmd-Q/Ctrl-Q pressed.
+                    if frame_input.has_key_quit() {
+                        return FrameOutput::exit();
+                    }
+
                     let mut redraw = frame_input.first_frame;
                     redraw |= primary_camera
                         .set_aspect(frame_input.viewport.aspect())

--- a/examples/texture/main.rs
+++ b/examples/texture/main.rs
@@ -102,6 +102,11 @@ fn main() {
             let mut rotating = false;
             window
                 .render_loop(move |frame_input| {
+                    // Quit if Cmd-Q/Ctrl-Q pressed.
+                    if frame_input.has_key_quit() {
+                        return FrameOutput::exit();
+                    }
+
                     let mut redraw = frame_input.first_frame;
                     redraw |= camera.set_aspect(frame_input.viewport.aspect()).unwrap();
 

--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -50,6 +50,11 @@ fn main() {
     // Start the main render loop
     window.render_loop(move |frame_input: FrameInput| // Begin a new frame with an updated frame input
     {
+        // Quit if Cmd-Q/Ctrl-Q pressed.
+        if frame_input.has_key_quit() {
+            return FrameOutput::exit();
+        }
+
         // Ensure the aspect ratio of the camera matches the aspect ratio of the window viewport
         camera.set_aspect(frame_input.viewport.aspect()).unwrap();
 

--- a/src/frame/input.rs
+++ b/src/frame/input.rs
@@ -28,6 +28,13 @@ pub struct FrameInput {
     pub first_frame: bool,
 }
 
+impl FrameInput {
+    /// Has a keyboard quit event.
+    pub fn has_key_quit(&self) -> bool {
+        self.events.iter().any(Event::is_key_quit)
+    }
+}
+
 /// State of a key or button click.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub enum State {
@@ -49,40 +56,75 @@ pub enum MouseButton {
     Middle,
 }
 
+/// Mouse click event.
+#[derive(Clone, Debug)]
+pub struct MouseClickEvent {
+    pub state: State,
+    pub button: MouseButton,
+    pub position: (f64, f64),
+    pub modifiers: Modifiers,
+    pub handled: bool,
+}
+
+/// Mouse motion event.
+#[derive(Clone, Debug)]
+pub struct MouseMotionEvent {
+    pub delta: (f64, f64),
+    pub position: (f64, f64),
+    pub modifiers: Modifiers,
+    pub handled: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct MouseWheelEvent {
+    pub delta: (f64, f64),
+    pub position: (f64, f64),
+    pub modifiers: Modifiers,
+    pub handled: bool,
+}
+
+/// Keyboard event.
+#[derive(Clone, Debug)]
+pub struct KeyEvent {
+    pub state: State,
+    pub kind: Key,
+    pub modifiers: Modifiers,
+    pub handled: bool,
+}
+
+impl KeyEvent {
+    /// Is this a quit event (Cmd-Q on mac, Ctrl-Q elsewhere).
+    pub fn is_quit(&self) -> bool {
+        self.modifiers.command == State::Pressed && self.kind == Key::Q
+    }
+}
+
+/// Keyboard modifiers changed.
+#[derive(Clone, Debug)]
+pub struct ModifiersChangeEvent {
+    pub modifiers: Modifiers,
+}
+
 /// An input event (from mouse, keyboard or similar).
 #[derive(Clone, Debug)]
 pub enum Event {
-    MouseClick {
-        state: State,
-        button: MouseButton,
-        position: (f64, f64),
-        modifiers: Modifiers,
-        handled: bool,
-    },
-    MouseMotion {
-        delta: (f64, f64),
-        position: (f64, f64),
-        modifiers: Modifiers,
-        handled: bool,
-    },
-    MouseWheel {
-        delta: (f64, f64),
-        position: (f64, f64),
-        modifiers: Modifiers,
-        handled: bool,
-    },
+    MouseClick(MouseClickEvent),
+    MouseMotion(MouseMotionEvent),
+    MouseWheel(MouseWheelEvent),
     MouseEnter,
     MouseLeave,
-    Key {
-        state: State,
-        kind: Key,
-        modifiers: Modifiers,
-        handled: bool,
-    },
-    ModifiersChange {
-        modifiers: Modifiers,
-    },
+    Key(KeyEvent),
+    ModifiersChange(ModifiersChangeEvent),
     Text(String),
+}
+
+impl Event {
+    pub fn is_key_quit(&self) -> bool {
+        match self {
+            Event::Key(e) => e.is_quit(),
+            _ => false,
+        }
+    }
 }
 
 /// Keyboard key input.

--- a/src/frame/output.rs
+++ b/src/frame/output.rs
@@ -30,6 +30,16 @@ pub struct FrameOutput {
     pub wait_next_event: bool,
 }
 
+impl FrameOutput {
+    /// Create an output which requests the exit from the loop.
+    pub fn exit() -> FrameOutput {
+        FrameOutput {
+            exit: true,
+            ..Default::default()
+        }
+    }
+}
+
 impl Default for FrameOutput {
     fn default() -> Self {
         Self {

--- a/src/gui/egui_gui.rs
+++ b/src/gui/egui_gui.rs
@@ -63,19 +63,19 @@ impl GUI {
         for event in frame_input.events.iter_mut() {
             if self.egui_context.wants_pointer_input() {
                 match event {
-                    Event::MouseClick {
+                    Event::MouseClick(MouseClickEvent {
                         ref mut handled, ..
-                    } => {
+                    }) => {
                         *handled = true;
                     }
-                    Event::MouseWheel {
+                    Event::MouseWheel(MouseWheelEvent {
                         ref mut handled, ..
-                    } => {
+                    }) => {
                         *handled = true;
                     }
-                    Event::MouseMotion {
+                    Event::MouseMotion(MouseMotionEvent {
                         ref mut handled, ..
-                    } => {
+                    }) => {
                         *handled = true;
                     }
                     _ => {}
@@ -85,9 +85,9 @@ impl GUI {
 
             if self.egui_context.wants_keyboard_input() {
                 match event {
-                    Event::Key {
+                    Event::Key(KeyEvent {
                         ref mut handled, ..
-                    } => {
+                    }) => {
                         *handled = true;
                     }
                     _ => {}
@@ -211,12 +211,12 @@ fn construct_input_state(frame_input: &mut FrameInput) -> egui::RawInput {
     let mut egui_events = Vec::new();
     for event in frame_input.events.iter() {
         match event {
-            Event::Key {
+            Event::Key(KeyEvent {
                 kind,
                 state,
                 modifiers,
                 handled,
-            } => {
+            }) => {
                 if !handled {
                     egui_events.push(egui::Event::Key {
                         key: translate_to_egui_key_code(kind),
@@ -225,13 +225,13 @@ fn construct_input_state(frame_input: &mut FrameInput) -> egui::RawInput {
                     });
                 }
             }
-            Event::MouseClick {
+            Event::MouseClick(MouseClickEvent {
                 state,
                 button,
                 position,
                 modifiers,
                 handled,
-            } => {
+            }) => {
                 if !handled {
                     egui_events.push(egui::Event::PointerButton {
                         pos: egui::Pos2 {
@@ -248,9 +248,9 @@ fn construct_input_state(frame_input: &mut FrameInput) -> egui::RawInput {
                     });
                 }
             }
-            Event::MouseMotion {
+            Event::MouseMotion(MouseMotionEvent {
                 position, handled, ..
-            } => {
+            }) => {
                 if !handled {
                     egui_events.push(egui::Event::PointerMoved(egui::Pos2 {
                         x: position.0 as f32,
@@ -264,12 +264,12 @@ fn construct_input_state(frame_input: &mut FrameInput) -> egui::RawInput {
             Event::MouseLeave => {
                 egui_events.push(egui::Event::PointerGone);
             }
-            Event::MouseWheel { delta, handled, .. } => {
+            Event::MouseWheel(MouseWheelEvent { delta, handled, .. }) => {
                 if !handled {
                     scroll_delta = egui::Vec2::new(delta.0 as f32, delta.1 as f32);
                 }
             }
-            Event::ModifiersChange { modifiers } => {
+            Event::ModifiersChange(ModifiersChangeEvent { modifiers }) => {
                 egui_modifiers = egui::Modifiers {
                     alt: modifiers.alt == State::Pressed,
                     ctrl: modifiers.ctrl == State::Pressed,

--- a/src/window/glutin_window.rs
+++ b/src/window/glutin_window.rs
@@ -1,7 +1,7 @@
 use crate::frame::*;
 use crate::math::*;
 use crate::window::WindowSettings;
-use crate::Context;
+use crate::{Context, Key};
 use glutin::event::{Event, WindowEvent};
 use glutin::event_loop::{ControlFlow, EventLoop};
 use glutin::window::WindowBuilder;
@@ -186,12 +186,12 @@ impl Window {
                                 crate::State::Released
                             };
                             if let Some(kind) = translate_virtual_key_code(keycode) {
-                                events.push(crate::Event::Key {
+                                events.push(crate::Event::Key(KeyEvent {
                                     state,
                                     kind,
                                     modifiers,
                                     handled: false,
-                                });
+                                }));
                             } else {
                                 if keycode == VirtualKeyCode::LControl
                                     || keycode == VirtualKeyCode::RControl
@@ -200,23 +200,31 @@ impl Window {
                                     if !cfg!(target_os = "macos") {
                                         modifiers.command = state;
                                     }
-                                    events.push(crate::Event::ModifiersChange { modifiers });
+                                    events.push(crate::Event::ModifiersChange(
+                                        ModifiersChangeEvent { modifiers },
+                                    ));
                                 } else if keycode == VirtualKeyCode::LAlt
                                     || keycode == VirtualKeyCode::RAlt
                                 {
                                     modifiers.alt = state;
-                                    events.push(crate::Event::ModifiersChange { modifiers });
+                                    events.push(crate::Event::ModifiersChange(
+                                        ModifiersChangeEvent { modifiers },
+                                    ));
                                 } else if keycode == VirtualKeyCode::LShift
                                     || keycode == VirtualKeyCode::RShift
                                 {
                                     modifiers.shift = state;
-                                    events.push(crate::Event::ModifiersChange { modifiers });
+                                    events.push(crate::Event::ModifiersChange(
+                                        ModifiersChangeEvent { modifiers },
+                                    ));
                                 } else if keycode == VirtualKeyCode::LWin
                                     || keycode == VirtualKeyCode::RWin
                                 {
                                     if cfg!(target_os = "macos") {
                                         modifiers.command = state;
-                                        events.push(crate::Event::ModifiersChange { modifiers });
+                                        events.push(crate::Event::ModifiersChange(
+                                            ModifiersChangeEvent { modifiers },
+                                        ));
                                     }
                                 }
                             }
@@ -227,7 +235,7 @@ impl Window {
                             match delta {
                                 glutin::event::MouseScrollDelta::LineDelta(x, y) => {
                                     let line_height = 24.0; // TODO
-                                    events.push(crate::Event::MouseWheel {
+                                    events.push(crate::Event::MouseWheel(MouseWheelEvent {
                                         delta: (
                                             (*x * line_height) as f64,
                                             (*y * line_height) as f64,
@@ -235,17 +243,17 @@ impl Window {
                                         position,
                                         modifiers,
                                         handled: false,
-                                    });
+                                    }));
                                 }
                                 glutin::event::MouseScrollDelta::PixelDelta(delta) => {
                                     let d =
                                         delta.to_logical(windowed_context.window().scale_factor());
-                                    events.push(crate::Event::MouseWheel {
+                                    events.push(crate::Event::MouseWheel(MouseWheelEvent {
                                         delta: (d.x, d.y),
                                         position,
                                         modifiers,
                                         handled: false,
-                                    });
+                                    }));
                                 }
                             }
                         }
@@ -264,13 +272,13 @@ impl Window {
                                 _ => None,
                             };
                             if let Some(b) = button {
-                                events.push(crate::Event::MouseClick {
+                                events.push(crate::Event::MouseClick(MouseClickEvent {
                                     state,
                                     button: b,
                                     position,
                                     modifiers,
                                     handled: false,
-                                });
+                                }));
                             }
                         }
                     }
@@ -281,12 +289,12 @@ impl Window {
                         } else {
                             (0.0, 0.0)
                         };
-                        events.push(crate::Event::MouseMotion {
+                        events.push(crate::Event::MouseMotion(MouseMotionEvent {
                             delta,
                             position: (p.x, p.y),
                             modifiers,
                             handled: false,
-                        });
+                        }));
                         cursor_pos = Some((p.x, p.y));
                     }
                     WindowEvent::ReceivedCharacter(ch) => {


### PR DESCRIPTION
* Add types for `Event` variants
* Add `FrameOutput::exit()` shortcut
* Add `KeyEvent::is_quit`, `Event::is_key_quit` and
  `FrameInput::has_key_quit`
* Add `FrameInput::has_key_quit`
* Quit examples on Cmd-Q/Ctrl-Q