### PR TITLE
Camera: Simplify camera by purging ThreeDResult

### DIFF
--- a/examples/environment/src/main.rs
+++ b/examples/environment/src/main.rs
@@ -25,8 +25,7 @@ pub async fn run() {
         degrees(45.0),
         0.1,
         1000.0,
-    )
-    .unwrap();
+    );
     let mut control = OrbitControl::new(*camera.target(), 1.0, 100.0);
 
     let mut loaded = three_d_asset::io::load_async(
@@ -77,7 +76,7 @@ pub async fn run() {
                     - (panel_width * frame_input.device_pixel_ratio) as u32,
                 height: frame_input.viewport.height,
             };
-            camera.set_viewport(viewport).unwrap();
+            camera.set_viewport(viewport);
             control
                 .handle_events(&mut camera, &mut frame_input.events)
                 .unwrap();

--- a/examples/fireworks/src/main.rs
+++ b/examples/fireworks/src/main.rs
@@ -71,8 +71,7 @@ pub fn run() {
         degrees(45.0),
         0.1,
         1000.0,
-    )
-    .unwrap();
+    );
     let mut control = FlyControl::new(0.1);
 
     let mut rng = rand::thread_rng();
@@ -102,7 +101,7 @@ pub fn run() {
     let mut color_index = 0;
     window
         .render_loop(move |mut frame_input| {
-            camera.set_viewport(frame_input.viewport).unwrap();
+            camera.set_viewport(frame_input.viewport);
 
             control
                 .handle_events(&mut camera, &mut frame_input.events)

--- a/examples/fog/src/main.rs
+++ b/examples/fog/src/main.rs
@@ -25,8 +25,7 @@ pub async fn run() {
         degrees(45.0),
         0.1,
         1000.0,
-    )
-    .unwrap();
+    );
     let mut control = FlyControl::new(0.05);
 
     let mut loaded = three_d_asset::io::load_async(&[
@@ -56,7 +55,7 @@ pub async fn run() {
     window
         .render_loop(move |mut frame_input| {
             let mut change = frame_input.first_frame;
-            change |= camera.set_viewport(frame_input.viewport).unwrap();
+            change |= camera.set_viewport(frame_input.viewport);
             change |= control
                 .handle_events(&mut camera, &mut frame_input.events)
                 .unwrap();

--- a/examples/forest/src/main.rs
+++ b/examples/forest/src/main.rs
@@ -24,8 +24,7 @@ pub async fn run() {
         degrees(60.0),
         0.1,
         10000.0,
-    )
-    .unwrap();
+    );
     let mut control = FlyControl::new(0.1);
 
     let mut loaded = three_d_asset::io::load_async(&[
@@ -113,7 +112,7 @@ pub async fn run() {
     window
         .render_loop(move |mut frame_input| {
             let mut redraw = frame_input.first_frame;
-            redraw |= camera.set_viewport(frame_input.viewport).unwrap();
+            redraw |= camera.set_viewport(frame_input.viewport);
 
             redraw |= control
                 .handle_events(&mut camera, &mut frame_input.events)

--- a/examples/headless/src/main.rs
+++ b/examples/headless/src/main.rs
@@ -15,8 +15,7 @@ fn main() {
         degrees(60.0),
         0.1,
         10.0,
-    )
-    .unwrap();
+    );
 
     // Create the scene - a single colored triangle
     let mut model = Gm::new(

--- a/examples/lighting/src/main.rs
+++ b/examples/lighting/src/main.rs
@@ -32,8 +32,7 @@ pub async fn run() {
         degrees(45.0),
         0.1,
         30.0,
-    )
-    .unwrap();
+    );
     let mut control = OrbitControl::new(*camera.target(), 1.0, 100.0);
     let mut gui = three_d::GUI::new(&context).unwrap();
 
@@ -237,7 +236,7 @@ pub async fn run() {
                     - (panel_width * frame_input.device_pixel_ratio) as u32,
                 height: frame_input.viewport.height,
             };
-            change |= camera.set_viewport(viewport).unwrap();
+            change |= camera.set_viewport(viewport);
             change |= control
                 .handle_events(&mut camera, &mut frame_input.events)
                 .unwrap();

--- a/examples/lights/src/main.rs
+++ b/examples/lights/src/main.rs
@@ -28,8 +28,7 @@ pub async fn run() {
         degrees(45.0),
         0.1,
         5000.0,
-    )
-    .unwrap();
+    );
     let mut control = FlyControl::new(0.01);
     let mut gui = three_d::GUI::new(&context).unwrap();
 
@@ -178,7 +177,7 @@ pub async fn run() {
                     - (panel_width * frame_input.device_pixel_ratio) as u32,
                 height: frame_input.viewport.height,
             };
-            camera.set_viewport(viewport).unwrap();
+            camera.set_viewport(viewport);
 
             control
                 .handle_events(&mut camera, &mut frame_input.events)

--- a/examples/logo/src/main.rs
+++ b/examples/logo/src/main.rs
@@ -24,8 +24,7 @@ pub async fn run() {
         degrees(60.0),
         0.1,
         10.0,
-    )
-    .unwrap();
+    );
 
     let mut cpu_mesh = CpuMesh::sphere(37);
     let mut colors = Vec::new();
@@ -77,7 +76,7 @@ pub async fn run() {
 
     window
         .render_loop(move |frame_input: FrameInput| {
-            camera.set_viewport(frame_input.viewport).unwrap();
+            camera.set_viewport(frame_input.viewport);
             frame_input
                 .screen()
                 .clear(ClearState::color_and_depth(1.0, 1.0, 1.0, 1.0, 1.0))

--- a/examples/mandelbrot/src/main.rs
+++ b/examples/mandelbrot/src/main.rs
@@ -47,8 +47,7 @@ pub fn main() {
         2.5,
         0.0,
         10.0,
-    )
-    .unwrap();
+    );
 
     let mut mesh = Gm::new(
         Mesh::new(
@@ -74,7 +73,7 @@ pub fn main() {
     window
         .render_loop(move |frame_input| {
             let mut redraw = frame_input.first_frame;
-            redraw |= camera.set_viewport(frame_input.viewport).unwrap();
+            redraw |= camera.set_viewport(frame_input.viewport);
 
             for event in frame_input.events.iter() {
                 match event {
@@ -85,7 +84,7 @@ pub fn main() {
                             let up = right.cross(camera.view_direction());
                             let delta =
                                 -right * speed * delta.0 as f32 + up * speed * delta.1 as f32;
-                            camera.translate(&delta).unwrap();
+                            camera.translate(&delta);
                             redraw = true;
                         }
                     }
@@ -102,8 +101,7 @@ pub fn main() {
                         let mut target = camera.position_at_pixel(pixel);
                         target.z = 0.0;
                         camera
-                            .zoom_towards(&target, distance * 0.05 * delta.1 as f32, 0.00001, 10.0)
-                            .unwrap();
+                            .zoom_towards(&target, distance * 0.05 * delta.1 as f32, 0.00001, 10.0);
                         redraw = true;
                     }
                     _ => {}

--- a/examples/mandelbrot/src/main.rs
+++ b/examples/mandelbrot/src/main.rs
@@ -100,8 +100,12 @@ pub fn main() {
                         );
                         let mut target = camera.position_at_pixel(pixel);
                         target.z = 0.0;
-                        camera
-                            .zoom_towards(&target, distance * 0.05 * delta.1 as f32, 0.00001, 10.0);
+                        camera.zoom_towards(
+                            &target,
+                            distance * 0.05 * delta.1 as f32,
+                            0.00001,
+                            10.0,
+                        );
                         redraw = true;
                     }
                     _ => {}

--- a/examples/normals/src/main.rs
+++ b/examples/normals/src/main.rs
@@ -76,8 +76,7 @@ pub async fn run() {
         degrees(45.0),
         0.1,
         1000.0,
-    )
-    .unwrap();
+    );
     let mut control = OrbitControl::new(*camera.target(), 1.0, 100.0);
 
     let ambient = AmbientLight::new(&context, 0.4, Color::WHITE).unwrap();
@@ -87,7 +86,7 @@ pub async fn run() {
     // main loop
     window
         .render_loop(move |mut frame_input| {
-            camera.set_viewport(frame_input.viewport).unwrap();
+            camera.set_viewport(frame_input.viewport);
             control
                 .handle_events(&mut camera, &mut frame_input.events)
                 .unwrap();

--- a/examples/pbr/src/main.rs
+++ b/examples/pbr/src/main.rs
@@ -25,8 +25,7 @@ pub async fn run() {
         degrees(45.0),
         0.1,
         1000.0,
-    )
-    .unwrap();
+    );
     let mut control = OrbitControl::new(*camera.target(), 1.0, 100.0);
     let mut gui = three_d::GUI::new(&context).unwrap();
 
@@ -82,7 +81,7 @@ pub async fn run() {
                     - (panel_width * frame_input.device_pixel_ratio) as u32,
                 height: frame_input.viewport.height,
             };
-            camera.set_viewport(viewport).unwrap();
+            camera.set_viewport(viewport);
             control
                 .handle_events(&mut camera, &mut frame_input.events)
                 .unwrap();

--- a/examples/picking/src/main.rs
+++ b/examples/picking/src/main.rs
@@ -24,8 +24,7 @@ pub async fn run() {
         degrees(45.0),
         0.1,
         1000.0,
-    )
-    .unwrap();
+    );
     let mut control = OrbitControl::new(*camera.target(), 1.0, 100.0);
 
     let mut sphere = CpuMesh::sphere(8);
@@ -59,7 +58,7 @@ pub async fn run() {
     window
         .render_loop(move |mut frame_input| {
             let mut change = frame_input.first_frame;
-            change |= camera.set_viewport(frame_input.viewport).unwrap();
+            change |= camera.set_viewport(frame_input.viewport);
 
             for event in frame_input.events.iter() {
                 match event {

--- a/examples/screen/src/main.rs
+++ b/examples/screen/src/main.rs
@@ -17,8 +17,7 @@ pub fn main() {
         degrees(45.0),
         0.1,
         10.0,
-    )
-    .unwrap();
+    );
 
     let cpu_mesh = CpuMesh {
         positions: Positions::F32(vec![
@@ -73,7 +72,7 @@ pub fn main() {
             let viewport_zoomed = zoom(viewport_zoom, viewport);
             let scissor_box_zoomed = zoom(scissor_zoom, viewport).into();
 
-            camera.set_viewport(viewport_zoomed).unwrap();
+            camera.set_viewport(viewport_zoomed);
             frame_input
                 .screen()
                 .clear(ClearState::color_and_depth(1.0, 1.0, 1.0, 1.0, 1.0))
@@ -108,7 +107,7 @@ pub fn main() {
                 width: 200,
                 height: 200,
             };
-            camera.set_viewport(secondary_viewport).unwrap();
+            camera.set_viewport(secondary_viewport);
             frame_input
                 .screen()
                 .clear_partially(

--- a/examples/shapes/src/main.rs
+++ b/examples/shapes/src/main.rs
@@ -17,8 +17,7 @@ pub fn main() {
         degrees(45.0),
         0.1,
         1000.0,
-    )
-    .unwrap();
+    );
     let mut control = OrbitControl::new(*camera.target(), 1.0, 100.0);
 
     let mut sphere = Gm::new(
@@ -96,7 +95,7 @@ pub fn main() {
 
     window
         .render_loop(move |mut frame_input: FrameInput| {
-            camera.set_viewport(frame_input.viewport).unwrap();
+            camera.set_viewport(frame_input.viewport);
             control
                 .handle_events(&mut camera, &mut frame_input.events)
                 .unwrap();

--- a/examples/sprites/src/main.rs
+++ b/examples/sprites/src/main.rs
@@ -24,8 +24,7 @@ pub async fn run() {
         degrees(60.0),
         0.1,
         1000.0,
-    )
-    .unwrap();
+    );
     let mut control = FlyControl::new(0.1);
 
     let axes = Axes::new(&context, 0.1, 1.0).unwrap();
@@ -78,7 +77,7 @@ pub async fn run() {
 
     window
         .render_loop(move |mut frame_input: FrameInput| {
-            camera.set_viewport(frame_input.viewport).unwrap();
+            camera.set_viewport(frame_input.viewport);
             control
                 .handle_events(&mut camera, &mut frame_input.events)
                 .unwrap();

--- a/examples/statues/src/main.rs
+++ b/examples/statues/src/main.rs
@@ -30,8 +30,7 @@ pub async fn run() {
         degrees(45.0),
         0.1,
         10000.0,
-    )
-    .unwrap();
+    );
     // Static camera to view frustum culling in effect
     let mut secondary_camera = Camera::new_perspective(
         window.viewport().unwrap(),
@@ -41,8 +40,7 @@ pub async fn run() {
         degrees(45.0),
         0.1,
         10000.0,
-    )
-    .unwrap();
+    );
     let mut control = OrbitControl::new(
         *primary_camera.target(),
         0.5 * primary_camera.target().distance(*primary_camera.position()),
@@ -167,8 +165,8 @@ pub async fn run() {
                     - (panel_width * frame_input.device_pixel_ratio) as u32,
                 height: frame_input.viewport.height,
             };
-            primary_camera.set_viewport(viewport).unwrap();
-            secondary_camera.set_viewport(viewport).unwrap();
+            primary_camera.set_viewport(viewport);
+            secondary_camera.set_viewport(viewport);
             control
                 .handle_events(&mut primary_camera, &mut frame_input.events)
                 .unwrap();

--- a/examples/texture/src/main.rs
+++ b/examples/texture/src/main.rs
@@ -24,8 +24,7 @@ pub async fn run() {
         degrees(45.0),
         0.1,
         1000.0,
-    )
-    .unwrap();
+    );
     let mut control = OrbitControl::new(*camera.target(), 1.0, 100.0);
 
     let mut loaded = three_d_asset::io::load_async(&[
@@ -78,7 +77,7 @@ pub async fn run() {
     window
         .render_loop(move |mut frame_input| {
             let mut redraw = frame_input.first_frame;
-            redraw |= camera.set_viewport(frame_input.viewport).unwrap();
+            redraw |= camera.set_viewport(frame_input.viewport);
             redraw |= control
                 .handle_events(&mut camera, &mut frame_input.events)
                 .unwrap();

--- a/examples/triangle/src/main.rs
+++ b/examples/triangle/src/main.rs
@@ -21,8 +21,7 @@ pub fn main() {
         degrees(45.0),
         0.1,
         10.0,
-    )
-    .unwrap();
+    );
 
     // Create a CPU-side mesh consisting of a single colored triangle
     let positions = vec![
@@ -51,7 +50,7 @@ pub fn main() {
     window.render_loop(move |frame_input: FrameInput| // Begin a new frame with an updated frame input
     {
         // Ensure the viewport matches the current window viewport which changes if the window is resized
-        camera.set_viewport(frame_input.viewport).unwrap();
+        camera.set_viewport(frame_input.viewport);
 
         // Set the current transformation of the triangle
         model.set_transformation(Mat4::from_angle_y(radians((frame_input.accumulated_time * 0.005) as f32)));

--- a/examples/volume/src/main.rs
+++ b/examples/volume/src/main.rs
@@ -24,8 +24,7 @@ pub async fn run() {
         degrees(45.0),
         0.1,
         1000.0,
-    )
-    .unwrap();
+    );
     let mut control = OrbitControl::new(*camera.target(), 0.25, 100.0);
 
     // Source: https://web.cs.ucdavis.edu/~okreylos/PhDStudies/Spring2000/ECS277/DataSets.html
@@ -70,7 +69,7 @@ pub async fn run() {
                     - (panel_width * frame_input.device_pixel_ratio) as u32,
                 height: frame_input.viewport.height,
             };
-            camera.set_viewport(viewport).unwrap();
+            camera.set_viewport(viewport);
             control
                 .handle_events(&mut camera, &mut frame_input.events)
                 .unwrap();

--- a/examples/wireframe/src/main.rs
+++ b/examples/wireframe/src/main.rs
@@ -26,8 +26,7 @@ pub async fn run() {
         degrees(45.0),
         0.1,
         1000.0,
-    )
-    .unwrap();
+    );
     let mut control = OrbitControl::new(*camera.target(), 0.1 * scene_radius, 100.0 * scene_radius);
 
     let mut loaded = three_d_asset::io::load_async(&[
@@ -92,7 +91,7 @@ pub async fn run() {
     window
         .render_loop(move |mut frame_input| {
             let mut redraw = frame_input.first_frame;
-            redraw |= camera.set_viewport(frame_input.viewport).unwrap();
+            redraw |= camera.set_viewport(frame_input.viewport);
             redraw |= control
                 .handle_events(&mut camera, &mut frame_input.events)
                 .unwrap();

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -112,15 +112,15 @@ impl Context {
                 1.0,
                 0.0,
                 10.0,
-            )?)
+            ));
         }
         let mut camera2d = self.camera2d.borrow_mut();
-        camera2d.as_mut().unwrap().set_viewport(viewport)?;
+        camera2d.as_mut().unwrap().set_viewport(viewport);
         camera2d.as_mut().unwrap().set_orthographic_projection(
             viewport.height as f32,
             0.0,
             10.0,
-        )?;
+        );
         camera2d.as_mut().unwrap().set_view(
             vec3(
                 viewport.width as f32 * 0.5,
@@ -133,7 +133,7 @@ impl Context {
                 0.0,
             ),
             vec3(0.0, -1.0, 0.0),
-        )?;
+        );
         callback(camera2d.as_ref().unwrap())
     }
 

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -116,11 +116,10 @@ impl Context {
         }
         let mut camera2d = self.camera2d.borrow_mut();
         camera2d.as_mut().unwrap().set_viewport(viewport);
-        camera2d.as_mut().unwrap().set_orthographic_projection(
-            viewport.height as f32,
-            0.0,
-            10.0,
-        );
+        camera2d
+            .as_mut()
+            .unwrap()
+            .set_orthographic_projection(viewport.height as f32, 0.0, 10.0);
         camera2d.as_mut().unwrap().set_view(
             vec3(
                 viewport.width as f32 * 0.5,

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -236,7 +236,7 @@ pub fn ray_intersect(
         0.01,
         0.0,
         max_depth,
-    )?;
+    );
     let mut texture = Texture2D::new_empty::<f32>(
         context,
         viewport.width,

--- a/src/renderer/deferred_pipeline.rs
+++ b/src/renderer/deferred_pipeline.rs
@@ -48,7 +48,7 @@ impl DeferredPipeline {
                 degrees(75.0),
                 0.01,
                 10.0,
-            )?,
+            ),
             debug_type: DebugType::NONE,
             geometry_pass_texture: Some(Texture2DArray::new_empty::<[u8; 4]>(
                 context,
@@ -90,19 +90,19 @@ impl DeferredPipeline {
                     *field_of_view_y,
                     camera.z_near(),
                     camera.z_far(),
-                )?;
+                );
             }
             ProjectionType::Orthographic { height, .. } => {
                 self.camera.set_orthographic_projection(
                     *height,
                     camera.z_near(),
                     camera.z_far(),
-                )?;
+                );
             }
         };
-        self.camera.set_viewport(viewport)?;
+        self.camera.set_viewport(viewport);
         self.camera
-            .set_view(*camera.position(), *camera.target(), *camera.up())?;
+            .set_view(*camera.position(), *camera.target(), *camera.up());
         self.geometry_pass_texture = Some(Texture2DArray::new_empty::<[u8; 4]>(
             &self.context,
             viewport.width,

--- a/src/renderer/deferred_pipeline.rs
+++ b/src/renderer/deferred_pipeline.rs
@@ -93,11 +93,8 @@ impl DeferredPipeline {
                 );
             }
             ProjectionType::Orthographic { height, .. } => {
-                self.camera.set_orthographic_projection(
-                    *height,
-                    camera.z_near(),
-                    camera.z_far(),
-                );
+                self.camera
+                    .set_orthographic_projection(*height, camera.z_near(), camera.z_far());
             }
         };
         self.camera.set_viewport(viewport);

--- a/src/renderer/light/directional_light.rs
+++ b/src/renderer/light/directional_light.rs
@@ -79,7 +79,7 @@ impl DirectionalLight {
             frustum_height,
             z_near,
             z_far,
-        )?;
+        );
         let mut shadow_texture = DepthTargetTexture2D::new(
             &self.context,
             texture_size,

--- a/src/renderer/light/spot_light.rs
+++ b/src/renderer/light/spot_light.rs
@@ -91,7 +91,7 @@ impl SpotLight {
             self.cutoff,
             z_near.max(0.01),
             z_far,
-        )?;
+        );
         self.shadow_matrix = shadow_matrix(&shadow_camera);
 
         let mut shadow_texture = DepthTargetTexture2D::new(

--- a/src/renderer/object/imposters.rs
+++ b/src/renderer/object/imposters.rs
@@ -157,7 +157,7 @@ impl ImpostersMaterial {
                 height,
                 0.0,
                 4.0 * (width + height),
-            )?;
+            );
             self.texture = Texture2DArray::new_empty::<[f16; 4]>(
                 &self.context,
                 texture_width,
@@ -184,7 +184,7 @@ impl ImpostersMaterial {
                     center + width * vec3(f32::cos(angle), 0.0, f32::sin(angle)),
                     center,
                     vec3(0.0, 1.0, 0.0),
-                )?;
+                );
                 RenderTarget::new(
                     self.texture.as_color_target(&layers, None),
                     depth_texture.as_depth_target(),

--- a/src/window/control/camera_control.rs
+++ b/src/window/control/camera_control.rs
@@ -156,33 +156,33 @@ impl CameraControl {
     ) -> ThreeDResult<bool> {
         match control_type {
             CameraAction::Pitch { speed } => {
-                camera.pitch(radians(speed * x as f32))?;
+                camera.pitch(radians(speed * x as f32));
             }
             CameraAction::OrbitUp { speed, target } => {
-                camera.rotate_around_with_fixed_up(&target, 0.0, speed * x as f32)?;
+                camera.rotate_around_with_fixed_up(&target, 0.0, speed * x as f32);
             }
             CameraAction::Yaw { speed } => {
-                camera.yaw(radians(speed * x as f32))?;
+                camera.yaw(radians(speed * x as f32));
             }
             CameraAction::OrbitLeft { speed, target } => {
-                camera.rotate_around_with_fixed_up(&target, speed * x as f32, 0.0)?;
+                camera.rotate_around_with_fixed_up(&target, speed * x as f32, 0.0);
             }
             CameraAction::Roll { speed } => {
-                camera.roll(radians(speed * x as f32))?;
+                camera.roll(radians(speed * x as f32));
             }
             CameraAction::Left { speed } => {
                 let change = -camera.right_direction() * x as f32 * speed;
-                camera.translate(&change)?;
+                camera.translate(&change);
             }
             CameraAction::Up { speed } => {
                 let right = camera.right_direction();
                 let up = right.cross(camera.view_direction());
                 let change = up * x as f32 * speed;
-                camera.translate(&change)?;
+                camera.translate(&change);
             }
             CameraAction::Forward { speed } => {
                 let change = camera.view_direction() * speed * x as f32;
-                camera.translate(&change)?;
+                camera.translate(&change);
             }
             CameraAction::Zoom {
                 target,
@@ -190,7 +190,7 @@ impl CameraControl {
                 min,
                 max,
             } => {
-                camera.zoom_towards(&target, speed * x as f32, min, max)?;
+                camera.zoom_towards(&target, speed * x as f32, min, max);
             }
             CameraAction::None => {}
         }


### PR DESCRIPTION
Hi Asny,

Since i've nothing better to do - on farthers day - than messing around with others brilliant work.
I wanted to publish my train of thought:

After 7e4a1c7 the camera struct is inherently infalible and based on
pure mathematical terms. However malformed input is still a thing. So i
propose assert!() (or even debug_assert!() ?) to catch potential bugs/programming errors upfront to assist developers.

Above ratianale may be supported by the fact that panic!() is already used?

I'm not sure i caught every reasonable asserts, or even got it right altogether - but its a start.