### PR TITLE
Add alpha_cutout property to materials to support transparency in deferred rendering.

### DIFF
--- a/src/core/cpu_material.rs
+++ b/src/core/cpu_material.rs
@@ -36,6 +36,8 @@ pub struct CPUMaterial {
     pub normal_scale: f32,
     /// A tangent space normal map, also known as bump map.
     pub normal_texture: Option<CPUTexture<u8>>,
+    /// Alpha cutout value for transparency in deferred rendering pipeline.
+    pub alpha_cutout: Option<f32>,
 }
 
 impl Default for CPUMaterial {
@@ -52,6 +54,7 @@ impl Default for CPUMaterial {
             occlusion_strength: 1.0,
             normal_texture: None,
             normal_scale: 1.0,
+            alpha_cutout: None,
         }
     }
 }

--- a/src/io/parser/gltf.rs
+++ b/src/io/parser/gltf.rs
@@ -164,6 +164,7 @@ fn parse_tree<'a>(
                         occlusion_texture,
                         occlusion_strength,
                         occlusion_metallic_roughness_texture: None,
+                        alpha_cutout: None,
                     });
                 }
 

--- a/src/renderer/material/physical_material.rs
+++ b/src/renderer/material/physical_material.rs
@@ -34,7 +34,7 @@ pub struct PhysicalMaterial {
     pub opaque_render_states: RenderStates,
     /// Render states used when the color is transparent (does not have a maximal alpha value).
     pub transparent_render_states: RenderStates,
-    /// Alpha cutoff value for transparency in deferred rendering pipeline.
+    /// Alpha cutout value for transparency in deferred rendering pipeline.
     pub alpha_cutout: Option<f32>,
 }
 
@@ -91,7 +91,7 @@ impl PhysicalMaterial {
                 blend: Blend::TRANSPARENCY,
                 ..Default::default()
             },
-            alpha_cutout: None,
+            alpha_cutout: cpu_material.alpha_cutout,
         })
     }
 

--- a/src/renderer/material/shaders/physical_material.frag
+++ b/src/renderer/material/shaders/physical_material.frag
@@ -34,6 +34,9 @@ void main()
     vec4 surface_color = albedo;
 #ifdef USE_ALBEDO_TEXTURE
     vec4 c = texture(albedoTexture, uvs);
+    #ifdef ALPHACUT
+        if (c.a < acut) discard;
+    #endif
     surface_color *= vec4(rgb_from_srgb(c.rgb), c.a);
 #endif
 #ifdef USE_VERTEX_COLORS


### PR DESCRIPTION
Just because deferred can't blend doesn't mean we can't just discard fragments.

Also fiddled about trying to get Alpha To Coverage working for stippled alpha, since three-d supports MSAA, and would pose that as a challenge for later.