### PR TITLE
Support borderless mode for both window or maximized

### DIFF
--- a/src/window/glutin_window.rs
+++ b/src/window/glutin_window.rs
@@ -60,6 +60,7 @@ impl Window {
         if settings.multisamples > 0 && !settings.multisamples.is_power_of_two() {
             Err(WindowError::InvalidNumberOfMSAASamples)?;
         }
+        let borderless = settings.borderless;
         let window_builder = if let Some((width, height)) = settings.max_size {
             WindowBuilder::new()
                 .with_title(&settings.title)
@@ -69,6 +70,7 @@ impl Window {
                 ))
                 .with_inner_size(dpi::LogicalSize::new(width as f64, height as f64))
                 .with_max_inner_size(dpi::LogicalSize::new(width as f64, height as f64))
+                .with_decorations(!borderless)
         } else {
             WindowBuilder::new()
                 .with_min_inner_size(dpi::LogicalSize::new(
@@ -76,6 +78,7 @@ impl Window {
                     settings.min_size.1,
                 ))
                 .with_title(&settings.title)
+                .with_decorations(!borderless)
                 .with_maximized(true)
         };
 

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -20,6 +20,10 @@ pub struct WindowSettings {
     /// On web, this can only be off (0) or on (>0).
     /// The actual number of samples depends on browser settings.
     pub multisamples: u8,
+    /// Borderless mode.
+    ///
+    /// No effect on web.
+    pub borderless: bool,
 }
 impl Default for WindowSettings {
     fn default() -> Self {
@@ -29,6 +33,7 @@ impl Default for WindowSettings {
             max_size: None,
             vsync: true,
             multisamples: 4,
+            borderless: false,
         }
     }
 }


### PR DESCRIPTION
Centering an unmaximized borderless window will require a monitorhandle from glutin. Will leave for later when individual monitors can be exposed and selected.