### PR TITLE
Rename Gm struct To GeometryMaterial

### DIFF
--- a/examples/environment/src/main.rs
+++ b/examples/environment/src/main.rs
@@ -39,7 +39,7 @@ pub async fn run() {
     );
     let light = AmbientLight::new_with_environment(&context, 1.0, Color::WHITE, skybox.texture());
 
-    let mut model = Gm::new(
+    let mut model = GeometryMaterial::new(
         Mesh::new(&context, &CpuMesh::sphere(32)),
         PhysicalMaterial::new_opaque(
             &context,

--- a/examples/forest/src/main.rs
+++ b/examples/forest/src/main.rs
@@ -79,7 +79,7 @@ pub async fn run() {
     );
 
     // Plane
-    let mut plane = Gm::new(
+    let mut plane = GeometryMaterial::new(
         Mesh::new(
             &context,
             &CpuMesh {

--- a/examples/headless/src/main.rs
+++ b/examples/headless/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
     );
 
     // Create the scene - a single colored triangle
-    let mut model = Gm::new(
+    let mut model = GeometryMaterial::new(
         Mesh::new(
             &context,
             &CpuMesh {

--- a/examples/lighting/src/main.rs
+++ b/examples/lighting/src/main.rs
@@ -66,7 +66,7 @@ pub async fn run() {
                 * Mat4::from_angle_x(degrees(-90.0))),
         )
         .unwrap();
-    let mut plane = Gm::new(
+    let mut plane = GeometryMaterial::new(
         Mesh::new(&context, &cpu_plane),
         PhysicalMaterial::new_opaque(
             &context,
@@ -76,7 +76,7 @@ pub async fn run() {
             },
         ),
     );
-    let deferred_plane = Gm::new(
+    let deferred_plane = GeometryMaterial::new(
         Mesh::new(&context, &cpu_plane),
         DeferredPhysicalMaterial::from_physical_material(&plane.material),
     );

--- a/examples/lights/src/main.rs
+++ b/examples/lights/src/main.rs
@@ -200,7 +200,7 @@ struct Glow {
     light: PointLight,
     velocity: Vec3,
     aabb: AxisAlignedBoundingBox,
-    sphere: Gm<Mesh, PhysicalMaterial>,
+    sphere: GeometryMaterial<Mesh, PhysicalMaterial>,
 }
 
 impl Glow {
@@ -220,7 +220,7 @@ impl Glow {
                 rng.gen::<f32>() * 2.0 - 1.0,
             )
             .normalize(),
-            sphere: Gm::new(
+            sphere: GeometryMaterial::new(
                 Mesh::new(context, &CpuMesh::sphere(16)),
                 PhysicalMaterial::default(),
             ),

--- a/examples/logo/src/main.rs
+++ b/examples/logo/src/main.rs
@@ -57,7 +57,7 @@ pub async fn run() {
             ..Default::default()
         },
     );
-    let mut model = Gm::new(Mesh::new(&context, &cpu_mesh), material);
+    let mut model = GeometryMaterial::new(Mesh::new(&context, &cpu_mesh), material);
     model.set_transformation(Mat4::from_angle_y(degrees(35.0)));
 
     let mut loaded = three_d_asset::io::load_async(

--- a/examples/mandelbrot/src/main.rs
+++ b/examples/mandelbrot/src/main.rs
@@ -42,7 +42,7 @@ pub fn main() {
         10.0,
     );
 
-    let mut mesh = Gm::new(
+    let mut mesh = GeometryMaterial::new(
         Mesh::new(
             &context,
             &CpuMesh {

--- a/examples/picking/src/main.rs
+++ b/examples/picking/src/main.rs
@@ -29,7 +29,7 @@ pub async fn run() {
 
     let mut sphere = CpuMesh::sphere(8);
     sphere.transform(&Mat4::from_scale(0.05)).unwrap();
-    let mut pick_mesh = Gm::new(
+    let mut pick_mesh = GeometryMaterial::new(
         Mesh::new(&context, &sphere),
         PhysicalMaterial::new_opaque(
             &context,

--- a/examples/screen/src/main.rs
+++ b/examples/screen/src/main.rs
@@ -33,7 +33,7 @@ pub fn main() {
         ..Default::default()
     };
 
-    let mut model = Gm::new(Mesh::new(&context, &cpu_mesh), ColorMaterial::default());
+    let mut model = GeometryMaterial::new(Mesh::new(&context, &cpu_mesh), ColorMaterial::default());
 
     let mut gui = three_d::GUI::new(&context);
     let mut viewport_zoom = 1.0;

--- a/examples/shapes/src/main.rs
+++ b/examples/shapes/src/main.rs
@@ -20,7 +20,7 @@ pub fn main() {
     );
     let mut control = OrbitControl::new(*camera.target(), 1.0, 100.0);
 
-    let mut sphere = Gm::new(
+    let mut sphere = GeometryMaterial::new(
         Mesh::new(&context, &CpuMesh::sphere(16)),
         PhysicalMaterial::new_transparent(
             &context,
@@ -36,7 +36,7 @@ pub fn main() {
         ),
     );
     sphere.set_transformation(Mat4::from_translation(vec3(0.0, 1.3, 0.0)) * Mat4::from_scale(0.2));
-    let mut cylinder = Gm::new(
+    let mut cylinder = GeometryMaterial::new(
         Mesh::new(&context, &CpuMesh::cylinder(16)),
         PhysicalMaterial::new_transparent(
             &context,
@@ -53,7 +53,7 @@ pub fn main() {
     );
     cylinder
         .set_transformation(Mat4::from_translation(vec3(1.3, 0.0, 0.0)) * Mat4::from_scale(0.2));
-    let mut cube = Gm::new(
+    let mut cube = GeometryMaterial::new(
         Mesh::new(&context, &CpuMesh::cube()),
         PhysicalMaterial::new_transparent(
             &context,

--- a/examples/sprites/src/main.rs
+++ b/examples/sprites/src/main.rs
@@ -83,18 +83,9 @@ pub async fn run() {
                 &camera,
                 &[
                     &axes,
-                    &Gm {
-                        geometry: &billboards,
-                        material: &material,
-                    },
-                    &Gm {
-                        geometry: &sprites_up,
-                        material: &material,
-                    },
-                    &Gm {
-                        geometry: &sprites,
-                        material: &material,
-                    },
+                    &GeometryMaterial::new(&billboards, &material),
+                    &GeometryMaterial::new(&sprites_up, &material),
+                    &GeometryMaterial::new(&sprites, &material),
                 ],
                 &[&ambient],
             );

--- a/examples/texture/src/main.rs
+++ b/examples/texture/src/main.rs
@@ -51,7 +51,7 @@ pub async fn run() {
         &loaded.deserialize("front").unwrap(),
         &loaded.deserialize("back").unwrap(),
     );
-    let mut box_object = Gm::new(
+    let mut box_object = GeometryMaterial::new(
         Mesh::new(&context, &CpuMesh::cube()),
         ColorMaterial {
             texture: Some(std::rc::Rc::new(Texture2D::new(

--- a/examples/triangle/src/main.rs
+++ b/examples/triangle/src/main.rs
@@ -41,7 +41,7 @@ pub fn main() {
     };
 
     // Construct a model, with a default color material, thereby transferring the mesh data to the GPU
-    let mut model = Gm::new(Mesh::new(&context, &cpu_mesh), ColorMaterial::default());
+    let mut model = GeometryMaterial::new(Mesh::new(&context, &cpu_mesh), ColorMaterial::default());
 
     // Start the main render loop
     window.render_loop(move |frame_input: FrameInput| // Begin a new frame with an updated frame input

--- a/examples/wireframe/src/main.rs
+++ b/examples/wireframe/src/main.rs
@@ -58,7 +58,7 @@ pub async fn run() {
     cylinder
         .transform(&Mat4::from_nonuniform_scale(1.0, 0.007, 0.007))
         .unwrap();
-    let edges = Gm::new(
+    let edges = GeometryMaterial::new(
         InstancedMesh::new(
             &context,
             &edge_transformations(&cpu_model.geometries[0]),
@@ -69,7 +69,7 @@ pub async fn run() {
 
     let mut sphere = CpuMesh::sphere(8);
     sphere.transform(&Mat4::from_scale(0.015)).unwrap();
-    let vertices = Gm::new(
+    let vertices = GeometryMaterial::new(
         InstancedMesh::new(
             &context,
             &vertex_transformations(&cpu_model.geometries[0]),

--- a/src/renderer/geometry.rs
+++ b/src/renderer/geometry.rs
@@ -1,6 +1,6 @@
 //!
 //! A collection of geometries implementing the [Geometry] trait, for example a [Mesh].
-//! A geometry together with a [material] can be rendered directly, or combined into an [object] (see [Gm]) that can be used in a render call, for example [RenderTarget::render].
+//! A geometry together with a [material] can be rendered directly, or combined into an [object] (see [GeometryMaterial]) that can be used in a render call, for example [RenderTarget::render].
 //!
 
 mod mesh;
@@ -26,7 +26,7 @@ pub use three_d_asset::{Indices, Positions, TriMesh as CpuMesh};
 
 ///
 /// Represents a 3D geometry that, together with a [material], can be rendered using [Geometry::render_with_material].
-/// Alternatively, a geometry and a material can be combined in a [Gm],
+/// Alternatively, a geometry and a material can be combined in a [GeometryMaterial],
 /// thereby creating an [Object] which can be used in a render call, for example [RenderTarget::render].
 ///
 /// If requested by the material, the geometry has to support the following attributes in the vertex shader source code.

--- a/src/renderer/material.rs
+++ b/src/renderer/material.rs
@@ -1,6 +1,6 @@
 //!
 //! A collection of common materials implementing the [Material] trait.
-//! A material together with a [geometry] can be rendered directly, or combined into an [object] (see [Gm]) that can be used in a render call, for example [RenderTarget::render].
+//! A material together with a [geometry] can be rendered directly, or combined into an [object] (see [GeometryMaterial]) that can be used in a render call, for example [RenderTarget::render].
 //!
 
 use crate::core::*;
@@ -66,7 +66,7 @@ pub enum MaterialType {
 
 ///
 /// Represents a material that, together with a [geometry], can be rendered using [Geometry::render_with_material].
-/// Alternatively, a geometry and a material can be combined in a [Gm],
+/// Alternatively, a geometry and a material can be combined in a [GeometryMaterial],
 /// thereby creating an [Object] which can be used in a render call, for example [RenderTarget::render].
 ///
 /// The material can use an attribute by adding the folowing to the fragment shader source code.

--- a/src/renderer/object.rs
+++ b/src/renderer/object.rs
@@ -1,11 +1,11 @@
 //!
 //! A collection of objects (implementing the [Object] trait) that can be rendered directly or used in a render call, for example [RenderTarget::render].
-//! Can be a combination of any [geometry] and [material] by using the [Gm] struct.
+//! Can be a combination of any [geometry] and [material] by using the [GeometryMaterial] struct.
 //!
 
-mod gm;
+mod geometry_material;
 #[doc(inline)]
-pub use gm::*;
+pub use geometry_material::*;
 
 mod model;
 #[doc(inline)]

--- a/src/renderer/object/axes.rs
+++ b/src/renderer/object/axes.rs
@@ -5,7 +5,7 @@ use crate::renderer::*;
 /// Used for easily debugging where objects are placed in the 3D world.
 ///
 pub struct Axes {
-    model: std::cell::RefCell<Gm<Mesh, ColorMaterial>>,
+    model: std::cell::RefCell<GeometryMaterial<Mesh, ColorMaterial>>,
     aabb_local: AxisAlignedBoundingBox,
     aabb: AxisAlignedBoundingBox,
     transformation: Mat4,
@@ -19,7 +19,7 @@ impl Axes {
         let mut mesh = CpuMesh::arrow(0.9, 0.6, 16);
         mesh.transform(&Mat4::from_nonuniform_scale(length, radius, radius))
             .unwrap();
-        let model = Gm::new(Mesh::new(context, &mesh), ColorMaterial::default());
+        let model = GeometryMaterial::new(Mesh::new(context, &mesh), ColorMaterial::default());
         let mut aabb = model.aabb();
         let mut aabb2 = aabb.clone();
         aabb2.transform(&Mat4::from_angle_z(degrees(90.0)));

--- a/src/renderer/object/bounding_box.rs
+++ b/src/renderer/object/bounding_box.rs
@@ -4,7 +4,7 @@ use crate::renderer::*;
 /// A bounding box object used for visualising an [AxisAlignedBoundingBox].
 ///
 pub struct BoundingBox<M: Material> {
-    model: Gm<InstancedMesh, M>,
+    model: GeometryMaterial<InstancedMesh, M>,
     aabb: AxisAlignedBoundingBox,
 }
 
@@ -76,7 +76,7 @@ impl<M: Material> BoundingBox<M> {
             vec3(size.z, thickness, thickness),
             vec3(size.z, thickness, thickness),
         ];
-        let model = Gm::new(
+        let model = GeometryMaterial::new(
             InstancedMesh::new(
                 context,
                 &Instances {

--- a/src/renderer/object/circle.rs
+++ b/src/renderer/object/circle.rs
@@ -5,7 +5,7 @@ use crate::renderer::*;
 ///
 pub struct Circle<M: Material> {
     context: Context,
-    model: Gm<Mesh, M>,
+    model: GeometryMaterial<Mesh, M>,
     radius: f32,
     center: Vec2,
 }
@@ -18,7 +18,7 @@ impl<M: Material> Circle<M> {
         let mesh = CpuMesh::circle(64);
         let mut circle = Self {
             context: context.clone(),
-            model: Gm::new(Mesh::new(context, &mesh), material),
+            model: GeometryMaterial::new(Mesh::new(context, &mesh), material),
             center,
             radius,
         };

--- a/src/renderer/object/geometry_material.rs
+++ b/src/renderer/object/geometry_material.rs
@@ -5,23 +5,23 @@ use crate::renderer::*;
 /// Use this to combine any [geometry] and [material] into an object that can be used in a render function for example [RenderTarget::render].
 /// The only requirement is that the geometry provides all the per vertex information (normals, uv coordinates, etc.) that the material requires.
 ///
-pub struct Gm<G: Geometry, M: Material> {
+pub struct GeometryMaterial<G: Geometry, M: Material> {
     /// The geometry
     pub geometry: G,
     /// The material applied to the geometry
     pub material: M,
 }
 
-impl<G: Geometry, M: Material> Gm<G, M> {
+impl<G: Geometry, M: Material> GeometryMaterial<G, M> {
     ///
-    /// Creates a new [Gm] from a geometry and material.
+    /// Creates a new [GeometryMaterial] from a geometry and material.
     ///
     pub fn new(geometry: G, material: M) -> Self {
         Self { geometry, material }
     }
 }
 
-impl<G: Geometry, M: Material> Geometry for Gm<G, M> {
+impl<G: Geometry, M: Material> Geometry for GeometryMaterial<G, M> {
     fn aabb(&self) -> AxisAlignedBoundingBox {
         self.geometry.aabb()
     }
@@ -36,7 +36,7 @@ impl<G: Geometry, M: Material> Geometry for Gm<G, M> {
     }
 }
 
-impl<G: Geometry, M: Material> Object for Gm<G, M> {
+impl<G: Geometry, M: Material> Object for GeometryMaterial<G, M> {
     fn render(&self, camera: &Camera, lights: &[&dyn Light]) {
         self.render_with_material(&self.material, camera, lights)
     }
@@ -46,7 +46,7 @@ impl<G: Geometry, M: Material> Object for Gm<G, M> {
     }
 }
 
-impl<G: Geometry + Clone, M: Material + Clone> Clone for Gm<G, M> {
+impl<G: Geometry + Clone, M: Material + Clone> Clone for GeometryMaterial<G, M> {
     fn clone(&self) -> Self {
         Self {
             geometry: self.geometry.clone(),
@@ -55,14 +55,14 @@ impl<G: Geometry + Clone, M: Material + Clone> Clone for Gm<G, M> {
     }
 }
 
-impl<G: Geometry, M: Material> std::ops::Deref for Gm<G, M> {
+impl<G: Geometry, M: Material> std::ops::Deref for GeometryMaterial<G, M> {
     type Target = G;
     fn deref(&self) -> &Self::Target {
         &self.geometry
     }
 }
 
-impl<G: Geometry, M: Material> std::ops::DerefMut for Gm<G, M> {
+impl<G: Geometry, M: Material> std::ops::DerefMut for GeometryMaterial<G, M> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.geometry
     }

--- a/src/renderer/object/instanced_model.rs
+++ b/src/renderer/object/instanced_model.rs
@@ -3,7 +3,7 @@ use crate::renderer::*;
 ///
 /// Similar to [Model], except it is possible to render many instances of the same model efficiently.
 ///
-pub struct InstancedModel<M: Material>(Vec<Gm<InstancedMesh, M>>);
+pub struct InstancedModel<M: Material>(Vec<GeometryMaterial<InstancedMesh, M>>);
 
 impl<M: Material> InstancedModel<M> {
     ///
@@ -26,7 +26,7 @@ impl<M: Material> InstancedModel<M> {
 
 impl<T: Material + FromCpuMaterial + Clone + Default> InstancedModel<T> {
     ///
-    /// Constructs an [InstancedModel] from a [CpuModel] and the given [Instances] attributes, ie. constructs a list of [Gm]s with a [InstancedMesh] as geometry (constructed from the [CpuMesh]es in the [CpuModel]) and
+    /// Constructs an [InstancedModel] from a [CpuModel] and the given [Instances] attributes, ie. constructs a list of [GeometryMaterial]s with a [InstancedMesh] as geometry (constructed from the [CpuMesh]es in the [CpuModel]) and
     /// a [material] type specified by the generic parameter which implement [FromCpuMaterial] (constructed from the [CpuMaterial]s in the [CpuModel]).
     ///
     pub fn new(
@@ -38,24 +38,21 @@ impl<T: Material + FromCpuMaterial + Clone + Default> InstancedModel<T> {
         for m in cpu_model.materials.iter() {
             materials.insert(m.name.clone(), T::from_cpu_material(context, m));
         }
-        let mut gms: Vec<Gm<InstancedMesh, T>> = Vec::new();
+        let mut gms: Vec<GeometryMaterial<InstancedMesh, T>> = Vec::new();
         for g in cpu_model.geometries.iter() {
             gms.push(if let Some(material_name) = &g.material_name {
-                Gm {
-                    geometry: InstancedMesh::new(context, instances, g),
-                    material: materials
+                GeometryMaterial::new(
+                    InstancedMesh::new(context, instances, g),
+                    materials
                         .get(material_name)
                         .ok_or(RendererError::MissingMaterial(
                             material_name.clone(),
                             g.name.clone(),
                         ))?
                         .clone(),
-                }
+                )
             } else {
-                Gm {
-                    geometry: InstancedMesh::new(context, instances, g),
-                    material: T::default(),
-                }
+                GeometryMaterial::new(InstancedMesh::new(context, instances, g), T::default())
             });
         }
         Ok(Self(gms))
@@ -63,7 +60,7 @@ impl<T: Material + FromCpuMaterial + Clone + Default> InstancedModel<T> {
 }
 
 impl<M: Material> std::ops::Deref for InstancedModel<M> {
-    type Target = Vec<Gm<InstancedMesh, M>>;
+    type Target = Vec<GeometryMaterial<InstancedMesh, M>>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }

--- a/src/renderer/object/line.rs
+++ b/src/renderer/object/line.rs
@@ -5,7 +5,7 @@ use crate::renderer::*;
 ///
 pub struct Line<M: Material> {
     context: Context,
-    model: Gm<Mesh, M>,
+    model: GeometryMaterial<Mesh, M>,
     pixel0: Vec2,
     pixel1: Vec2,
     thickness: f32,
@@ -27,7 +27,7 @@ impl<M: Material> Line<M> {
             .unwrap();
         let mut line = Self {
             context: context.clone(),
-            model: Gm::new(Mesh::new(context, &mesh), material),
+            model: GeometryMaterial::new(Mesh::new(context, &mesh), material),
             pixel0,
             pixel1,
             thickness,

--- a/src/renderer/object/rectangle.rs
+++ b/src/renderer/object/rectangle.rs
@@ -4,7 +4,7 @@ use crate::renderer::*;
 /// A rectangle 2D object which can be rendered.
 ///
 pub struct Rectangle<M: Material> {
-    model: Gm<Mesh, M>,
+    model: GeometryMaterial<Mesh, M>,
     context: Context,
     width: f32,
     height: f32,
@@ -27,7 +27,7 @@ impl<M: Material> Rectangle<M> {
         let mut mesh = CpuMesh::square();
         mesh.transform(&(Mat4::from_scale(0.5))).unwrap();
         let mut rectangle = Self {
-            model: Gm::new(Mesh::new(context, &mesh), material),
+            model: GeometryMaterial::new(Mesh::new(context, &mesh), material),
             context: context.clone(),
             width,
             height,

--- a/src/renderer/object/voxel_grid.rs
+++ b/src/renderer/object/voxel_grid.rs
@@ -5,11 +5,11 @@ pub use three_d_asset::VoxelGrid as CpuVoxelGrid;
 ///
 /// A voxel grid inside a cube with a [material] type specified by the generic parameter.
 ///
-pub struct VoxelGrid<M: Material>(Gm<Mesh, M>);
+pub struct VoxelGrid<M: Material>(GeometryMaterial<Mesh, M>);
 
 impl<M: Material + FromCpuVoxelGrid> VoxelGrid<M> {
     ///
-    /// Constructs a [VoxelGrid] from a [CpuVoxelGrid], ie. constructs a [Gm] with a cube [Mesh] as geometry and
+    /// Constructs a [VoxelGrid] from a [CpuVoxelGrid], ie. constructs a [GeometryMaterial] with a cube [Mesh] as geometry and
     /// a [material] type specified by the generic parameter which implement [FromCpuVoxelGrid].
     ///
     pub fn new(context: &Context, cpu_voxel_grid: &CpuVoxelGrid) -> Self {
@@ -20,7 +20,7 @@ impl<M: Material + FromCpuVoxelGrid> VoxelGrid<M> {
             0.5 * cpu_voxel_grid.size.z,
         ))
         .expect("Invalid size for VoxelGrid");
-        let gm = Gm::new(
+        let gm = GeometryMaterial::new(
             Mesh::new(&context, &cube),
             M::from_cpu_voxel_grid(context, cpu_voxel_grid),
         );
@@ -29,7 +29,7 @@ impl<M: Material + FromCpuVoxelGrid> VoxelGrid<M> {
 }
 
 impl<M: Material> std::ops::Deref for VoxelGrid<M> {
-    type Target = Gm<Mesh, M>;
+    type Target = GeometryMaterial<Mesh, M>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }


### PR DESCRIPTION
Hi,

I the distant memory i feel like i did this before? But i did a search and couldn't find it :man_shrugging: 

While i'm still reading though your code i keep bumping into this lonely (in terms of naming convention) Gm type.
I mean this is the only type that's defined by a short abreviation, no? Anyway I fixed it to match other three-d types.

There should be no functional difference, except i also made use of GeometryMaterial::new() tree wide.