### PR TITLE
Make CullType and DepthTestType transparent enums

### DIFF
--- a/src/core/program.rs
+++ b/src/core/program.rs
@@ -537,17 +537,9 @@ impl Program {
                     CullType::None => {
                         context.disable(consts::CULL_FACE);
                     }
-                    CullType::Back => {
+                    c => {
                         context.enable(consts::CULL_FACE);
-                        context.cull_face(consts::BACK);
-                    }
-                    CullType::Front => {
-                        context.enable(consts::CULL_FACE);
-                        context.cull_face(consts::FRONT);
-                    }
-                    CullType::FrontAndBack => {
-                        context.enable(consts::CULL_FACE);
-                        context.cull_face(consts::FRONT_AND_BACK);
+                        context.cull_face(c as _);
                     }
                 }
                 CURRENT_CULL = cull;
@@ -650,32 +642,7 @@ impl Program {
             }
 
             if depth_test.is_some() && depth_test.unwrap() != CURRENT_DEPTH_TEST {
-                match depth_test.unwrap() {
-                    DepthTestType::Never => {
-                        context.depth_func(consts::NEVER);
-                    }
-                    DepthTestType::Less => {
-                        context.depth_func(consts::LESS);
-                    }
-                    DepthTestType::Equal => {
-                        context.depth_func(consts::EQUAL);
-                    }
-                    DepthTestType::LessOrEqual => {
-                        context.depth_func(consts::LEQUAL);
-                    }
-                    DepthTestType::Greater => {
-                        context.depth_func(consts::GREATER);
-                    }
-                    DepthTestType::NotEqual => {
-                        context.depth_func(consts::NOTEQUAL);
-                    }
-                    DepthTestType::GreaterOrEqual => {
-                        context.depth_func(consts::GEQUAL);
-                    }
-                    DepthTestType::Always => {
-                        context.depth_func(consts::ALWAYS);
-                    }
-                }
+                context.depth_func(depth_test.unwrap() as _);
                 CURRENT_DEPTH_TEST = depth_test.unwrap();
             }
         }

--- a/src/core/render_states.rs
+++ b/src/core/render_states.rs
@@ -1,3 +1,5 @@
+use crate::context::consts;
+
 ///
 /// A set of render specific states that has to be specified at each render call.
 ///
@@ -44,11 +46,12 @@ impl Default for RenderStates {
 /// Defines whether the triangles that are backfacing, frontfacing or both should be skipped in a render call.
 ///
 #[derive(Debug, Copy, Clone, PartialEq)]
+#[repr(u32 /* GLenum */)]
 pub enum CullType {
-    None,
-    Back,
-    Front,
-    FrontAndBack,
+    None = 0,
+    Back = consts::BACK,
+    Front = consts::FRONT,
+    FrontAndBack = consts::FRONT_AND_BACK,
 }
 
 ///
@@ -61,15 +64,16 @@ pub enum CullType {
 /// [DepthTargetTexture2D](crate::DepthTargetTexture2D) or [DepthTargetTexture2DArray](crate::DepthTargetTexture2DArray).
 ///
 #[derive(Debug, Copy, Clone, PartialEq)]
+#[repr(u32 /* GLenum */)]
 pub enum DepthTestType {
-    Never,
-    Less,
-    Equal,
-    LessOrEqual,
-    Greater,
-    NotEqual,
-    GreaterOrEqual,
-    Always,
+    Never = consts::NEVER,
+    Less = consts::LESS,
+    Equal = consts::EQUAL,
+    LessOrEqual = consts::LEQUAL,
+    Greater = consts::GREATER,
+    NotEqual = consts::NOTEQUAL,
+    GreaterOrEqual = consts::GEQUAL,
+    Always = consts::ALWAYS,
 }
 
 ///


### PR DESCRIPTION
* save a couple lines of code
* make code easier to read (it is clear now what each enum represent)
* insignificantly improve performance and code size