### PR TITLE
Fix canvas size on fractional device pixel ratios

### DIFF
--- a/src/window/canvas.rs
+++ b/src/window/canvas.rs
@@ -168,20 +168,14 @@ impl Window {
             self.set_canvas_size().unwrap();
             let device_pixel_ratio = self.pixels_per_point();
             let canvas = self.canvas.as_ref().unwrap();
-            let (width, height) = (
-                (canvas.width() as f64 / device_pixel_ratio) as u32,
-                (canvas.height() as f64 / device_pixel_ratio) as u32,
-            );
+            let (width, height) = (canvas.width(), canvas.height());
             let frame_input = FrameInput {
                 events,
                 elapsed_time,
                 accumulated_time,
-                viewport: Viewport::new_at_origo(
-                    (device_pixel_ratio * width as f64) as u32,
-                    (device_pixel_ratio * height as f64) as u32,
-                ),
-                window_width: width,
-                window_height: height,
+                viewport: Viewport::new_at_origo(width, height),
+                window_width: (width as f64 / device_pixel_ratio) as u32,
+                window_height: (height as f64 / device_pixel_ratio) as u32,
                 device_pixel_ratio,
                 first_frame: first_frame,
             };
@@ -219,9 +213,21 @@ impl Window {
         };
         width = u32::max(width, self.settings.min_size.0);
         height = u32::max(height, self.settings.min_size.1);
+
+        let device_pixel_ratio = self.pixels_per_point();
+
+        // Determine the amount of actual pixels we want to render:
+        let width_px = (device_pixel_ratio * width as f64) as u32;
+        let height_px = (device_pixel_ratio * height as f64) as u32;
+
+        // Determine the CSS width & height, which are adjusted for the device
+        // pixel ratio and can be fractional:
+        let width_css = (width_px as f64) / device_pixel_ratio;
+        let height_css = (height_px as f64) / device_pixel_ratio;
+
         let mut style = canvas.style().css_text();
-        let w = format!("width:{}px;", width);
-        let h = format!("height:{}px;", height);
+        let w = format!("width:{}px;", width_css);
+        let h = format!("height:{}px;", height_css);
         if let Some(start) = style.find("width") {
             let mut end = start;
             for char in style[start..].chars() {
@@ -248,9 +254,9 @@ impl Window {
         }
 
         canvas.style().set_css_text(&style);
-        let device_pixel_ratio = self.pixels_per_point();
-        canvas.set_width((device_pixel_ratio * width as f64) as u32);
-        canvas.set_height((device_pixel_ratio * height as f64) as u32);
+        canvas.set_width(width_px);
+        canvas.set_height(height_px);
+
         Ok(())
     }
 


### PR DESCRIPTION
This PR aims to fix some rounding errors that occur when having a non-integer device pixel ratio. This made it impossible to render pixel-perfect in some cases, which would be required in things like pixelart games or maybe other cases like UI rendering.

I tried to keep the changes as minimal as possible, but only with these changes I was able to render pixel-perfect textures, where one pixel in the texture exactly matches a pixel in the final canvas:

- Allow the size given in the CSS styles to be fractional, as this is intended behavior. For example, if the canvas is 200 native pixels wide (so the HTML attribute says width="200"), with a device pixel ratio of 1.5 the CSS width should be:
  `(200/1.5)px = 133.333333px`
- Made sure width & height passed to the viewport in the FrameInput is the actual size in native pixels. Previously, the original native pixels (returned by `canvas.width()` and `canvas.height()`) were first converted to account for the device pixel ratio and then rounded, as this is expected for the window_width and window_height attributes in the FrameInput. However, then these values were extrapolated again to get the viewport width + height, which resulted in rounding errors to make the viewport not match the actual size in native pixels.

# How to test

If you have a fractional device pixel ratio such as 1.5 (you can fake it by using the browser zoom), then you can watch the width/height attributes of the `<canvas>` as well as the width/height CSS styles of the `<canvas>`, as well as log the `viewport` and `window_width` & `window_height` attributes of `FrameInput` during rendering. You will notice, in the previous versions there will be a mismatch of these metrics that are off by some pixels in some cases where rounding errors happened.

With this PR, the native pixels (width/height HTML attributes of the canvas and also the width/height attributes of the FrameInput's viewport) will __always match__, and the CSS styles of width/height will __always__ be `(native pixels / device pixel ratio)px`, even if it's fractional (which is desired).