### PR TITLE
Take Glow context using Arc.

### DIFF
--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -2,6 +2,7 @@ use super::*;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
+use std::sync::Arc;
 
 #[doc(hidden)]
 pub use crate::context::HasContext;
@@ -13,7 +14,7 @@ pub use crate::context::HasContext;
 ///
 #[derive(Clone)]
 pub struct Context {
-    context: Rc<crate::context::Context>,
+    context: Arc<crate::context::Context>,
     pub(super) vao: crate::context::VertexArray,
     programs: Rc<RefCell<HashMap<String, Program>>>,
     effects: Rc<RefCell<HashMap<String, ImageEffect>>>,
@@ -29,7 +30,7 @@ impl Context {
     /// Since the content in the [context](crate::context) module is just a re-export of [glow](https://crates.io/crates/glow),
     /// you can also call this method with a reference counter to a glow context created using glow and not the re-export in [context](crate::context).
     ///
-    pub fn from_gl_context(context: Rc<crate::context::Context>) -> ThreeDResult<Self> {
+    pub fn from_gl_context(context: Arc<crate::context::Context>) -> ThreeDResult<Self> {
         #[cfg(not(target_arch = "wasm32"))]
         unsafe {
             // Enable seamless cube map textures

--- a/src/window/canvas.rs
+++ b/src/window/canvas.rs
@@ -3,6 +3,7 @@ use crate::window::*;
 use serde::Serialize;
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::sync::Arc;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::WebGl2RenderingContext;
@@ -145,7 +146,7 @@ impl Window {
             .get_extension("OES_texture_float_linear")
             .map_err(|e| CanvasError::OESTextureFloatNotSupported(format!(": {:?}", e)))?;
 
-        crate::core::Context::from_gl_context(Rc::new(
+        crate::core::Context::from_gl_context(Arc::new(
             crate::context::Context::from_webgl2_context(context),
         ))
     }

--- a/src/window/glutin_window.rs
+++ b/src/window/glutin_window.rs
@@ -52,7 +52,7 @@ impl Window {
         Ok(Window {
             windowed_context,
             event_loop,
-            gl: crate::core::Context::from_gl_context(std::rc::Rc::new(context))?,
+            gl: crate::core::Context::from_gl_context(std::sync::Arc::new(context))?,
         })
     }
 

--- a/src/window/headless.rs
+++ b/src/window/headless.rs
@@ -14,7 +14,7 @@ impl Context {
         let cb = ContextBuilder::new();
         let (headless_context, _el) = build_context(cb).unwrap();
         let headless_context = unsafe { headless_context.make_current().unwrap() };
-        let mut c = Self::from_gl_context(std::rc::Rc::new(unsafe {
+        let mut c = Self::from_gl_context(std::sync::Arc::new(unsafe {
             crate::context::Context::from_loader_function(|s| {
                 headless_context.get_proc_address(s) as *const _
             })


### PR DESCRIPTION
This allows usage with a Glow context that is passed between threads.

A `glow::Context` is `Send` and `Sync` on native platforms, which is preserved by wrapping it in an `Arc<_>`. However an `Rc<_>` takes ownership of the context and binds it to a single thread, since it is `!Send` and `!Sync`. This is an unnecessary limitation, since an OpenGL context may be moved between threads, provided that it is only current on one thread at a time.