### PR TITLE
cargo-deny

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,6 @@
 name: build
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -10,8 +10,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        rust: [stable, nightly]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        rust: [ stable, nightly ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,6 @@
 name: build
 
-on: [ push, pull_request ]
+on: [push, pull_request]
 
 env:
   CARGO_TERM_COLOR: always
@@ -10,8 +10,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
-        rust: [ stable, nightly ]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        rust: [stable, nightly]
 
     steps:
       - uses: actions/checkout@v2
@@ -67,3 +67,8 @@ jobs:
             fi
           done
 
+  cargo-deny:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: EmbarkStudios/cargo-deny-action@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ reqwest = { version = "0.11", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 gltf = { version = "1.0.0", features = ["utils"], optional = true }
 wavefront_obj = { version = "10.0", optional = true }
-image = { version = "0.24", optional = true, default-features = false, features = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "dds", "farbfeld"]}
+image = { version = "0.23", optional = true, default-features = false, features = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "dds", "farbfeld"]}
 egui = { version = "0.13", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.build-dependencies]

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,51 @@
+# https://embarkstudios.github.io/cargo-deny/
+
+targets = [
+    { triple = "aarch64-apple-darwin" },
+    { triple = "aarch64-linux-android" },
+    { triple = "x86_64-apple-darwin" },
+    { triple = "x86_64-pc-windows-msvc" },
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "x86_64-unknown-linux-musl" },
+]
+
+[advisories]
+vulnerability = "deny"
+unmaintained = "warn"
+yanked = "deny"
+ignore = []
+
+[bans]
+multiple-versions = "deny"
+wildcards = "allow"        # at least until https://github.com/EmbarkStudios/cargo-deny/issues/241 is fixed
+deny = []
+
+skip = [
+    { name = "base64" },              # gltf uses an old version
+    { name = "cfg-if" },              # winit depends on an old version
+    { name = "core-foundation" },     # winit depends on an old version
+    { name = "core-foundation-sys" }, # winit depends on an old version
+    { name = "core-graphics" },       # winit depends on an old version
+    { name = "miniz_oxide" },         # image crate depends on an old version
+]
+skip-tree = []
+
+
+[licenses]
+unlicensed = "deny"
+allow-osi-fsf-free = "neither"
+confidence-threshold = 0.92 # We want really high confidence when inferring licenses from text
+copyleft = "deny"
+allow = [
+    # "Apache-2.0 WITH LLVM-exception", # https://spdx.org/licenses/LLVM-exception.html
+    "Apache-2.0",   # https://tldrlegal.com/license/apache-license-2.0-(apache-2.0)
+    "BSD-2-Clause", # https://tldrlegal.com/license/bsd-2-clause-license-(freebsd)
+    "BSD-3-Clause", # https://tldrlegal.com/license/bsd-3-clause-license-(revised)
+    "BSL-1.0",      # https://tldrlegal.com/license/boost-software-license-1.0-explained
+    "CC0-1.0",      # https://creativecommons.org/publicdomain/zero/1.0/
+    "ISC",          # https://tldrlegal.com/license/-isc-license
+    "MIT",          # https://tldrlegal.com/license/mit-license
+    # "MPL-2.0",      # https://www.mozilla.org/en-US/MPL/2.0/FAQ/ - see Q11
+    # "OpenSSL",      # https://www.openssl.org/source/license.html
+    "Zlib", # https://tldrlegal.com/license/zlib-libpng-license-(zlib)
+]

--- a/src/io/parser/img.rs
+++ b/src/io/parser/img.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 ///
 pub fn image_from_bytes(bytes: &[u8]) -> ThreeDResult<CpuTexture> {
     use image::DynamicImage;
+    use image::GenericImageView as _;
     let img = image::load_from_memory(bytes)?;
     let width = img.width();
     let height = img.height();


### PR DESCRIPTION
[cargo-deny](https://github.com/EmbarkStudios/cargo-deny) is an amazing tool that protects from:

* duplicated crates (code bloat)
* copy-left licenses in the dependency tree
* RUSTSEC advisories

…and more!

In this case I noticed that `three-d` brought in two copies of the `image` crate, which means a lot of extra code, which is in particularly worrisome when compiling to Wasm.