### PR TITLE
CPUVertexBuffer newtype

### DIFF
--- a/examples/forest/main.rs
+++ b/examples/forest/main.rs
@@ -132,9 +132,9 @@ fn main() {
             let mut plane = Mesh::new_with_material(
                 &context,
                 &CPUMesh {
-                    positions: vec![
+                    positions: CPUVertexBuffer::from_xyz(vec![
                         -10000.0, 0.0, 10000.0, 10000.0, 0.0, 10000.0, 0.0, 0.0, -10000.0,
-                    ],
+                    ]),
                     normals: Some(vec![0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0]),
                     ..Default::default()
                 },

--- a/examples/lighting/main.rs
+++ b/examples/lighting/main.rs
@@ -45,9 +45,9 @@ fn main() {
             let mut plane = Mesh::new_with_material(
                 &context,
                 &CPUMesh {
-                    positions: vec![
+                    positions: CPUVertexBuffer::from_xyz(vec![
                         -10000.0, -1.0, 10000.0, 10000.0, -1.0, 10000.0, 0.0, -1.0, -10000.0,
-                    ],
+                    ]),
                     normals: Some(vec![0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0]),
                     ..Default::default()
                 },

--- a/examples/mandelbrot/main.rs
+++ b/examples/mandelbrot/main.rs
@@ -34,7 +34,7 @@ fn main() {
         &context,
         &CPUMesh {
             indices: Some(Indices::U8(indices)),
-            positions,
+            positions: CPUVertexBuffer::from_xyz(positions),
             ..Default::default()
         },
     )

--- a/examples/pbr/main.rs
+++ b/examples/pbr/main.rs
@@ -42,9 +42,9 @@ fn main() {
         let plane = Mesh::new_with_material(
             &context,
             &CPUMesh {
-                positions: vec![
+                positions: CPUVertexBuffer::from_xyz(vec![
                     -10000.0, -1.3, 10000.0, 10000.0, -1.3, 10000.0, 0.0, -1.3, -10000.0,
-                ],
+                ]),
                 normals: Some(vec![0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0]),
                 ..Default::default()
             },

--- a/examples/texture/main.rs
+++ b/examples/texture/main.rs
@@ -42,7 +42,7 @@ fn main() {
         ],
         move |loaded| {
             let mut box_cpu_mesh = CPUMesh {
-                positions: cube_positions(),
+                positions: CPUVertexBuffer::from_xyz(cube_positions()),
                 uvs: Some(cube_uvs()),
                 ..Default::default()
             };

--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -39,7 +39,7 @@ fn main() {
         0, 0, 255, 255, // top
     ];
     let cpu_mesh = CPUMesh {
-        positions,
+        positions: CPUVertexBuffer::from_xyz(positions),
         colors: Some(colors),
         ..Default::default()
     };

--- a/examples/wireframe/main.rs
+++ b/examples/wireframe/main.rs
@@ -174,7 +174,7 @@ fn main() {
 }
 
 fn vertex_transformations(cpu_mesh: &CPUMesh) -> Vec<Mat4> {
-    let mut iter = cpu_mesh.positions.iter();
+    let mut iter = cpu_mesh.positions.data().iter();
     let mut vertex_transformations = Vec::new();
     while let Some(v) = iter.next() {
         vertex_transformations.push(Mat4::from_translation(vec3(
@@ -191,16 +191,8 @@ fn edge_transformations(cpu_mesh: &CPUMesh) -> Vec<Mat4> {
     let indices = cpu_mesh.indices.as_ref().unwrap().into_u32();
     for f in 0..indices.len() / 3 {
         let mut fun = |i1, i2| {
-            let p1 = vec3(
-                cpu_mesh.positions[i1 * 3],
-                cpu_mesh.positions[i1 * 3 + 1],
-                cpu_mesh.positions[i1 * 3 + 2],
-            );
-            let p2 = vec3(
-                cpu_mesh.positions[i2 * 3],
-                cpu_mesh.positions[i2 * 3 + 1],
-                cpu_mesh.positions[i2 * 3 + 2],
-            );
+            let p1 = cpu_mesh.positions.xyz_at(i1);
+            let p2 = cpu_mesh.positions.xyz_at(i2);
             let scale = Mat4::from_nonuniform_scale((p1 - p2).magnitude(), 1.0, 1.0);
             let rotation =
                 rotation_matrix_from_dir_to_dir(vec3(1.0, 0.0, 0.0), (p2 - p1).normalize());

--- a/src/core/vertex_buffer.rs
+++ b/src/core/vertex_buffer.rs
@@ -1,5 +1,57 @@
 use crate::context::{consts, Context};
 use crate::core::{Error, VertexBufferDataType};
+use crate::{vec3, Vec3};
+
+/// A buffer containing vertex data.
+#[derive(Default, Debug)]
+pub struct CPUVertexBuffer {
+    data: Vec<f32>,
+}
+
+impl CPUVertexBuffer {
+    pub fn from_xyz(xyz: Vec<f32>) -> CPUVertexBuffer {
+        Self::try_from_xyz(xyz).unwrap()
+    }
+
+    pub fn try_from_xyz(xyz: Vec<f32>) -> Result<CPUVertexBuffer, Error> {
+        if xyz.len() % 3 != 0 {
+            return Err(Error::MeshError {
+                message: format!("positions len must be divisible by 3: {}", xyz.len()),
+            });
+        }
+        Ok(CPUVertexBuffer { data: xyz })
+    }
+
+    pub fn xyz_at(&self, index: usize) -> Vec3 {
+        vec3(
+            self.data[index * 3],
+            self.data[index * 3 + 1],
+            self.data[index * 3 + 2],
+        )
+    }
+
+    pub fn set_xyz_at(&mut self, index: usize, vertex: Vec3) {
+        self.data[index * 3] = vertex.x;
+        self.data[index * 3 + 1] = vertex.y;
+        self.data[index * 3 + 2] = vertex.z;
+    }
+
+    pub fn position_count(&self) -> usize {
+        self.data.len() / 3
+    }
+
+    pub fn extend(&mut self, other: &CPUVertexBuffer) {
+        self.data.extend(&other.data);
+    }
+
+    pub fn data(&self) -> &[f32] {
+        &self.data
+    }
+
+    pub fn into_data(self) -> Vec<f32> {
+        self.data
+    }
+}
 
 ///
 /// A buffer containing per vertex data, for example positions, normals, uv coordinates or colors

--- a/src/io/gltf.rs
+++ b/src/io/gltf.rs
@@ -1,7 +1,10 @@
+use std::path::Path;
+
+use ::gltf::Gltf;
+
 use crate::definition::*;
 use crate::io::*;
-use ::gltf::Gltf;
-use std::path::Path;
+use crate::CPUVertexBuffer;
 
 impl<'a> Loaded<'a> {
     pub fn gltf(
@@ -165,7 +168,7 @@ fn parse_tree<'a>(
 
                 cpu_meshes.push(CPUMesh {
                     name: name.clone(),
-                    positions,
+                    positions: CPUVertexBuffer::from_xyz(positions),
                     normals,
                     indices,
                     colors,

--- a/src/io/obj.rs
+++ b/src/io/obj.rs
@@ -1,7 +1,9 @@
-use crate::definition::*;
-use crate::io::*;
 use std::collections::HashMap;
 use std::path::Path;
+
+use crate::definition::*;
+use crate::io::*;
+use crate::CPUVertexBuffer;
 
 impl<'a> Loaded<'a> {
     ///
@@ -150,7 +152,7 @@ impl<'a> Loaded<'a> {
                 cpu_meshes.push(CPUMesh {
                     name: object.name.to_string(),
                     material_name: mesh.material_name.clone(),
-                    positions,
+                    positions: CPUVertexBuffer::from_xyz(positions),
                     indices: Some(Indices::U32(indices)),
                     normals: Some(normals),
                     uvs: Some(uvs),

--- a/src/io/threed.rs
+++ b/src/io/threed.rs
@@ -1,6 +1,8 @@
+use std::path::Path;
+
 use crate::definition::*;
 use crate::io::*;
-use std::path::Path;
+use crate::CPUVertexBuffer;
 
 impl<'a> Loaded<'a> {
     ///
@@ -39,7 +41,11 @@ impl<'a> Loaded<'a> {
             cpu_meshes.push(CPUMesh {
                 name: mesh.name,
                 material_name: mesh.material_name,
-                positions: mesh.positions,
+                positions: CPUVertexBuffer::try_from_xyz(mesh.positions).map_err(|_| {
+                    IOError::FailedToLoad {
+                        message: format!("incorrect positions array"),
+                    }
+                })?,
                 indices: mesh.indices.map(|i| Indices::U32(i)),
                 normals: mesh.normals,
                 uvs: mesh.uvs,
@@ -169,7 +175,7 @@ impl Saver {
                 name: cpu_mesh.name,
                 material_name: cpu_mesh.material_name,
                 indices,
-                positions: cpu_mesh.positions,
+                positions: cpu_mesh.positions.into_data(),
                 normals: cpu_mesh.normals,
                 uvs: cpu_mesh.uvs,
             });

--- a/src/math/aabb.rs
+++ b/src/math/aabb.rs
@@ -1,4 +1,5 @@
 use crate::math::*;
+use crate::CPUVertexBuffer;
 
 ///
 /// A bounding box that aligns with the x, y and z axes.
@@ -25,7 +26,7 @@ impl AxisAlignedBoundingBox {
     /// Constructs a new bounding box and expands it such that all of the given positions are contained inside the bounding box.
     /// A position consisting of an x, y and z coordinate corresponds to three consecutive value in the positions array.
     ///
-    pub fn new_with_positions(positions: &[f32]) -> Self {
+    pub fn new_with_positions(positions: &CPUVertexBuffer) -> Self {
         let mut aabb = Self::empty();
         aabb.expand(positions);
         aabb
@@ -59,25 +60,15 @@ impl AxisAlignedBoundingBox {
     /// Expands the bounding box such that all of the given positions are contained inside the bounding box.
     /// A position consisting of an x, y and z coordinate corresponds to three consecutive value in the positions array.
     ///
-    pub fn expand(&mut self, positions: &[f32]) {
-        for i in 0..positions.len() {
-            match i % 3 {
-                0 => {
-                    self.min.x = f32::min(positions[i], self.min.x);
-                    self.max.x = f32::max(positions[i], self.max.x);
-                }
-                1 => {
-                    self.min.y = f32::min(positions[i], self.min.y);
-                    self.max.y = f32::max(positions[i], self.max.y);
-                }
-                2 => {
-                    self.min.z = f32::min(positions[i], self.min.z);
-                    self.max.z = f32::max(positions[i], self.max.z);
-                }
-                _ => {
-                    unreachable!()
-                }
-            };
+    pub fn expand(&mut self, positions: &CPUVertexBuffer) {
+        for i in 0..positions.position_count() {
+            let vertex = positions.xyz_at(i);
+            self.min.x = f32::min(vertex.x, self.min.x);
+            self.max.x = f32::max(vertex.x, self.max.x);
+            self.min.y = f32::min(vertex.y, self.min.y);
+            self.max.y = f32::max(vertex.y, self.max.y);
+            self.min.z = f32::min(vertex.z, self.min.z);
+            self.max.z = f32::max(vertex.z, self.max.z);
         }
     }
 

--- a/src/object/instanced_mesh.rs
+++ b/src/object/instanced_mesh.rs
@@ -66,7 +66,7 @@ impl InstancedMesh {
         transformations: &[Mat4],
         cpu_mesh: &CPUMesh,
     ) -> Result<Self, Error> {
-        let position_buffer = VertexBuffer::new_with_static(context, &cpu_mesh.positions)?;
+        let position_buffer = VertexBuffer::new_with_static(context, &cpu_mesh.positions.data())?;
         let normal_buffer = if let Some(ref normals) = cpu_mesh.normals {
             Some(VertexBuffer::new_with_static(context, normals)?)
         } else {

--- a/src/object/mesh.rs
+++ b/src/object/mesh.rs
@@ -111,28 +111,18 @@ impl Mesh {
                     ),
                 });
             }
-            if cpu_mesh.positions.len() % 3 != 0 {
-                return Err(Error::MeshError {
-                    message: format!(
-                        "when indices specified, element count in positions of mesh `{}` \
-                            must be divisible by 3, actual count is {}",
-                        cpu_mesh.name,
-                        cpu_mesh.positions.len()
-                    ),
-                });
-            }
             if cfg!(debug) {
                 let indices_valid = match indices {
                     Indices::U8(ind) => {
-                        let len = cpu_mesh.positions.len();
+                        let len = cpu_mesh.positions.position_count();
                         ind.iter().all(|&i| (i as usize) < len)
                     }
                     Indices::U16(ind) => {
-                        let len = cpu_mesh.positions.len();
+                        let len = cpu_mesh.positions.position_count();
                         ind.iter().all(|&i| (i as usize) < len)
                     }
                     Indices::U32(ind) => {
-                        let len = cpu_mesh.positions.len();
+                        let len = cpu_mesh.positions.position_count();
                         ind.iter().all(|&i| (i as usize) < len)
                     }
                 };
@@ -142,19 +132,19 @@ impl Mesh {
                             "some indices of mesh `{}` \
                                 are outside of valid number of positions, which is {}",
                             cpu_mesh.name,
-                            cpu_mesh.positions.len()
+                            cpu_mesh.positions.position_count()
                         ),
                     });
                 }
             }
         } else {
-            if cpu_mesh.positions.len() % 9 != 0 {
+            if cpu_mesh.positions.position_count() % 3 != 0 {
                 return Err(Error::MeshError {
                     message: format!(
                         "when indices unspecified, element count in positions of mesh `{}` \
-                            must be divisible by 9, actual count is {}",
+                            must be divisible by 3, actual count is {}",
                         cpu_mesh.name,
-                        cpu_mesh.positions.len()
+                        cpu_mesh.positions.position_count()
                     ),
                 });
             }
@@ -169,7 +159,10 @@ impl Mesh {
     pub fn new(context: &Context, cpu_mesh: &CPUMesh) -> Result<Self, Error> {
         Self::validate(cpu_mesh)?;
 
-        let position_buffer = Rc::new(VertexBuffer::new_with_static(context, &cpu_mesh.positions)?);
+        let position_buffer = Rc::new(VertexBuffer::new_with_static(
+            context,
+            cpu_mesh.positions.data(),
+        )?);
         let normal_buffer = if let Some(ref normals) = cpu_mesh.normals {
             Some(Rc::new(VertexBuffer::new_with_static(context, normals)?))
         } else {

--- a/src/object/particles.rs
+++ b/src/object/particles.rs
@@ -112,7 +112,7 @@ pub struct Particles {
 
 impl Particles {
     pub fn new(context: &Context, cpu_mesh: &CPUMesh, acceleration: &Vec3) -> Result<Self, Error> {
-        let position_buffer = VertexBuffer::new_with_static(context, &cpu_mesh.positions)?;
+        let position_buffer = VertexBuffer::new_with_static(context, cpu_mesh.positions.data())?;
         let normal_buffer = if let Some(ref normals) = cpu_mesh.normals {
             Some(VertexBuffer::new_with_static(context, normals)?)
         } else {


### PR DESCRIPTION
Currently it is a wrapper for `Vec<f32>` which asserts length is
divisible by 3, but it can be latext extended to store tuples of
four elements: `(x, y, z, w)`.