### PR TITLE
glTF transform

### DIFF
--- a/examples/pbr/src/main.rs
+++ b/examples/pbr/src/main.rs
@@ -44,8 +44,7 @@ pub async fn run() {
     let (mut cpu_meshes, cpu_materials) = loaded.gltf("DamagedHelmet.glb").unwrap();
     let material = PhysicalMaterial::new(&context, &cpu_materials[0]).unwrap();
     cpu_meshes[0].compute_tangents().unwrap();
-    let mut model = Model::new_with_material(&context, &cpu_meshes[0], material.clone()).unwrap();
-    model.set_transformation(Mat4::from_angle_x(degrees(90.0)));
+    let model = Model::new_with_material(&context, &cpu_meshes[0], material.clone()).unwrap();
 
     let light =
         AmbientLight::new_with_environment(&context, 1.0, Color::WHITE, skybox.texture()).unwrap();

--- a/src/core/cpu_mesh.rs
+++ b/src/core/cpu_mesh.rs
@@ -203,24 +203,7 @@ impl CpuMesh {
                 }
             }
             Positions::F64(ref mut positions) => {
-                let t = Matrix4::new(
-                    transform.x.x as f64,
-                    transform.x.y as f64,
-                    transform.x.z as f64,
-                    transform.x.w as f64,
-                    transform.y.x as f64,
-                    transform.y.y as f64,
-                    transform.y.z as f64,
-                    transform.y.w as f64,
-                    transform.z.x as f64,
-                    transform.z.y as f64,
-                    transform.z.z as f64,
-                    transform.z.w as f64,
-                    transform.w.x as f64,
-                    transform.w.y as f64,
-                    transform.w.z as f64,
-                    transform.w.w as f64,
-                );
+                let t = transform.cast::<f64>().unwrap();
                 for pos in positions.iter_mut() {
                     *pos = (t * pos.extend(1.0)).truncate();
                 }


### PR DESCRIPTION
Previously the `transform` for the glTF nodes were ignored, which means meshes consisting of several nodes with different transforms would be all jumbled.

Also, today I learned that Blender swizzles glTF files on load/save: https://github.com/KhronosGroup/glTF-Blender-Exporter/blob/master/docs/developer.md#implementation-details  😡🤬 . This led me on a long goose chase to try to figure out why all meshes were lying on their side.