### PR TITLE
Mutability pattern proposal

### DIFF
--- a/src/renderer/object/instanced_model.rs
+++ b/src/renderer/object/instanced_model.rs
@@ -1,7 +1,7 @@
 use crate::core::*;
 use crate::renderer::*;
-use std::rc::Rc;
 use std::cell::RefCell;
+use std::rc::Rc;
 
 ///
 /// Similar to [Model], except it is possible to render many instances of the same model efficiently.
@@ -35,7 +35,12 @@ impl InstancedModel<ColorMaterial> {
         instances: &[ModelInstance],
         cpu_mesh: &CPUMesh,
     ) -> ThreeDResult<Self> {
-        Self::new_with_material(context, instances, cpu_mesh, Rc::new(ColorMaterial::default()))
+        Self::new_with_material(
+            context,
+            instances,
+            cpu_mesh,
+            Rc::new(ColorMaterial::default()),
+        )
     }
 }
 

--- a/src/renderer/object/instanced_model.rs
+++ b/src/renderer/object/instanced_model.rs
@@ -90,7 +90,7 @@ impl<M: ForwardMaterial> InstancedModel<M> {
     /// Create an instance for each element with the given mesh and texture transforms.
     ///
     pub fn set_instances(&self, new_instances: &[ModelInstance]) {
-        let mut instances = self.instances.borrow_mut();
+        let instances = &mut *self.instances.borrow_mut();
         *instances = new_instances.to_vec();
         self.set_buffers_dirty(true);
     }
@@ -149,7 +149,7 @@ impl<M: ForwardMaterial> InstancedModel<M> {
     }
 
     fn set_buffers_dirty(&self, bool: bool) {
-        let mut dirty = self.buffers_dirty.borrow_mut();
+        let dirty = &mut self.buffers_dirty.borrow_mut();
         *dirty = bool
     }
 

--- a/src/renderer/object/instanced_model.rs
+++ b/src/renderer/object/instanced_model.rs
@@ -113,29 +113,26 @@ impl<M: ForwardMaterial> InstancedModel<M> {
         let mut row2 = Vec::new();
         let mut row3 = Vec::new();
         let mut subt = Vec::new();
-        let root_transform = *self.transformation.borrow();
         let instances = &*self.instances.borrow();
         let instance_buffer1 = &mut *self.instance_buffer1.borrow_mut();
         let instance_buffer2 = &mut *self.instance_buffer2.borrow_mut();
         let instance_buffer3 = &mut *self.instance_buffer3.borrow_mut();
         let instance_buffer4 = &mut *self.instance_buffer4.borrow_mut();
-        let mut combined_transform: Mat4;
         for instance in instances.iter() {
-            combined_transform = root_transform * instance.mesh_transform;
-            row1.push(combined_transform.x.x);
-            row1.push(combined_transform.y.x);
-            row1.push(combined_transform.z.x);
-            row1.push(combined_transform.w.x);
+            row1.push(instance.mesh_transform.x.x);
+            row1.push(instance.mesh_transform.y.x);
+            row1.push(instance.mesh_transform.z.x);
+            row1.push(instance.mesh_transform.w.x);
 
-            row2.push(combined_transform.x.y);
-            row2.push(combined_transform.y.y);
-            row2.push(combined_transform.z.y);
-            row2.push(combined_transform.w.y);
+            row2.push(instance.mesh_transform.x.y);
+            row2.push(instance.mesh_transform.y.y);
+            row2.push(instance.mesh_transform.z.y);
+            row2.push(instance.mesh_transform.w.y);
 
-            row3.push(combined_transform.x.z);
-            row3.push(combined_transform.y.z);
-            row3.push(combined_transform.z.z);
-            row3.push(combined_transform.w.z);
+            row3.push(instance.mesh_transform.x.z);
+            row3.push(instance.mesh_transform.y.z);
+            row3.push(instance.mesh_transform.z.z);
+            row3.push(instance.mesh_transform.w.z);
 
             subt.push(instance.texture_transform.offset_x);
             subt.push(instance.texture_transform.offset_y);


### PR DESCRIPTION
Fell asleep on the couch, woke up to epiphany, such is code.

There is a tendency for RefCell to be described or annotated for use in a form like `Rc<RefCell<>>`. One might infer that this is akin to a much more familiar and straightforward `Arc<Mutex<Struct>>` in usage, but this description can be hugely misleading. The proper notation for describing the use of RefCell should instead be `Rc<Struct<RefCell<Value>>`, making the overall structure reference counted but only the internal values mutable on demand. This permits sharable immutable models to call immutable methods that may alter _private_ mutable state, propagating changes to all sharing the model.

Proposed here is a mutability policy and initial implementation. It can be noted that implementing this policy on InstancedModel as in the PR required no outside changes beyond eventually applying the same policy to Materials.

1. All structs utilizing `RefCell` shall be `Rc` wrapped at creation and `.clone()`'d for use in other structs.
2. All usage of `RefCell` shall only be on _private_ struct fields.
3. No method of a struct utilizing `RefCell` will be `&mut self`.
4. Any function taking a reference that may be to a struct utilizing `RefCell` shall perform the amperslam (`&*`).

This policy ensures that absolutely no mutability is exposed outside of the struct's own methods, and even within those methods mutability is strictly explicit, e.g. `let foo = &mut *self.foo.borrow_mut()`, instead of the implicit function arg `&mut self`. The use of an amperslam is idempotent for non-`Rc`-wrapped structs while transparently shedding the `Rc` pointer.

A tradeoff is the need to declare borrows in methods using self-reference, e.g. `let foo = self.foo.borrow();`, but this again reinforces the explicitness of the mutability.

_Edit:_ Syntactical tweaks