### PR TITLE
Add `BoundingBox::new_with_line_thickness`

### DIFF
--- a/src/renderer/object/bounding_box.rs
+++ b/src/renderer/object/bounding_box.rs
@@ -14,10 +14,30 @@ impl<M: Material> BoundingBox<M> {
         aabb: AxisAlignedBoundingBox,
         material: M,
     ) -> ThreeDResult<Self> {
+        let size = aabb.size();
+        let thickness = 0.02 * size.x.max(size.y).max(size.z);
+
+        Self::new_with_line_thickness(
+            context,
+            aabb,
+            material,
+            thickness,
+        )
+    }
+
+    ///
+    /// Creates a bounding box object from an axis aligned bounding box with a specified line
+    /// thickness.
+    ///
+    pub fn new_with_line_thickness(
+        context: &Context,
+        aabb: AxisAlignedBoundingBox,
+        material: M,
+        thickness: f32,
+    ) -> ThreeDResult<Self> {
         let max = aabb.max();
         let min = aabb.min();
         let size = aabb.size();
-        let thickness = 0.02 * size.x.max(size.y).max(size.z);
         let transformations = [
             Mat4::from_translation(min) * Mat4::from_nonuniform_scale(size.x, thickness, thickness),
             Mat4::from_translation(vec3(min.x, max.y, max.z))

--- a/src/renderer/object/bounding_box.rs
+++ b/src/renderer/object/bounding_box.rs
@@ -17,19 +17,14 @@ impl<M: Material> BoundingBox<M> {
         let size = aabb.size();
         let thickness = 0.02 * size.x.max(size.y).max(size.z);
 
-        Self::new_with_line_thickness(
-            context,
-            aabb,
-            material,
-            thickness,
-        )
+        Self::new_with_material_and_thickness(context, aabb, material, thickness)
     }
 
     ///
     /// Creates a bounding box object from an axis aligned bounding box with a specified line
     /// thickness.
     ///
-    pub fn new_with_line_thickness(
+    pub fn new_with_material_and_thickness(
         context: &Context,
         aabb: AxisAlignedBoundingBox,
         material: M,


### PR DESCRIPTION
I was looking to visualize the print volume of a 3D printer but the line thickness was thicker then I wanted for my application.

`BoundingBox::new_with_line_thickness` allows developers to override the default line thickness on bounding boxes.

### Before:
![image](https://user-images.githubusercontent.com/145184/150693761-3b32c5b2-2f37-41e9-88d8-fa37f80112a6.png)

### After:

![image](https://user-images.githubusercontent.com/145184/150693600-e436efef-02d6-431e-9c40-d1a29a336ed7.png)
