### PR TITLE
Don't panic on NaN when sorting

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -172,7 +172,9 @@ pub fn cmp_render_order(
     if obj0.is_transparent() == obj1.is_transparent() {
         let distance_a = camera.position().distance2(obj0.aabb().center());
         let distance_b = camera.position().distance2(obj1.aabb().center());
-        if obj0.is_transparent() {
+        if distance_a.is_nan() || distance_b.is_nan() {
+            distance_a.is_nan().cmp(&distance_b.is_nan()) // whatever - just save us from panicing on unwrap below
+        } else if obj0.is_transparent() {
             distance_b.partial_cmp(&distance_a).unwrap()
         } else {
             distance_a.partial_cmp(&distance_b).unwrap()


### PR DESCRIPTION
I've gotten panics in sorting.

I suspect it might be caused by rendering `InstancedModel`:s with empty `Instances`, leading to bad bounding boxes. In any case, I don't want panics.