### PR TITLE
Deferred clean up

### DIFF
--- a/examples/fireworks/main.rs
+++ b/examples/fireworks/main.rs
@@ -9,7 +9,7 @@ struct FireworksMaterial {
     pub fade: f32,
 }
 
-impl ForwardMaterial for FireworksMaterial {
+impl Material for FireworksMaterial {
     fn fragment_shader_source(&self, _use_vertex_colors: bool, _lights: &Lights) -> String {
         include_str!("../assets/shaders/particles.frag").to_string()
     }

--- a/examples/fireworks/main.rs
+++ b/examples/fireworks/main.rs
@@ -139,7 +139,7 @@ fn main() {
                 let f = particles.time / explosion_time.max(0.0);
                 fireworks_material.fade = 1.0 - f * f * f * f;
                 fireworks_material.color = colors[color_index];
-                particles.render_forward(&fireworks_material, &camera, &Lights::default())?;
+                particles.render_with_material(&fireworks_material, &camera, &Lights::default())?;
                 Ok(())
             })
             .unwrap();

--- a/examples/lighting/main.rs
+++ b/examples/lighting/main.rs
@@ -284,9 +284,22 @@ fn main() {
                 // Geometry pass
                 if change && current_pipeline == Pipeline::Deferred {
                     deferred_pipeline
-                        .geometry_pass(
+                        .render_pass(
                             &camera,
-                            &[(model, &model.material), (&plane, &plane.material)],
+                            &[
+                                (
+                                    model,
+                                    DeferredPhysicalMaterial::from_physical_material(
+                                        &model.material,
+                                    ),
+                                ),
+                                (
+                                    &plane,
+                                    DeferredPhysicalMaterial::from_physical_material(
+                                        &plane.material,
+                                    ),
+                                ),
+                            ],
                         )
                         .unwrap();
                 }
@@ -297,12 +310,12 @@ fn main() {
                         Pipeline::Forward => {
                             match deferred_pipeline.debug_type {
                                 DebugType::NORMAL => {
-                                    plane.render_forward(
+                                    plane.render_with_material(
                                         &NormalMaterial::from_physical_material(&plane.material),
                                         &camera,
                                         &lights,
                                     )?;
-                                    model.render_forward(
+                                    model.render_with_material(
                                         &NormalMaterial::from_physical_material(&model.material),
                                         &camera,
                                         &lights,
@@ -310,16 +323,24 @@ fn main() {
                                 }
                                 DebugType::DEPTH => {
                                     let depth_material = DepthMaterial::default();
-                                    plane.render_forward(&depth_material, &camera, &lights)?;
-                                    model.render_forward(&depth_material, &camera, &lights)?;
+                                    plane.render_with_material(
+                                        &depth_material,
+                                        &camera,
+                                        &lights,
+                                    )?;
+                                    model.render_with_material(
+                                        &depth_material,
+                                        &camera,
+                                        &lights,
+                                    )?;
                                 }
                                 DebugType::ORM => {
-                                    plane.render_forward(
+                                    plane.render_with_material(
                                         &ORMMaterial::from_physical_material(&plane.material),
                                         &camera,
                                         &lights,
                                     )?;
-                                    model.render_forward(
+                                    model.render_with_material(
                                         &ORMMaterial::from_physical_material(&model.material),
                                         &camera,
                                         &lights,
@@ -327,21 +348,29 @@ fn main() {
                                 }
                                 DebugType::POSITION => {
                                     let position_material = PositionMaterial::default();
-                                    plane.render_forward(&position_material, &camera, &lights)?;
-                                    model.render_forward(&position_material, &camera, &lights)?;
+                                    plane.render_with_material(
+                                        &position_material,
+                                        &camera,
+                                        &lights,
+                                    )?;
+                                    model.render_with_material(
+                                        &position_material,
+                                        &camera,
+                                        &lights,
+                                    )?;
                                 }
                                 DebugType::UV => {
                                     let uv_material = UVMaterial::default();
-                                    plane.render_forward(&uv_material, &camera, &lights)?;
-                                    model.render_forward(&uv_material, &camera, &lights)?;
+                                    plane.render_with_material(&uv_material, &camera, &lights)?;
+                                    model.render_with_material(&uv_material, &camera, &lights)?;
                                 }
                                 DebugType::COLOR => {
-                                    plane.render_forward(
+                                    plane.render_with_material(
                                         &ColorMaterial::from_physical_material(&plane.material),
                                         &camera,
                                         &lights,
                                     )?;
-                                    model.render_forward(
+                                    model.render_with_material(
                                         &ColorMaterial::from_physical_material(&model.material),
                                         &camera,
                                         &lights,
@@ -355,13 +384,7 @@ fn main() {
                             };
                         }
                         Pipeline::Deferred => {
-                            deferred_pipeline.light_pass(
-                                &camera,
-                                lights.ambient.as_ref(),
-                                &lights.directional.iter().collect::<Vec<_>>(),
-                                &lights.spot.iter().collect::<Vec<_>>(),
-                                &lights.point.iter().collect::<Vec<_>>(),
-                            )?;
+                            deferred_pipeline.lighting_pass(&camera, &lights)?;
                         }
                     }
                     gui.render()?;

--- a/examples/mandelbrot/main.rs
+++ b/examples/mandelbrot/main.rs
@@ -4,7 +4,7 @@ use three_d::window::*;
 
 struct MandelbrotMaterial {}
 
-impl ForwardMaterial for MandelbrotMaterial {
+impl Material for MandelbrotMaterial {
     fn fragment_shader_source(&self, _use_vertex_colors: bool, _lights: &Lights) -> String {
         include_str!("../assets/shaders/mandelbrot.frag").to_string()
     }

--- a/examples/pbr/main.rs
+++ b/examples/pbr/main.rs
@@ -166,7 +166,7 @@ fn main() {
                             opaque_render_states: model.material.opaque_render_states,
                             transparent_render_states: model.material.transparent_render_states,
                         };
-                        model.render_forward(&material, &camera, &lights)?;
+                        model.render_with_material(&material, &camera, &lights)?;
                     }
                     gui.render()?;
                     Ok(())

--- a/examples/pbr/main.rs
+++ b/examples/pbr/main.rs
@@ -165,7 +165,6 @@ fn main() {
                             },
                             opaque_render_states: model.material.opaque_render_states,
                             transparent_render_states: model.material.transparent_render_states,
-                            alpha_cutout: model.material.alpha_cutout,
                         };
                         model.render_forward(&material, &camera, &lights)?;
                     }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -160,7 +160,7 @@ pub fn ray_intersect<S: Shadable>(
         },
         || {
             for geometry in geometries {
-                geometry.render_forward(&depth_material, &camera, &Lights::default())?;
+                geometry.render_with_material(&depth_material, &camera, &Lights::default())?;
             }
             Ok(())
         },

--- a/src/renderer/deferred_pipeline.rs
+++ b/src/renderer/deferred_pipeline.rs
@@ -27,6 +27,7 @@ pub struct DeferredPipeline {
     /// Set this to visualize the positions, normals etc. for debug purposes.
     ///
     pub debug_type: DebugType,
+    #[deprecated = "use lighting_pass where Light struct contain lighting model"]
     pub lighting_model: LightingModel,
     camera: Camera,
     geometry_pass_texture: Option<ColorTargetTexture2DArray<u8>>,

--- a/src/renderer/deferred_pipeline.rs
+++ b/src/renderer/deferred_pipeline.rs
@@ -138,7 +138,7 @@ impl DeferredPipeline {
                 .iter()
                 .filter(|(g, _)| self.camera.in_frustum(&g.aabb()))
             {
-                geometry.render_forward(
+                geometry.render_with_material(
                     &DeferredPhysicalMaterial::from_physical_material(material),
                     &self.camera,
                     &Lights::default(),

--- a/src/renderer/deferred_pipeline.rs
+++ b/src/renderer/deferred_pipeline.rs
@@ -71,10 +71,10 @@ impl DeferredPipeline {
     /// This function must not be called in a render target render function and needs to be followed
     /// by a call to [DeferredPipeline::light_pass].
     ///
-    pub fn geometry_pass<G: Geometry, M: DeferredMaterial>(
+    pub fn geometry_pass<G: Geometry>(
         &mut self,
         camera: &Camera,
-        objects: &[(G, M)],
+        objects: &[(G, DeferredPhysicalMaterial)],
     ) -> ThreeDResult<()> {
         let viewport = Viewport::new_at_origo(camera.viewport().width, camera.viewport().height);
         self.geometry_pass_texture = Some(ColorTargetTexture2DArray::<u8>::new(

--- a/src/renderer/deferred_pipeline.rs
+++ b/src/renderer/deferred_pipeline.rs
@@ -74,7 +74,7 @@ impl DeferredPipeline {
     pub fn geometry_pass<G: Geometry>(
         &mut self,
         camera: &Camera,
-        objects: &[(G, DeferredPhysicalMaterial)],
+        objects: &[(G, &PhysicalMaterial)],
     ) -> ThreeDResult<()> {
         let viewport = Viewport::new_at_origo(camera.viewport().width, camera.viewport().height);
         self.geometry_pass_texture = Some(ColorTargetTexture2DArray::<u8>::new(
@@ -106,7 +106,11 @@ impl DeferredPipeline {
         .write(&[0, 1], 0, ClearState::default(), || {
             for (geometry, material) in objects.iter().filter(|(g, _)| camera.in_frustum(&g.aabb()))
             {
-                geometry.render_deferred(material, camera, viewport)?;
+                geometry.render_deferred(
+                    &DeferredPhysicalMaterial::from_physical_material(material),
+                    camera,
+                    viewport,
+                )?;
             }
             Ok(())
         })?;

--- a/src/renderer/deferred_pipeline.rs
+++ b/src/renderer/deferred_pipeline.rs
@@ -17,8 +17,8 @@ pub enum DebugType {
 ///
 /// Deferred render pipeline which can render objects (implementing the [Geometry] trait) with a [DeferredPhysicalMaterial] and lighting.
 /// Supports different types of lighting models by changing the [DeferredPipeline::lighting_model] field.
-/// Deferred rendering draws the geometry information into a buffer in the [DeferredPipeline::geometry_pass] and use that information in the [DeferredPipeline::light_pass].
-/// This means that the lighting is only calculated once per pixel since the depth testing is happening in the geometry pass.
+/// Deferred rendering draws the geometry information into a buffer in the [DeferredPipeline::render_pass] and use that information in the [DeferredPipeline::light_pass].
+/// This means that the lighting is only calculated once per pixel since the depth testing is happening in the render pass.
 /// **Note:** Deferred rendering does not support blending and therefore does not support transparency!
 ///
 pub struct DeferredPipeline {
@@ -174,7 +174,7 @@ impl DeferredPipeline {
     }
 
     ///
-    /// Uses the geometry and surface material parameters written in the last [DeferredPipeline::geometry_pass] call
+    /// Uses the geometry and surface material parameters written in the last [DeferredPipeline::render_pass] call
     /// and all of the given lights to render the objects.
     /// Must be called in a render target render function,
     /// for example in the callback function of [Screen::write].

--- a/src/renderer/deferred_pipeline.rs
+++ b/src/renderer/deferred_pipeline.rs
@@ -15,7 +15,7 @@ pub enum DebugType {
     NONE,
 }
 ///
-/// Deferred render pipeline which can render objects (implementing the [Geometry] trait) with materials (implementing the [DeferredMaterial] trait) and lighting.
+/// Deferred render pipeline which can render objects (implementing the [Geometry] trait) with a [DeferredPhysicalMaterial] and lighting.
 /// Supports different types of lighting models by changing the [DeferredPipeline::lighting_model] field.
 /// Deferred rendering draws the geometry information into a buffer in the [DeferredPipeline::geometry_pass] and use that information in the [DeferredPipeline::light_pass].
 /// This means that the lighting is only calculated once per pixel since the depth testing is happening in the geometry pass.

--- a/src/renderer/forward_pipeline.rs
+++ b/src/renderer/forward_pipeline.rs
@@ -44,7 +44,7 @@ impl ForwardPipeline {
             .iter()
             .filter(|o| !o.is_transparent() && camera.in_frustum(&o.aabb()))
         {
-            object.render_forward(&depth_material, camera, &Lights::default())?;
+            object.render_with_material(&depth_material, camera, &Lights::default())?;
         }
         Ok(())
     }

--- a/src/renderer/light.rs
+++ b/src/renderer/light.rs
@@ -60,6 +60,10 @@ impl Lights {
         }
         Ok(())
     }
+
+    pub fn iter<'a>(&'a self) -> LightsIterator<'a> {
+        LightsIterator::new(self)
+    }
 }
 
 impl Default for Lights {
@@ -74,7 +78,7 @@ impl Default for Lights {
     }
 }
 
-struct LightsIterator<'a> {
+pub struct LightsIterator<'a> {
     lights: &'a Lights,
     index: usize,
 }

--- a/src/renderer/light/directional_light.rs
+++ b/src/renderer/light/directional_light.rs
@@ -119,7 +119,11 @@ impl DirectionalLight {
                 .iter()
                 .filter(|g| shadow_camera.in_frustum(&g.aabb()))
             {
-                geometry.render_forward(&depth_material, &shadow_camera, &Lights::default())?;
+                geometry.render_with_material(
+                    &depth_material,
+                    &shadow_camera,
+                    &Lights::default(),
+                )?;
             }
             Ok(())
         })?;

--- a/src/renderer/material.rs
+++ b/src/renderer/material.rs
@@ -31,6 +31,10 @@ mod physical_material;
 #[doc(inline)]
 pub use physical_material::*;
 
+mod deferred_physical_material;
+#[doc(inline)]
+pub use deferred_physical_material::*;
+
 ///
 /// Represents a material that can be applied to a [Shadable] object.
 ///
@@ -66,19 +70,5 @@ impl<T: ForwardMaterial + ?Sized> ForwardMaterial for &T {
     }
     fn is_transparent(&self) -> bool {
         (*self).is_transparent()
-    }
-}
-
-///
-/// Represents a material that can be used in a [DeferredPipeline::geometry_pass].
-///
-pub trait DeferredMaterial: ForwardMaterial {
-    /// Returns the deferred version of the fragment shader source for this material.
-    fn fragment_shader_source_deferred(&self, use_vertex_colors: bool) -> String;
-}
-
-impl<T: DeferredMaterial + ?Sized> DeferredMaterial for &T {
-    fn fragment_shader_source_deferred(&self, use_vertex_colors: bool) -> String {
-        (*self).fragment_shader_source_deferred(use_vertex_colors)
     }
 }

--- a/src/renderer/material.rs
+++ b/src/renderer/material.rs
@@ -41,7 +41,7 @@ pub use deferred_physical_material::*;
 /// The material can use the attributes position (in world space) by adding `in vec3 pos;`,
 /// normal by `in vec3 nor;`, uv coordinates by `in vec2 uvs;` and color by `in vec4 col;` to the fragment shader source code.
 ///
-pub trait ForwardMaterial {
+pub trait Material {
     /// Returns the fragment shader source for this material. Should output the final fragment color.
     fn fragment_shader_source(&self, use_vertex_colors: bool, lights: &Lights) -> String;
     /// Sends the uniform data needed for this material to the fragment shader.
@@ -53,7 +53,7 @@ pub trait ForwardMaterial {
     fn is_transparent(&self) -> bool;
 }
 
-impl<T: ForwardMaterial + ?Sized> ForwardMaterial for &T {
+impl<T: Material + ?Sized> Material for &T {
     fn fragment_shader_source(&self, use_vertex_colors: bool, lights: &Lights) -> String {
         (*self).fragment_shader_source(use_vertex_colors, lights)
     }

--- a/src/renderer/material/color_material.rs
+++ b/src/renderer/material/color_material.rs
@@ -42,7 +42,7 @@ impl ColorMaterial {
     }
 }
 
-impl ForwardMaterial for ColorMaterial {
+impl Material for ColorMaterial {
     fn fragment_shader_source(&self, use_vertex_colors: bool, _lights: &Lights) -> String {
         let mut shader = String::new();
         if self.texture.is_some() {

--- a/src/renderer/material/deferred_physical_material.rs
+++ b/src/renderer/material/deferred_physical_material.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 
 ///
 /// The deferred part of a physically-based material that renders a [Shadable] object in an approximate correct physical manner based on Physically Based Rendering (PBR).
-/// Must be used together with a [DeferredRenderPipeline].
+/// Must be used together with a [DeferredPipeline].
 /// This material is affected by lights.
 ///
 #[derive(Clone)]

--- a/src/renderer/material/deferred_physical_material.rs
+++ b/src/renderer/material/deferred_physical_material.rs
@@ -113,7 +113,6 @@ impl DeferredPhysicalMaterial {
 impl ForwardMaterial for DeferredPhysicalMaterial {
     fn fragment_shader_source(&self, use_vertex_colors: bool, lights: &Lights) -> String {
         let mut output = lights.fragment_shader_source();
-        output.push_str("#define DEFERRED\n");
         if self.albedo_texture.is_some()
             || self.metallic_roughness_texture.is_some()
             || self.normal_texture.is_some()
@@ -146,7 +145,7 @@ impl ForwardMaterial for DeferredPhysicalMaterial {
         if use_vertex_colors {
             output.push_str("#define USE_VERTEX_COLORS\nin vec4 col;\n");
         }
-        output.push_str(include_str!("shaders/physical_material.frag"));
+        output.push_str(include_str!("shaders/deferred_physical_material.frag"));
         output
     }
 

--- a/src/renderer/material/deferred_physical_material.rs
+++ b/src/renderer/material/deferred_physical_material.rs
@@ -110,7 +110,7 @@ impl DeferredPhysicalMaterial {
     }
 }
 
-impl ForwardMaterial for DeferredPhysicalMaterial {
+impl Material for DeferredPhysicalMaterial {
     fn fragment_shader_source(&self, use_vertex_colors: bool, lights: &Lights) -> String {
         let mut output = lights.fragment_shader_source();
         if self.albedo_texture.is_some()

--- a/src/renderer/material/deferred_physical_material.rs
+++ b/src/renderer/material/deferred_physical_material.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 /// This material is affected by lights.
 ///
 #[derive(Clone)]
-pub struct PhysicalMaterial {
+pub struct DeferredPhysicalMaterial {
     /// Name. Used for matching geometry and material.
     pub name: String,
     /// Albedo base color, also called diffuse color. Assumed to be in linear color space.
@@ -30,20 +30,17 @@ pub struct PhysicalMaterial {
     pub normal_scale: f32,
     /// A tangent space normal map, also known as bump map.
     pub normal_texture: Option<Rc<Texture2D>>,
-    /// Render states used when the color is opaque (has a maximal alpha value).
-    pub opaque_render_states: RenderStates,
-    /// Render states used when the color is transparent (does not have a maximal alpha value).
-    pub transparent_render_states: RenderStates,
-
-    pub emissive: Color,
-    pub emissive_texture: Option<Rc<Texture2D>>,
+    /// Render states
+    pub render_states: RenderStates,
+    /// Alpha cutout value for transparency in deferred rendering pipeline.
+    pub alpha_cutout: Option<f32>,
 }
 
-impl PhysicalMaterial {
+impl DeferredPhysicalMaterial {
     ///
     /// Constructs a new physical material from a [CPUMaterial].
     /// If the input contains an [CPUMaterial::occlusion_metallic_roughness_texture], this texture is used for both
-    /// [PhysicalMaterial::metallic_roughness_texture] and [PhysicalMaterial::occlusion_texture] while any [CPUMaterial::metallic_roughness_texture] or [CPUMaterial::occlusion_texture] are ignored.
+    /// [DeferredPhysicalMaterial::metallic_roughness_texture] and [DeferredPhysicalMaterial::occlusion_texture] while any [CPUMaterial::metallic_roughness_texture] or [CPUMaterial::occlusion_texture] are ignored.
     ///
     pub fn new(context: &Context, cpu_material: &CPUMaterial) -> ThreeDResult<Self> {
         let albedo_texture = if let Some(ref cpu_texture) = cpu_material.albedo_texture {
@@ -75,11 +72,6 @@ impl PhysicalMaterial {
         } else {
             None
         };
-        let emissive_texture = if let Some(ref cpu_texture) = cpu_material.emissive_texture {
-            Some(Rc::new(Texture2D::new(&context, cpu_texture)?))
-        } else {
-            None
-        };
         Ok(Self {
             name: cpu_material.name.clone(),
             albedo: cpu_material.albedo,
@@ -91,26 +83,38 @@ impl PhysicalMaterial {
             normal_scale: cpu_material.normal_scale,
             occlusion_texture,
             occlusion_strength: cpu_material.occlusion_strength,
-            opaque_render_states: RenderStates::default(),
-            transparent_render_states: RenderStates {
-                write_mask: WriteMask::COLOR,
-                blend: Blend::TRANSPARENCY,
-                ..Default::default()
-            },
-            emissive: cpu_material.emissive,
-            emissive_texture,
+            render_states: RenderStates::default(),
+            alpha_cutout: cpu_material.alpha_cutout,
         })
+    }
+
+    pub fn from_physical_material(physical_material: &PhysicalMaterial) -> Self {
+        Self {
+            name: physical_material.name.clone(),
+            albedo: physical_material.albedo,
+            albedo_texture: physical_material.albedo_texture.clone(),
+            metallic: physical_material.metallic,
+            roughness: physical_material.roughness,
+            metallic_roughness_texture: physical_material.metallic_roughness_texture.clone(),
+            normal_texture: physical_material.normal_texture.clone(),
+            normal_scale: physical_material.normal_scale,
+            occlusion_texture: physical_material.occlusion_texture.clone(),
+            occlusion_strength: physical_material.occlusion_strength,
+            render_states: physical_material.opaque_render_states,
+            alpha_cutout: None,
+        }
     }
 }
 
-impl ForwardMaterial for PhysicalMaterial {
+impl ForwardMaterial for DeferredPhysicalMaterial {
     fn fragment_shader_source(&self, use_vertex_colors: bool, lights: &Lights) -> String {
         let mut output = lights.fragment_shader_source();
+        output.push_str("#define DEFERRED\n");
         if self.albedo_texture.is_some()
             || self.metallic_roughness_texture.is_some()
             || self.normal_texture.is_some()
             || self.occlusion_texture.is_some()
-            || self.emissive_texture.is_some()
+            || self.alpha_cutout.is_some()
         {
             output.push_str("in vec2 uvs;\n");
             if self.albedo_texture.is_some() {
@@ -125,8 +129,14 @@ impl ForwardMaterial for PhysicalMaterial {
             if self.normal_texture.is_some() {
                 output.push_str("#define USE_NORMAL_TEXTURE;\nin vec3 tang;\nin vec3 bitang;\n");
             }
-            if self.emissive_texture.is_some() {
-                output.push_str("#define USE_EMISSIVE_TEXTURE;\n");
+            if self.alpha_cutout.is_some() {
+                output.push_str(
+                    format!(
+                        "#define ALPHACUT;\nfloat acut = {};",
+                        self.alpha_cutout.unwrap()
+                    )
+                    .as_str(),
+                );
             }
         }
         if use_vertex_colors {
@@ -135,6 +145,7 @@ impl ForwardMaterial for PhysicalMaterial {
         output.push_str(include_str!("shaders/physical_material.frag"));
         output
     }
+
     fn use_uniforms(
         &self,
         program: &Program,
@@ -145,9 +156,6 @@ impl ForwardMaterial for PhysicalMaterial {
         program.use_uniform_float("metallic", &self.metallic)?;
         program.use_uniform_float("roughness", &self.roughness)?;
         program.use_uniform_vec4("albedo", &self.albedo.to_vec4())?;
-        if program.requires_uniform("emissive") {
-            program.use_uniform_vec3("emissive", &self.emissive.to_vec3())?;
-        }
         if let Some(ref texture) = self.albedo_texture {
             program.use_texture("albedoTexture", texture.as_ref())?;
         }
@@ -162,32 +170,19 @@ impl ForwardMaterial for PhysicalMaterial {
             program.use_uniform_float("normalScale", &self.normal_scale)?;
             program.use_texture("normalTexture", texture.as_ref())?;
         }
-        if program.requires_uniform("emissiveTexture") {
-            if let Some(ref texture) = self.emissive_texture {
-                program.use_texture("emissiveTexture", texture.as_ref())?;
-            }
-        }
         Ok(())
     }
 
     fn render_states(&self) -> RenderStates {
-        if self.is_transparent() {
-            self.transparent_render_states
-        } else {
-            self.opaque_render_states
-        }
+        self.render_states
     }
+
     fn is_transparent(&self) -> bool {
-        self.albedo.a != 255
-            || self
-                .albedo_texture
-                .as_ref()
-                .map(|t| t.is_transparent())
-                .unwrap_or(false)
+        false
     }
 }
 
-impl Default for PhysicalMaterial {
+impl Default for DeferredPhysicalMaterial {
     fn default() -> Self {
         Self {
             name: "default".to_string(),
@@ -200,14 +195,8 @@ impl Default for PhysicalMaterial {
             normal_scale: 1.0,
             occlusion_texture: None,
             occlusion_strength: 1.0,
-            opaque_render_states: RenderStates::default(),
-            transparent_render_states: RenderStates {
-                write_mask: WriteMask::COLOR,
-                blend: Blend::TRANSPARENCY,
-                ..Default::default()
-            },
-            emissive: Color::BLACK,
-            emissive_texture: None,
+            render_states: RenderStates::default(),
+            alpha_cutout: None,
         }
     }
 }

--- a/src/renderer/material/deferred_physical_material.rs
+++ b/src/renderer/material/deferred_physical_material.rs
@@ -3,7 +3,8 @@ use crate::renderer::*;
 use std::rc::Rc;
 
 ///
-/// A physically-based material that renders a [Shadable] object in an approximate correct physical manner based on Physically Based Rendering (PBR).
+/// The deferred part of a physically-based material that renders a [Shadable] object in an approximate correct physical manner based on Physically Based Rendering (PBR).
+/// Must be used together with a [DeferredRenderPipeline].
 /// This material is affected by lights.
 ///
 #[derive(Clone)]
@@ -38,7 +39,7 @@ pub struct DeferredPhysicalMaterial {
 
 impl DeferredPhysicalMaterial {
     ///
-    /// Constructs a new physical material from a [CPUMaterial].
+    /// Constructs a new deferred physical material from a [CPUMaterial].
     /// If the input contains an [CPUMaterial::occlusion_metallic_roughness_texture], this texture is used for both
     /// [DeferredPhysicalMaterial::metallic_roughness_texture] and [DeferredPhysicalMaterial::occlusion_texture] while any [CPUMaterial::metallic_roughness_texture] or [CPUMaterial::occlusion_texture] are ignored.
     ///
@@ -88,6 +89,9 @@ impl DeferredPhysicalMaterial {
         })
     }
 
+    ///
+    /// Constructs a deferred physical material from a physical material.
+    ///
     pub fn from_physical_material(physical_material: &PhysicalMaterial) -> Self {
         Self {
             name: physical_material.name.clone(),

--- a/src/renderer/material/depth_material.rs
+++ b/src/renderer/material/depth_material.rs
@@ -8,7 +8,7 @@ pub struct DepthMaterial {
     pub render_states: RenderStates,
 }
 
-impl ForwardMaterial for DepthMaterial {
+impl Material for DepthMaterial {
     fn fragment_shader_source(&self, _use_vertex_colors: bool, _lights: &Lights) -> String {
         include_str!("shaders/depth_material.frag").to_string()
     }

--- a/src/renderer/material/normal_material.rs
+++ b/src/renderer/material/normal_material.rs
@@ -34,7 +34,7 @@ impl NormalMaterial {
     }
 }
 
-impl ForwardMaterial for NormalMaterial {
+impl Material for NormalMaterial {
     fn fragment_shader_source(&self, _use_vertex_colors: bool, _lights: &Lights) -> String {
         let mut shader = String::new();
         if self.normal_texture.is_some() {

--- a/src/renderer/material/orm_material.rs
+++ b/src/renderer/material/orm_material.rs
@@ -33,7 +33,7 @@ impl ORMMaterial {
     }
 }
 
-impl ForwardMaterial for ORMMaterial {
+impl Material for ORMMaterial {
     fn fragment_shader_source(&self, _use_vertex_colors: bool, _lights: &Lights) -> String {
         let mut output = String::new();
         if self.metallic_roughness_texture.is_some() || self.occlusion_texture.is_some() {

--- a/src/renderer/material/physical_material.rs
+++ b/src/renderer/material/physical_material.rs
@@ -103,7 +103,7 @@ impl PhysicalMaterial {
     }
 }
 
-impl ForwardMaterial for PhysicalMaterial {
+impl Material for PhysicalMaterial {
     fn fragment_shader_source(&self, use_vertex_colors: bool, lights: &Lights) -> String {
         let mut output = lights.fragment_shader_source();
         if self.albedo_texture.is_some()

--- a/src/renderer/material/position_material.rs
+++ b/src/renderer/material/position_material.rs
@@ -6,7 +6,7 @@ pub struct PositionMaterial {
     pub render_states: RenderStates,
 }
 
-impl ForwardMaterial for PositionMaterial {
+impl Material for PositionMaterial {
     fn fragment_shader_source(&self, _use_vertex_colors: bool, _lights: &Lights) -> String {
         include_str!("shaders/position_material.frag").to_string()
     }

--- a/src/renderer/material/shaders/deferred_physical_material.frag
+++ b/src/renderer/material/shaders/deferred_physical_material.frag
@@ -30,6 +30,7 @@ in vec3 pos;
 in vec3 nor;
 
 layout (location = 0) out vec4 outColor;
+layout (location = 1) out vec4 outNormal;
 
 void main()
 {
@@ -66,12 +67,6 @@ void main()
     normal = tbn * ((2.0 * texture(normalTexture, uvs).xyz - 1.0) * vec3(normalScale, normalScale, 1.0));
 #endif
 
-    vec3 total_emissive = emissive;
-#ifdef USE_EMISSIVE_TEXTURE
-    vec4 e = texture(emissiveTexture, uvs);
-    total_emissive *= rgb_from_srgb(e.rgb);
-#endif
-
-    outColor.rgb = srgb_from_rgb(total_emissive + calculate_lighting(surface_color.rgb, pos, normal, metallic_factor, roughness_factor, occlusion));
-    outColor.a = surface_color.a;
+    outColor = vec4(surface_color.rgb, metallic_factor);
+    outNormal = vec4(0.5 * normal.xy + 0.5, occlusion, roughness_factor);
 }

--- a/src/renderer/material/uv_material.rs
+++ b/src/renderer/material/uv_material.rs
@@ -6,7 +6,7 @@ pub struct UVMaterial {
     pub render_states: RenderStates,
 }
 
-impl ForwardMaterial for UVMaterial {
+impl Material for UVMaterial {
     fn fragment_shader_source(&self, _use_vertex_colors: bool, _lights: &Lights) -> String {
         include_str!("shaders/uv_material.frag").to_string()
     }

--- a/src/renderer/object.rs
+++ b/src/renderer/object.rs
@@ -143,7 +143,7 @@ impl<T: GeometryMut + ?Sized> GeometryMut for &mut T {
 // Shadable trait
 
 ///
-/// Represents a 3D object that is possible to render with [Material]s and [DeferredMaterial]s.
+/// Represents a 3D object that is possible to render with a material that implements the [Material] trait.
 ///
 /// If requested by the material, the shadable object has to support the attributes position (in world space) `out vec3 pos;`,
 /// normal `out vec3 nor;`, uv coordinates `out vec2 uvs;` and color `out vec4 col;` in the vertex shader source code.

--- a/src/renderer/object.rs
+++ b/src/renderer/object.rs
@@ -143,7 +143,7 @@ impl<T: GeometryMut + ?Sized> GeometryMut for &mut T {
 // Shadable trait
 
 ///
-/// Represents a 3D object that is possible to render with [ForwardMaterial]s and [DeferredMaterial]s.
+/// Represents a 3D object that is possible to render with [Material]s and [DeferredMaterial]s.
 ///
 /// If requested by the material, the shadable object has to support the attributes position (in world space) `out vec3 pos;`,
 /// normal `out vec3 nor;`, uv coordinates `out vec2 uvs;` and color `out vec4 col;` in the vertex shader source code.
@@ -157,7 +157,7 @@ pub trait Shadable {
     ///
     fn render_with_material(
         &self,
-        material: &dyn ForwardMaterial,
+        material: &dyn Material,
         camera: &Camera,
         lights: &Lights,
     ) -> ThreeDResult<()>;
@@ -171,7 +171,7 @@ pub trait Shadable {
     #[deprecated = "use render_with_material instead"]
     fn render_forward(
         &self,
-        material: &dyn ForwardMaterial,
+        material: &dyn Material,
         camera: &Camera,
         lights: &Lights,
     ) -> ThreeDResult<()>;
@@ -192,7 +192,7 @@ pub trait Shadable {
 impl<T: Shadable + ?Sized> Shadable for &T {
     fn render_with_material(
         &self,
-        material: &dyn ForwardMaterial,
+        material: &dyn Material,
         camera: &Camera,
         lights: &Lights,
     ) -> ThreeDResult<()> {
@@ -201,7 +201,7 @@ impl<T: Shadable + ?Sized> Shadable for &T {
 
     fn render_forward(
         &self,
-        material: &dyn ForwardMaterial,
+        material: &dyn Material,
         camera: &Camera,
         lights: &Lights,
     ) -> ThreeDResult<()> {
@@ -221,7 +221,7 @@ impl<T: Shadable + ?Sized> Shadable for &T {
 impl<T: Shadable + ?Sized> Shadable for &mut T {
     fn render_with_material(
         &self,
-        material: &dyn ForwardMaterial,
+        material: &dyn Material,
         camera: &Camera,
         lights: &Lights,
     ) -> ThreeDResult<()> {
@@ -230,7 +230,7 @@ impl<T: Shadable + ?Sized> Shadable for &mut T {
 
     fn render_forward(
         &self,
-        material: &dyn ForwardMaterial,
+        material: &dyn Material,
         camera: &Camera,
         lights: &Lights,
     ) -> ThreeDResult<()> {
@@ -250,7 +250,7 @@ impl<T: Shadable + ?Sized> Shadable for &mut T {
 // Shadable2D trait
 
 ///
-/// Represents a 2D object that is possible to render with [ForwardMaterial]s.
+/// Represents a 2D object that is possible to render with [Material]s.
 ///
 pub trait Shadable2D {
     ///
@@ -258,11 +258,8 @@ pub trait Shadable2D {
     /// Must be called in a render target render function,
     /// for example in the callback function of [Screen::write](crate::Screen::write).
     ///
-    fn render_with_material(
-        &self,
-        material: &dyn ForwardMaterial,
-        viewport: Viewport,
-    ) -> ThreeDResult<()>;
+    fn render_with_material(&self, material: &dyn Material, viewport: Viewport)
+        -> ThreeDResult<()>;
 
     ///
     /// Render the object with the given material.
@@ -270,27 +267,19 @@ pub trait Shadable2D {
     /// for example in the callback function of [Screen::write](crate::Screen::write).
     ///
     #[deprecated = "use render_with_material instead"]
-    fn render_forward(
-        &self,
-        material: &dyn ForwardMaterial,
-        viewport: Viewport,
-    ) -> ThreeDResult<()>;
+    fn render_forward(&self, material: &dyn Material, viewport: Viewport) -> ThreeDResult<()>;
 }
 
 impl<T: Shadable2D + ?Sized> Shadable2D for &T {
     fn render_with_material(
         &self,
-        material: &dyn ForwardMaterial,
+        material: &dyn Material,
         viewport: Viewport,
     ) -> ThreeDResult<()> {
         (*self).render_with_material(material, viewport)
     }
 
-    fn render_forward(
-        &self,
-        material: &dyn ForwardMaterial,
-        viewport: Viewport,
-    ) -> ThreeDResult<()> {
+    fn render_forward(&self, material: &dyn Material, viewport: Viewport) -> ThreeDResult<()> {
         (*self).render_forward(material, viewport)
     }
 }
@@ -298,17 +287,13 @@ impl<T: Shadable2D + ?Sized> Shadable2D for &T {
 impl<T: Shadable2D + ?Sized> Shadable2D for &mut T {
     fn render_with_material(
         &self,
-        material: &dyn ForwardMaterial,
+        material: &dyn Material,
         viewport: Viewport,
     ) -> ThreeDResult<()> {
         (**self).render_with_material(material, viewport)
     }
 
-    fn render_forward(
-        &self,
-        material: &dyn ForwardMaterial,
-        viewport: Viewport,
-    ) -> ThreeDResult<()> {
+    fn render_forward(&self, material: &dyn Material, viewport: Viewport) -> ThreeDResult<()> {
         (**self).render_forward(material, viewport)
     }
 }

--- a/src/renderer/object.rs
+++ b/src/renderer/object.rs
@@ -258,6 +258,18 @@ pub trait Shadable2D {
     /// Must be called in a render target render function,
     /// for example in the callback function of [Screen::write](crate::Screen::write).
     ///
+    fn render_with_material(
+        &self,
+        material: &dyn ForwardMaterial,
+        viewport: Viewport,
+    ) -> ThreeDResult<()>;
+
+    ///
+    /// Render the object with the given material.
+    /// Must be called in a render target render function,
+    /// for example in the callback function of [Screen::write](crate::Screen::write).
+    ///
+    #[deprecated = "use render_with_material instead"]
     fn render_forward(
         &self,
         material: &dyn ForwardMaterial,
@@ -266,6 +278,14 @@ pub trait Shadable2D {
 }
 
 impl<T: Shadable2D + ?Sized> Shadable2D for &T {
+    fn render_with_material(
+        &self,
+        material: &dyn ForwardMaterial,
+        viewport: Viewport,
+    ) -> ThreeDResult<()> {
+        (*self).render_with_material(material, viewport)
+    }
+
     fn render_forward(
         &self,
         material: &dyn ForwardMaterial,
@@ -276,6 +296,14 @@ impl<T: Shadable2D + ?Sized> Shadable2D for &T {
 }
 
 impl<T: Shadable2D + ?Sized> Shadable2D for &mut T {
+    fn render_with_material(
+        &self,
+        material: &dyn ForwardMaterial,
+        viewport: Viewport,
+    ) -> ThreeDResult<()> {
+        (**self).render_with_material(material, viewport)
+    }
+
     fn render_forward(
         &self,
         material: &dyn ForwardMaterial,

--- a/src/renderer/object.rs
+++ b/src/renderer/object.rs
@@ -155,6 +155,20 @@ pub trait Shadable {
     /// for example in the callback function of [Screen::write](crate::Screen::write).
     /// You can use [Lights::default()] if you know the material does not require lights.
     ///
+    fn render_with_material(
+        &self,
+        material: &dyn ForwardMaterial,
+        camera: &Camera,
+        lights: &Lights,
+    ) -> ThreeDResult<()>;
+
+    ///
+    /// Render the object with the given material.
+    /// Must be called in a render target render function,
+    /// for example in the callback function of [Screen::write](crate::Screen::write).
+    /// You can use [Lights::default()] if you know the material does not require lights.
+    ///
+    #[deprecated = "use render_with_material instead"]
     fn render_forward(
         &self,
         material: &dyn ForwardMaterial,
@@ -176,6 +190,15 @@ pub trait Shadable {
 }
 
 impl<T: Shadable + ?Sized> Shadable for &T {
+    fn render_with_material(
+        &self,
+        material: &dyn ForwardMaterial,
+        camera: &Camera,
+        lights: &Lights,
+    ) -> ThreeDResult<()> {
+        (*self).render_with_material(material, camera, lights)
+    }
+
     fn render_forward(
         &self,
         material: &dyn ForwardMaterial,
@@ -196,6 +219,15 @@ impl<T: Shadable + ?Sized> Shadable for &T {
 }
 
 impl<T: Shadable + ?Sized> Shadable for &mut T {
+    fn render_with_material(
+        &self,
+        material: &dyn ForwardMaterial,
+        camera: &Camera,
+        lights: &Lights,
+    ) -> ThreeDResult<()> {
+        (**self).render_with_material(material, camera, lights)
+    }
+
     fn render_forward(
         &self,
         material: &dyn ForwardMaterial,

--- a/src/renderer/object.rs
+++ b/src/renderer/object.rs
@@ -166,9 +166,10 @@ pub trait Shadable {
     /// Render the geometry and surface material parameters of the object.
     /// Should usually not be called directly but used in [DeferredPipeline::geometry_pass].
     ///
+    #[deprecated]
     fn render_deferred(
         &self,
-        material: &dyn DeferredMaterial,
+        material: &DeferredPhysicalMaterial,
         camera: &Camera,
         viewport: Viewport,
     ) -> ThreeDResult<()>;
@@ -186,7 +187,7 @@ impl<T: Shadable + ?Sized> Shadable for &T {
 
     fn render_deferred(
         &self,
-        material: &dyn DeferredMaterial,
+        material: &DeferredPhysicalMaterial,
         camera: &Camera,
         viewport: Viewport,
     ) -> ThreeDResult<()> {
@@ -206,7 +207,7 @@ impl<T: Shadable + ?Sized> Shadable for &mut T {
 
     fn render_deferred(
         &self,
-        material: &dyn DeferredMaterial,
+        material: &DeferredPhysicalMaterial,
         camera: &Camera,
         viewport: Viewport,
     ) -> ThreeDResult<()> {

--- a/src/renderer/object/axes.rs
+++ b/src/renderer/object/axes.rs
@@ -53,7 +53,7 @@ impl Shadable for Axes {
 
     fn render_deferred(
         &self,
-        material: &dyn DeferredMaterial,
+        material: &DeferredPhysicalMaterial,
         camera: &Camera,
         viewport: Viewport,
     ) -> ThreeDResult<()> {

--- a/src/renderer/object/axes.rs
+++ b/src/renderer/object/axes.rs
@@ -37,18 +37,27 @@ impl Axes {
 }
 
 impl Shadable for Axes {
-    fn render_forward(
+    fn render_with_material(
         &self,
         material: &dyn ForwardMaterial,
         camera: &Camera,
         lights: &Lights,
     ) -> ThreeDResult<()> {
         let mut model = self.model.clone();
-        model.render_forward(material, camera, lights)?;
+        model.render_with_material(material, camera, lights)?;
         model.set_transformation(self.transformation * Mat4::from_angle_z(degrees(90.0)));
-        model.render_forward(material, camera, lights)?;
+        model.render_with_material(material, camera, lights)?;
         model.set_transformation(self.transformation * Mat4::from_angle_y(degrees(-90.0)));
-        model.render_forward(material, camera, lights)
+        model.render_with_material(material, camera, lights)
+    }
+
+    fn render_forward(
+        &self,
+        material: &dyn ForwardMaterial,
+        camera: &Camera,
+        lights: &Lights,
+    ) -> ThreeDResult<()> {
+        self.render_with_material(material, camera, lights)
     }
 
     fn render_deferred(

--- a/src/renderer/object/axes.rs
+++ b/src/renderer/object/axes.rs
@@ -39,7 +39,7 @@ impl Axes {
 impl Shadable for Axes {
     fn render_with_material(
         &self,
-        material: &dyn ForwardMaterial,
+        material: &dyn Material,
         camera: &Camera,
         lights: &Lights,
     ) -> ThreeDResult<()> {
@@ -53,7 +53,7 @@ impl Shadable for Axes {
 
     fn render_forward(
         &self,
-        material: &dyn ForwardMaterial,
+        material: &dyn Material,
         camera: &Camera,
         lights: &Lights,
     ) -> ThreeDResult<()> {

--- a/src/renderer/object/axes.rs
+++ b/src/renderer/object/axes.rs
@@ -96,7 +96,7 @@ impl GeometryMut for Axes {
 impl Object for Axes {
     fn render(&self, camera: &Camera, _lights: &Lights) -> ThreeDResult<()> {
         let mut model = self.model.clone();
-        model.render_forward(
+        model.render_with_material(
             &ColorMaterial {
                 color: Color::RED,
                 ..Default::default()
@@ -105,7 +105,7 @@ impl Object for Axes {
             &Lights::default(),
         )?;
         model.set_transformation(self.transformation * Mat4::from_angle_z(degrees(90.0)));
-        model.render_forward(
+        model.render_with_material(
             &ColorMaterial {
                 color: Color::GREEN,
                 ..Default::default()
@@ -114,7 +114,7 @@ impl Object for Axes {
             &Lights::default(),
         )?;
         model.set_transformation(self.transformation * Mat4::from_angle_y(degrees(-90.0)));
-        model.render_forward(
+        model.render_with_material(
             &ColorMaterial {
                 color: Color::BLUE,
                 ..Default::default()

--- a/src/renderer/object/bounding_box.rs
+++ b/src/renderer/object/bounding_box.rs
@@ -62,13 +62,22 @@ impl<M: ForwardMaterial> BoundingBox<M> {
 }
 
 impl<M: ForwardMaterial> Shadable for BoundingBox<M> {
+    fn render_with_material(
+        &self,
+        material: &dyn ForwardMaterial,
+        camera: &Camera,
+        lights: &Lights,
+    ) -> ThreeDResult<()> {
+        self.model.render_with_material(material, camera, lights)
+    }
+
     fn render_forward(
         &self,
         material: &dyn ForwardMaterial,
         camera: &Camera,
         lights: &Lights,
     ) -> ThreeDResult<()> {
-        self.model.render_forward(material, camera, lights)
+        self.render_with_material(material, camera, lights)
     }
 
     fn render_deferred(

--- a/src/renderer/object/bounding_box.rs
+++ b/src/renderer/object/bounding_box.rs
@@ -1,11 +1,11 @@
 use crate::renderer::*;
 
-pub struct BoundingBox<M: ForwardMaterial> {
+pub struct BoundingBox<M: Material> {
     model: InstancedModel<M>,
     aabb: AxisAlignedBoundingBox,
 }
 
-impl<M: ForwardMaterial> BoundingBox<M> {
+impl<M: Material> BoundingBox<M> {
     ///
     /// Creates a bounding box object from an axis aligned bounding box.
     ///
@@ -61,10 +61,10 @@ impl<M: ForwardMaterial> BoundingBox<M> {
     }
 }
 
-impl<M: ForwardMaterial> Shadable for BoundingBox<M> {
+impl<M: Material> Shadable for BoundingBox<M> {
     fn render_with_material(
         &self,
-        material: &dyn ForwardMaterial,
+        material: &dyn Material,
         camera: &Camera,
         lights: &Lights,
     ) -> ThreeDResult<()> {
@@ -73,7 +73,7 @@ impl<M: ForwardMaterial> Shadable for BoundingBox<M> {
 
     fn render_forward(
         &self,
-        material: &dyn ForwardMaterial,
+        material: &dyn Material,
         camera: &Camera,
         lights: &Lights,
     ) -> ThreeDResult<()> {
@@ -90,7 +90,7 @@ impl<M: ForwardMaterial> Shadable for BoundingBox<M> {
     }
 }
 
-impl<M: ForwardMaterial> Geometry for BoundingBox<M> {
+impl<M: Material> Geometry for BoundingBox<M> {
     fn aabb(&self) -> AxisAlignedBoundingBox {
         self.aabb
     }
@@ -100,7 +100,7 @@ impl<M: ForwardMaterial> Geometry for BoundingBox<M> {
     }
 }
 
-impl<M: ForwardMaterial> Object for BoundingBox<M> {
+impl<M: Material> Object for BoundingBox<M> {
     fn render(&self, camera: &Camera, lights: &Lights) -> ThreeDResult<()> {
         self.model.render(camera, lights)
     }

--- a/src/renderer/object/bounding_box.rs
+++ b/src/renderer/object/bounding_box.rs
@@ -73,7 +73,7 @@ impl<M: ForwardMaterial> Shadable for BoundingBox<M> {
 
     fn render_deferred(
         &self,
-        material: &dyn DeferredMaterial,
+        material: &DeferredPhysicalMaterial,
         camera: &Camera,
         viewport: Viewport,
     ) -> ThreeDResult<()> {

--- a/src/renderer/object/circle.rs
+++ b/src/renderer/object/circle.rs
@@ -52,15 +52,23 @@ impl<M: ForwardMaterial> Circle<M> {
 }
 
 impl<M: ForwardMaterial> Shadable2D for Circle<M> {
-    fn render_forward(
+    fn render_with_material(
         &self,
         material: &dyn ForwardMaterial,
         viewport: Viewport,
     ) -> ThreeDResult<()> {
         self.context.camera2d(viewport, |camera2d| {
             self.model
-                .render_forward(material, camera2d, &Lights::default())
+                .render_with_material(material, camera2d, &Lights::default())
         })
+    }
+
+    fn render_forward(
+        &self,
+        material: &dyn ForwardMaterial,
+        viewport: Viewport,
+    ) -> ThreeDResult<()> {
+        self.render_with_material(material, viewport)
     }
 }
 

--- a/src/renderer/object/circle.rs
+++ b/src/renderer/object/circle.rs
@@ -1,14 +1,14 @@
 use crate::renderer::*;
 
 #[derive(Clone)]
-pub struct Circle<M: ForwardMaterial> {
+pub struct Circle<M: Material> {
     context: Context,
     model: Model<M>,
     radius: f32,
     center: Vec2,
 }
 
-impl<M: ForwardMaterial> Circle<M> {
+impl<M: Material> Circle<M> {
     pub fn new_with_material(
         context: &Context,
         center: Vec2,
@@ -51,10 +51,10 @@ impl<M: ForwardMaterial> Circle<M> {
     }
 }
 
-impl<M: ForwardMaterial> Shadable2D for Circle<M> {
+impl<M: Material> Shadable2D for Circle<M> {
     fn render_with_material(
         &self,
-        material: &dyn ForwardMaterial,
+        material: &dyn Material,
         viewport: Viewport,
     ) -> ThreeDResult<()> {
         self.context.camera2d(viewport, |camera2d| {
@@ -63,16 +63,12 @@ impl<M: ForwardMaterial> Shadable2D for Circle<M> {
         })
     }
 
-    fn render_forward(
-        &self,
-        material: &dyn ForwardMaterial,
-        viewport: Viewport,
-    ) -> ThreeDResult<()> {
+    fn render_forward(&self, material: &dyn Material, viewport: Viewport) -> ThreeDResult<()> {
         self.render_with_material(material, viewport)
     }
 }
 
-impl<M: ForwardMaterial> Object2D for Circle<M> {
+impl<M: Material> Object2D for Circle<M> {
     fn render(&self, viewport: Viewport) -> ThreeDResult<()> {
         self.context.camera2d(viewport, |camera2d| {
             self.model.render(camera2d, &Lights::default())

--- a/src/renderer/object/instanced_model.rs
+++ b/src/renderer/object/instanced_model.rs
@@ -4,7 +4,7 @@ use crate::renderer::*;
 ///
 /// Similar to [Model], except it is possible to render many instances of the same model efficiently.
 ///
-pub struct InstancedModel<M: ForwardMaterial> {
+pub struct InstancedModel<M: Material> {
     context: Context,
     mesh: Mesh,
     instance_count: u32,
@@ -34,7 +34,7 @@ impl InstancedModel<ColorMaterial> {
     }
 }
 
-impl<M: ForwardMaterial> InstancedModel<M> {
+impl<M: Material> InstancedModel<M> {
     pub fn new_with_material(
         context: &Context,
         transformations: &[Mat4],
@@ -182,7 +182,7 @@ impl<M: ForwardMaterial> InstancedModel<M> {
     }
 }
 
-impl<M: ForwardMaterial> Geometry for InstancedModel<M> {
+impl<M: Material> Geometry for InstancedModel<M> {
     fn aabb(&self) -> AxisAlignedBoundingBox {
         self.aabb
     }
@@ -192,17 +192,17 @@ impl<M: ForwardMaterial> Geometry for InstancedModel<M> {
     }
 }
 
-impl<M: ForwardMaterial> GeometryMut for InstancedModel<M> {
+impl<M: Material> GeometryMut for InstancedModel<M> {
     fn set_transformation(&mut self, transformation: Mat4) {
         self.transformation = transformation;
         self.update_aabb();
     }
 }
 
-impl<M: ForwardMaterial> Shadable for InstancedModel<M> {
+impl<M: Material> Shadable for InstancedModel<M> {
     fn render_with_material(
         &self,
-        material: &dyn ForwardMaterial,
+        material: &dyn Material,
         camera: &Camera,
         lights: &Lights,
     ) -> ThreeDResult<()> {
@@ -225,7 +225,7 @@ impl<M: ForwardMaterial> Shadable for InstancedModel<M> {
 
     fn render_forward(
         &self,
-        material: &dyn ForwardMaterial,
+        material: &dyn Material,
         camera: &Camera,
         lights: &Lights,
     ) -> ThreeDResult<()> {
@@ -257,7 +257,7 @@ impl<M: ForwardMaterial> Shadable for InstancedModel<M> {
     }
 }
 
-impl<M: ForwardMaterial> Object for InstancedModel<M> {
+impl<M: Material> Object for InstancedModel<M> {
     fn render(&self, camera: &Camera, lights: &Lights) -> ThreeDResult<()> {
         self.render_with_material(&self.material, camera, lights)
     }

--- a/src/renderer/object/instanced_model.rs
+++ b/src/renderer/object/instanced_model.rs
@@ -217,17 +217,18 @@ impl<M: ForwardMaterial> Shadable for InstancedModel<M> {
 
     fn render_deferred(
         &self,
-        material: &dyn DeferredMaterial,
+        material: &DeferredPhysicalMaterial,
         camera: &Camera,
         viewport: Viewport,
     ) -> ThreeDResult<()> {
+        let lights = Lights::default();
         let fragment_shader_source =
-            material.fragment_shader_source_deferred(self.mesh.color_buffer.is_some());
+            material.fragment_shader_source(self.mesh.color_buffer.is_some(), &lights);
         self.context.program(
             &Self::vertex_shader_source(&fragment_shader_source)?,
             &fragment_shader_source,
             |program| {
-                material.use_uniforms(program, camera, &Lights::default())?;
+                material.use_uniforms(program, camera, &lights)?;
                 self.draw(
                     program,
                     material.render_states(),

--- a/src/renderer/object/instanced_model.rs
+++ b/src/renderer/object/instanced_model.rs
@@ -259,7 +259,7 @@ impl<M: ForwardMaterial> Shadable for InstancedModel<M> {
 
 impl<M: ForwardMaterial> Object for InstancedModel<M> {
     fn render(&self, camera: &Camera, lights: &Lights) -> ThreeDResult<()> {
-        self.render_forward(&self.material, camera, lights)
+        self.render_with_material(&self.material, camera, lights)
     }
 
     fn is_transparent(&self) -> bool {

--- a/src/renderer/object/instanced_model.rs
+++ b/src/renderer/object/instanced_model.rs
@@ -200,7 +200,7 @@ impl<M: ForwardMaterial> GeometryMut for InstancedModel<M> {
 }
 
 impl<M: ForwardMaterial> Shadable for InstancedModel<M> {
-    fn render_forward(
+    fn render_with_material(
         &self,
         material: &dyn ForwardMaterial,
         camera: &Camera,
@@ -221,6 +221,15 @@ impl<M: ForwardMaterial> Shadable for InstancedModel<M> {
                 )
             },
         )
+    }
+
+    fn render_forward(
+        &self,
+        material: &dyn ForwardMaterial,
+        camera: &Camera,
+        lights: &Lights,
+    ) -> ThreeDResult<()> {
+        self.render_with_material(material, camera, lights)
     }
 
     fn render_deferred(

--- a/src/renderer/object/line.rs
+++ b/src/renderer/object/line.rs
@@ -1,7 +1,7 @@
 use crate::renderer::*;
 
 #[derive(Clone)]
-pub struct Line<M: ForwardMaterial> {
+pub struct Line<M: Material> {
     context: Context,
     model: Model<M>,
     pixel0: Vec2,
@@ -9,7 +9,7 @@ pub struct Line<M: ForwardMaterial> {
     width: f32,
 }
 
-impl<M: ForwardMaterial> Line<M> {
+impl<M: Material> Line<M> {
     pub fn new_with_material(
         context: &Context,
         pixel0: Vec2,
@@ -69,10 +69,10 @@ impl<M: ForwardMaterial> Line<M> {
     }
 }
 
-impl<M: ForwardMaterial> Shadable2D for Line<M> {
+impl<M: Material> Shadable2D for Line<M> {
     fn render_with_material(
         &self,
-        material: &dyn ForwardMaterial,
+        material: &dyn Material,
         viewport: Viewport,
     ) -> ThreeDResult<()> {
         self.context.camera2d(viewport, |camera2d| {
@@ -81,16 +81,12 @@ impl<M: ForwardMaterial> Shadable2D for Line<M> {
         })
     }
 
-    fn render_forward(
-        &self,
-        material: &dyn ForwardMaterial,
-        viewport: Viewport,
-    ) -> ThreeDResult<()> {
+    fn render_forward(&self, material: &dyn Material, viewport: Viewport) -> ThreeDResult<()> {
         self.render_with_material(material, viewport)
     }
 }
 
-impl<M: ForwardMaterial> Object2D for Line<M> {
+impl<M: Material> Object2D for Line<M> {
     fn render(&self, viewport: Viewport) -> ThreeDResult<()> {
         self.context.camera2d(viewport, |camera2d| {
             self.model.render(camera2d, &Lights::default())

--- a/src/renderer/object/line.rs
+++ b/src/renderer/object/line.rs
@@ -70,15 +70,23 @@ impl<M: ForwardMaterial> Line<M> {
 }
 
 impl<M: ForwardMaterial> Shadable2D for Line<M> {
-    fn render_forward(
+    fn render_with_material(
         &self,
         material: &dyn ForwardMaterial,
         viewport: Viewport,
     ) -> ThreeDResult<()> {
         self.context.camera2d(viewport, |camera2d| {
             self.model
-                .render_forward(material, camera2d, &Lights::default())
+                .render_with_material(material, camera2d, &Lights::default())
         })
+    }
+
+    fn render_forward(
+        &self,
+        material: &dyn ForwardMaterial,
+        viewport: Viewport,
+    ) -> ThreeDResult<()> {
+        self.render_with_material(material, viewport)
     }
 }
 

--- a/src/renderer/object/model.rs
+++ b/src/renderer/object/model.rs
@@ -88,7 +88,7 @@ impl<M: ForwardMaterial> GeometryMut for Model<M> {
 }
 
 impl<M: ForwardMaterial> Shadable for Model<M> {
-    fn render_forward(
+    fn render_with_material(
         &self,
         material: &dyn ForwardMaterial,
         camera: &Camera,
@@ -110,6 +110,15 @@ impl<M: ForwardMaterial> Shadable for Model<M> {
                 )
             },
         )
+    }
+
+    fn render_forward(
+        &self,
+        material: &dyn ForwardMaterial,
+        camera: &Camera,
+        lights: &Lights,
+    ) -> ThreeDResult<()> {
+        self.render_with_material(material, camera, lights)
     }
 
     fn render_deferred(

--- a/src/renderer/object/model.rs
+++ b/src/renderer/object/model.rs
@@ -3,10 +3,10 @@ use crate::renderer::*;
 use std::rc::Rc;
 
 ///
-/// A 3D model consisting of a triangle mesh and any material that implements the `ForwardMaterial` trait.
+/// A 3D model consisting of a triangle mesh and any material that implements the `Material` trait.
 ///
 #[derive(Clone)]
-pub struct Model<M: ForwardMaterial> {
+pub struct Model<M: Material> {
     context: Context,
     mesh: Rc<Mesh>,
     aabb: AxisAlignedBoundingBox,
@@ -25,7 +25,7 @@ impl Model<ColorMaterial> {
     }
 }
 
-impl<M: ForwardMaterial> Model<M> {
+impl<M: Material> Model<M> {
     ///
     /// Creates a new 3D model with a triangle mesh as geometry and the given material.
     ///
@@ -68,7 +68,7 @@ impl<M: ForwardMaterial> Model<M> {
     }
 }
 
-impl<M: ForwardMaterial> Geometry for Model<M> {
+impl<M: Material> Geometry for Model<M> {
     fn aabb(&self) -> AxisAlignedBoundingBox {
         self.aabb
     }
@@ -78,7 +78,7 @@ impl<M: ForwardMaterial> Geometry for Model<M> {
     }
 }
 
-impl<M: ForwardMaterial> GeometryMut for Model<M> {
+impl<M: Material> GeometryMut for Model<M> {
     fn set_transformation(&mut self, transformation: Mat4) {
         self.transformation = transformation;
         let mut aabb = self.aabb_local.clone();
@@ -87,10 +87,10 @@ impl<M: ForwardMaterial> GeometryMut for Model<M> {
     }
 }
 
-impl<M: ForwardMaterial> Shadable for Model<M> {
+impl<M: Material> Shadable for Model<M> {
     fn render_with_material(
         &self,
-        material: &dyn ForwardMaterial,
+        material: &dyn Material,
         camera: &Camera,
         lights: &Lights,
     ) -> ThreeDResult<()> {
@@ -114,7 +114,7 @@ impl<M: ForwardMaterial> Shadable for Model<M> {
 
     fn render_forward(
         &self,
-        material: &dyn ForwardMaterial,
+        material: &dyn Material,
         camera: &Camera,
         lights: &Lights,
     ) -> ThreeDResult<()> {
@@ -147,7 +147,7 @@ impl<M: ForwardMaterial> Shadable for Model<M> {
     }
 }
 
-impl<M: ForwardMaterial> Object for Model<M> {
+impl<M: Material> Object for Model<M> {
     fn render(&self, camera: &Camera, lights: &Lights) -> ThreeDResult<()> {
         self.render_with_material(&self.material, camera, lights)
     }

--- a/src/renderer/object/model.rs
+++ b/src/renderer/object/model.rs
@@ -114,17 +114,18 @@ impl<M: ForwardMaterial> Shadable for Model<M> {
 
     fn render_deferred(
         &self,
-        material: &dyn DeferredMaterial,
+        material: &DeferredPhysicalMaterial,
         camera: &Camera,
         viewport: Viewport,
     ) -> ThreeDResult<()> {
+        let lights = Lights::default();
         let fragment_shader_source =
-            material.fragment_shader_source_deferred(self.mesh.color_buffer.is_some());
+            material.fragment_shader_source(self.mesh.color_buffer.is_some(), &lights);
         self.context.program(
             &Mesh::vertex_shader_source(&fragment_shader_source)?,
             &fragment_shader_source,
             |program| {
-                material.use_uniforms(program, camera, &Lights::default())?;
+                material.use_uniforms(program, camera, &lights)?;
                 self.mesh.draw(
                     program,
                     material.render_states(),

--- a/src/renderer/object/model.rs
+++ b/src/renderer/object/model.rs
@@ -149,7 +149,7 @@ impl<M: ForwardMaterial> Shadable for Model<M> {
 
 impl<M: ForwardMaterial> Object for Model<M> {
     fn render(&self, camera: &Camera, lights: &Lights) -> ThreeDResult<()> {
-        self.render_forward(&self.material, camera, lights)
+        self.render_with_material(&self.material, camera, lights)
     }
 
     fn is_transparent(&self) -> bool {

--- a/src/renderer/object/particles.rs
+++ b/src/renderer/object/particles.rs
@@ -234,7 +234,7 @@ impl Shadable for Particles {
 
     fn render_deferred(
         &self,
-        _material: &dyn DeferredMaterial,
+        _material: &DeferredPhysicalMaterial,
         _camera: &Camera,
         _viewport: Viewport,
     ) -> ThreeDResult<()> {

--- a/src/renderer/object/particles.rs
+++ b/src/renderer/object/particles.rs
@@ -173,7 +173,7 @@ impl GeometryMut for Particles {
 impl Shadable for Particles {
     fn render_with_material(
         &self,
-        material: &dyn ForwardMaterial,
+        material: &dyn Material,
         camera: &Camera,
         lights: &Lights,
     ) -> ThreeDResult<()> {
@@ -234,7 +234,7 @@ impl Shadable for Particles {
 
     fn render_forward(
         &self,
-        material: &dyn ForwardMaterial,
+        material: &dyn Material,
         camera: &Camera,
         lights: &Lights,
     ) -> ThreeDResult<()> {

--- a/src/renderer/object/particles.rs
+++ b/src/renderer/object/particles.rs
@@ -171,7 +171,7 @@ impl GeometryMut for Particles {
 }
 
 impl Shadable for Particles {
-    fn render_forward(
+    fn render_with_material(
         &self,
         material: &dyn ForwardMaterial,
         camera: &Camera,
@@ -230,6 +230,15 @@ impl Shadable for Particles {
                 Ok(())
             },
         )
+    }
+
+    fn render_forward(
+        &self,
+        material: &dyn ForwardMaterial,
+        camera: &Camera,
+        lights: &Lights,
+    ) -> ThreeDResult<()> {
+        self.render_with_material(material, camera, lights)
     }
 
     fn render_deferred(

--- a/src/renderer/object/rectangle.rs
+++ b/src/renderer/object/rectangle.rs
@@ -1,7 +1,7 @@
 use crate::renderer::*;
 
 #[derive(Clone)]
-pub struct Rectangle<M: ForwardMaterial> {
+pub struct Rectangle<M: Material> {
     model: Model<M>,
     context: Context,
     width: f32,
@@ -10,7 +10,7 @@ pub struct Rectangle<M: ForwardMaterial> {
     rotation: Radians,
 }
 
-impl<M: ForwardMaterial> Rectangle<M> {
+impl<M: Material> Rectangle<M> {
     pub fn new_with_material(
         context: &Context,
         center: Vec2,
@@ -70,10 +70,10 @@ impl<M: ForwardMaterial> Rectangle<M> {
     }
 }
 
-impl<M: ForwardMaterial> Shadable2D for Rectangle<M> {
+impl<M: Material> Shadable2D for Rectangle<M> {
     fn render_with_material(
         &self,
-        material: &dyn ForwardMaterial,
+        material: &dyn Material,
         viewport: Viewport,
     ) -> ThreeDResult<()> {
         self.context.camera2d(viewport, |camera2d| {
@@ -82,16 +82,12 @@ impl<M: ForwardMaterial> Shadable2D for Rectangle<M> {
         })
     }
 
-    fn render_forward(
-        &self,
-        material: &dyn ForwardMaterial,
-        viewport: Viewport,
-    ) -> ThreeDResult<()> {
+    fn render_forward(&self, material: &dyn Material, viewport: Viewport) -> ThreeDResult<()> {
         self.render_with_material(material, viewport)
     }
 }
 
-impl<M: ForwardMaterial> Object2D for Rectangle<M> {
+impl<M: Material> Object2D for Rectangle<M> {
     fn render(&self, viewport: Viewport) -> ThreeDResult<()> {
         self.context.camera2d(viewport, |camera2d| {
             self.model.render(camera2d, &Lights::default())

--- a/src/renderer/object/rectangle.rs
+++ b/src/renderer/object/rectangle.rs
@@ -71,15 +71,23 @@ impl<M: ForwardMaterial> Rectangle<M> {
 }
 
 impl<M: ForwardMaterial> Shadable2D for Rectangle<M> {
-    fn render_forward(
+    fn render_with_material(
         &self,
         material: &dyn ForwardMaterial,
         viewport: Viewport,
     ) -> ThreeDResult<()> {
         self.context.camera2d(viewport, |camera2d| {
             self.model
-                .render_forward(material, camera2d, &Lights::default())
+                .render_with_material(material, camera2d, &Lights::default())
         })
+    }
+
+    fn render_forward(
+        &self,
+        material: &dyn ForwardMaterial,
+        viewport: Viewport,
+    ) -> ThreeDResult<()> {
+        self.render_with_material(material, viewport)
     }
 }
 


### PR DESCRIPTION
- Merge `ForwardMaterial` and `DeferredMaterial` into one trait
- `Shadable` trait has one function (`render_with_material`). `render_forward` and `render_deferred` are deprecated.
- Made a new `Material` called `DeferredPhysicalMaterial` that is the same as the deferred version of the `PhysicalMaterial`
- `DeferredPipeline` use new `Light` struct and `DeferredPhysicalMaterial`