### PR TITLE
Make all structs Send and Sync.

### DIFF
--- a/examples/sprites/src/main.rs
+++ b/examples/sprites/src/main.rs
@@ -36,7 +36,7 @@ pub async fn run() {
         .unwrap();
     let material = ColorMaterial {
         color: Color::WHITE,
-        texture: Some(std::rc::Rc::new(Texture2D::new(&context, &img))),
+        texture: Some(std::sync::Arc::new(Texture2D::new(&context, &img))),
         ..Default::default()
     };
 

--- a/examples/texture/src/main.rs
+++ b/examples/texture/src/main.rs
@@ -54,7 +54,7 @@ pub async fn run() {
     let mut box_object = Gm::new(
         Mesh::new(&context, &CpuMesh::cube()),
         ColorMaterial {
-            texture: Some(std::rc::Rc::new(Texture2D::new(
+            texture: Some(std::sync::Arc::new(Texture2D::new(
                 &context,
                 &loaded.deserialize("test_texture").unwrap(),
             ))),

--- a/src/renderer/geometry.rs
+++ b/src/renderer/geometry.rs
@@ -96,7 +96,7 @@ impl<T: Geometry> Geometry for Box<T> {
     }
 }
 
-impl<T: Geometry> Geometry for std::rc::Rc<T> {
+impl<T: Geometry> Geometry for std::sync::Arc<T> {
     fn render_with_material(
         &self,
         material: &dyn Material,
@@ -111,18 +111,20 @@ impl<T: Geometry> Geometry for std::rc::Rc<T> {
     }
 }
 
-impl<T: Geometry> Geometry for std::rc::Rc<std::cell::RefCell<T>> {
+impl<T: Geometry> Geometry for std::sync::Arc<std::sync::RwLock<T>> {
     fn render_with_material(
         &self,
         material: &dyn Material,
         camera: &Camera,
         lights: &[&dyn Light],
     ) {
-        self.borrow().render_with_material(material, camera, lights)
+        self.read()
+            .unwrap()
+            .render_with_material(material, camera, lights)
     }
 
     fn aabb(&self) -> AxisAlignedBoundingBox {
-        self.borrow().aabb()
+        self.read().unwrap().aabb()
     }
 }
 
@@ -155,15 +157,17 @@ impl<T: Geometry2D> Geometry2D for Box<T> {
     }
 }
 
-impl<T: Geometry2D> Geometry2D for std::rc::Rc<T> {
+impl<T: Geometry2D> Geometry2D for std::sync::Arc<T> {
     fn render_with_material(&self, material: &dyn Material, viewport: Viewport) {
         self.as_ref().render_with_material(material, viewport)
     }
 }
 
-impl<T: Geometry2D> Geometry2D for std::rc::Rc<std::cell::RefCell<T>> {
+impl<T: Geometry2D> Geometry2D for std::sync::Arc<std::sync::RwLock<T>> {
     fn render_with_material(&self, material: &dyn Material, viewport: Viewport) {
-        self.borrow().render_with_material(material, viewport)
+        self.read()
+            .unwrap()
+            .render_with_material(material, viewport)
     }
 }
 

--- a/src/renderer/light.rs
+++ b/src/renderer/light.rs
@@ -87,7 +87,7 @@ impl<T: Light> Light for Box<T> {
     }
 }
 
-impl<T: Light> Light for std::rc::Rc<T> {
+impl<T: Light> Light for std::sync::Arc<T> {
     fn shader_source(&self, i: u32) -> String {
         self.as_ref().shader_source(i)
     }
@@ -96,12 +96,12 @@ impl<T: Light> Light for std::rc::Rc<T> {
     }
 }
 
-impl<T: Light> Light for std::rc::Rc<std::cell::RefCell<T>> {
+impl<T: Light> Light for std::sync::Arc<std::sync::RwLock<T>> {
     fn shader_source(&self, i: u32) -> String {
-        self.borrow().shader_source(i)
+        self.read().unwrap().shader_source(i)
     }
     fn use_uniforms(&self, program: &Program, i: u32) {
-        self.borrow().use_uniforms(program, i)
+        self.read().unwrap().use_uniforms(program, i)
     }
 }
 

--- a/src/renderer/material.rs
+++ b/src/renderer/material.rs
@@ -166,7 +166,7 @@ impl<T: Material> Material for Box<T> {
     }
 }
 
-impl<T: Material> Material for std::rc::Rc<T> {
+impl<T: Material> Material for std::sync::Arc<T> {
     fn fragment_shader_source(&self, use_vertex_colors: bool, lights: &[&dyn Light]) -> String {
         self.as_ref()
             .fragment_shader_source(use_vertex_colors, lights)
@@ -182,19 +182,20 @@ impl<T: Material> Material for std::rc::Rc<T> {
     }
 }
 
-impl<T: Material> Material for std::rc::Rc<std::cell::RefCell<T>> {
+impl<T: Material> Material for std::sync::Arc<std::sync::RwLock<T>> {
     fn fragment_shader_source(&self, use_vertex_colors: bool, lights: &[&dyn Light]) -> String {
-        self.borrow()
+        self.read()
+            .unwrap()
             .fragment_shader_source(use_vertex_colors, lights)
     }
     fn use_uniforms(&self, program: &Program, camera: &Camera, lights: &[&dyn Light]) {
-        self.borrow().use_uniforms(program, camera, lights)
+        self.read().unwrap().use_uniforms(program, camera, lights)
     }
     fn render_states(&self) -> RenderStates {
-        self.borrow().render_states()
+        self.read().unwrap().render_states()
     }
     fn material_type(&self) -> MaterialType {
-        self.borrow().material_type()
+        self.read().unwrap().material_type()
     }
 }
 

--- a/src/renderer/material/color_material.rs
+++ b/src/renderer/material/color_material.rs
@@ -1,6 +1,6 @@
 use crate::core::*;
 use crate::renderer::*;
-use std::rc::Rc;
+use std::sync::Arc;
 
 ///
 /// A material that renders a [Geometry] in a color defined by multiplying a color with an optional texture and optional per vertex colors.
@@ -11,7 +11,7 @@ pub struct ColorMaterial {
     /// Base surface color. Assumed to be in linear color space.
     pub color: Color,
     /// An optional texture which is samples using uv coordinates (requires that the [Geometry] supports uv coordinates).
-    pub texture: Option<Rc<Texture2D>>,
+    pub texture: Option<Arc<Texture2D>>,
     /// Render states.
     pub render_states: RenderStates,
     /// Whether this material should be treated as a transparent material (An object needs to be rendered differently depending on whether it is transparent or opaque).
@@ -35,7 +35,7 @@ impl ColorMaterial {
     /// Constructs a new opaque color material from a [CpuMaterial].
     pub fn new_opaque(context: &Context, cpu_material: &CpuMaterial) -> Self {
         let texture = if let Some(ref cpu_texture) = cpu_material.albedo_texture {
-            Some(Rc::new(Texture2D::new(&context, cpu_texture)))
+            Some(Arc::new(Texture2D::new(&context, cpu_texture)))
         } else {
             None
         };
@@ -50,7 +50,7 @@ impl ColorMaterial {
     /// Constructs a new transparent color material from a [CpuMaterial].
     pub fn new_transparent(context: &Context, cpu_material: &CpuMaterial) -> Self {
         let texture = if let Some(ref cpu_texture) = cpu_material.albedo_texture {
-            Some(Rc::new(Texture2D::new(&context, cpu_texture)))
+            Some(Arc::new(Texture2D::new(&context, cpu_texture)))
         } else {
             None
         };

--- a/src/renderer/material/deferred_physical_material.rs
+++ b/src/renderer/material/deferred_physical_material.rs
@@ -1,6 +1,6 @@
 use crate::core::*;
 use crate::renderer::*;
-use std::rc::Rc;
+use std::sync::Arc;
 
 ///
 /// Similar to [PhysicalMaterial] except that rendering happens in two stages which produces the same result, but is more efficient for complex scenes.
@@ -19,29 +19,29 @@ pub struct DeferredPhysicalMaterial {
     /// Albedo base color, also called diffuse color. Assumed to be in linear color space.
     pub albedo: Color,
     /// Texture with albedo base colors, also called diffuse color. Assumed to be in sRGB with or without an alpha channel.
-    pub albedo_texture: Option<Rc<Texture2D>>,
+    pub albedo_texture: Option<Arc<Texture2D>>,
     /// A value in the range `[0..1]` specifying how metallic the material is.
     pub metallic: f32,
     /// A value in the range `[0..1]` specifying how rough the material surface is.
     pub roughness: f32,
     /// Texture containing the metallic and roughness parameters which are multiplied with the [Self::metallic] and [Self::roughness] values in the shader.
     /// The metallic values are sampled from the blue channel and the roughness from the green channel.
-    pub metallic_roughness_texture: Option<Rc<Texture2D>>,
+    pub metallic_roughness_texture: Option<Arc<Texture2D>>,
     /// A scalar multiplier controlling the amount of occlusion applied from the [Self::occlusion_texture]. A value of 0.0 means no occlusion. A value of 1.0 means full occlusion.
     pub occlusion_strength: f32,
     /// An occlusion map. Higher values indicate areas that should receive full indirect lighting and lower values indicate no indirect lighting.
     /// The occlusion values are sampled from the red channel.
-    pub occlusion_texture: Option<Rc<Texture2D>>,
+    pub occlusion_texture: Option<Arc<Texture2D>>,
     /// A scalar multiplier applied to each normal vector of the [Self::normal_texture].
     pub normal_scale: f32,
     /// A tangent space normal map, also known as bump map.
-    pub normal_texture: Option<Rc<Texture2D>>,
+    pub normal_texture: Option<Arc<Texture2D>>,
     /// Render states
     pub render_states: RenderStates,
     /// Color of light shining from an object.
     pub emissive: Color,
     /// Texture with color of light shining from an object.
-    pub emissive_texture: Option<Rc<Texture2D>>,
+    pub emissive_texture: Option<Arc<Texture2D>>,
     /// A threshold on the alpha value of the color as a workaround for transparency.
     /// If the alpha value of a pixel touched by an object with this material is less than the threshold, then that object is not contributing to the color of that pixel.
     /// On the other hand, if the alpha value is more than the threshold, then it is contributing fully to that pixel and thereby blocks out everything behind.
@@ -56,16 +56,16 @@ impl DeferredPhysicalMaterial {
     ///
     pub fn new(context: &Context, cpu_material: &CpuMaterial) -> Self {
         let albedo_texture = if let Some(ref cpu_texture) = cpu_material.albedo_texture {
-            Some(Rc::new(Texture2D::new(&context, cpu_texture)))
+            Some(Arc::new(Texture2D::new(&context, cpu_texture)))
         } else {
             None
         };
         let metallic_roughness_texture =
             if let Some(ref cpu_texture) = cpu_material.occlusion_metallic_roughness_texture {
-                Some(Rc::new(Texture2D::new(&context, cpu_texture)))
+                Some(Arc::new(Texture2D::new(&context, cpu_texture)))
             } else {
                 if let Some(ref cpu_texture) = cpu_material.metallic_roughness_texture {
-                    Some(Rc::new(Texture2D::new(&context, cpu_texture)))
+                    Some(Arc::new(Texture2D::new(&context, cpu_texture)))
                 } else {
                     None
                 }
@@ -74,18 +74,18 @@ impl DeferredPhysicalMaterial {
             metallic_roughness_texture.clone()
         } else {
             if let Some(ref cpu_texture) = cpu_material.occlusion_texture {
-                Some(Rc::new(Texture2D::new(&context, cpu_texture)))
+                Some(Arc::new(Texture2D::new(&context, cpu_texture)))
             } else {
                 None
             }
         };
         let normal_texture = if let Some(ref cpu_texture) = cpu_material.normal_texture {
-            Some(Rc::new(Texture2D::new(&context, cpu_texture)))
+            Some(Arc::new(Texture2D::new(&context, cpu_texture)))
         } else {
             None
         };
         let emissive_texture = if let Some(ref cpu_texture) = cpu_material.emissive_texture {
-            Some(Rc::new(Texture2D::new(&context, cpu_texture)))
+            Some(Arc::new(Texture2D::new(&context, cpu_texture)))
         } else {
             None
         };

--- a/src/renderer/material/isosurface_material.rs
+++ b/src/renderer/material/isosurface_material.rs
@@ -9,7 +9,7 @@ use crate::renderer::*;
 #[derive(Clone)]
 pub struct IsosurfaceMaterial {
     /// The voxel data that defines the isosurface.
-    pub voxels: std::rc::Rc<Texture3D>,
+    pub voxels: std::sync::Arc<Texture3D>,
     /// Threshold (in the range [0..1]) that defines the surface in the voxel data.
     pub threshold: f32,
     /// Base surface color. Assumed to be in linear color space.
@@ -64,7 +64,7 @@ impl Material for IsosurfaceMaterial {
 impl FromCpuVoxelGrid for IsosurfaceMaterial {
     fn from_cpu_voxel_grid(context: &Context, cpu_voxel_grid: &CpuVoxelGrid) -> Self {
         Self {
-            voxels: std::rc::Rc::new(Texture3D::new(&context, &cpu_voxel_grid.voxels)),
+            voxels: std::sync::Arc::new(Texture3D::new(&context, &cpu_voxel_grid.voxels)),
             lighting_model: LightingModel::Blinn,
             size: cpu_voxel_grid.size,
             threshold: 0.15,

--- a/src/renderer/material/normal_material.rs
+++ b/src/renderer/material/normal_material.rs
@@ -1,6 +1,6 @@
 use crate::core::*;
 use crate::renderer::*;
-use std::rc::Rc;
+use std::sync::Arc;
 
 ///
 /// Render the object with colors that reflect its normals which primarily is used for debug purposes.
@@ -12,7 +12,7 @@ pub struct NormalMaterial {
     /// A scalar multiplier applied to each normal vector of the [Self::normal_texture].
     pub normal_scale: f32,
     /// A tangent space normal map, also known as bump map.
-    pub normal_texture: Option<Rc<Texture2D>>,
+    pub normal_texture: Option<Arc<Texture2D>>,
     /// Render states.
     pub render_states: RenderStates,
 }
@@ -21,7 +21,7 @@ impl NormalMaterial {
     /// Constructs a new normal material from a [CpuMaterial] where only relevant information is used.
     pub fn new(context: &Context, cpu_material: &CpuMaterial) -> Self {
         let normal_texture = if let Some(ref cpu_texture) = cpu_material.normal_texture {
-            Some(Rc::new(Texture2D::new(&context, cpu_texture)))
+            Some(Arc::new(Texture2D::new(&context, cpu_texture)))
         } else {
             None
         };

--- a/src/renderer/material/orm_material.rs
+++ b/src/renderer/material/orm_material.rs
@@ -1,6 +1,6 @@
 use crate::core::*;
 use crate::renderer::*;
-use std::rc::Rc;
+use std::sync::Arc;
 
 ///
 /// Render the object with colors that reflect its ORM (occlusion, roughness and metallic) values which primarily is used for debug purposes.
@@ -14,12 +14,12 @@ pub struct ORMMaterial {
     pub roughness: f32,
     /// Texture containing the metallic and roughness parameters which are multiplied with the [Self::metallic] and [Self::roughness] values in the shader.
     /// The metallic values are sampled from the blue channel and the roughness from the green channel.
-    pub metallic_roughness_texture: Option<Rc<Texture2D>>,
+    pub metallic_roughness_texture: Option<Arc<Texture2D>>,
     /// A scalar multiplier controlling the amount of occlusion applied from the [Self::occlusion_texture]. A value of 0.0 means no occlusion. A value of 1.0 means full occlusion.
     pub occlusion_strength: f32,
     /// An occlusion map. Higher values indicate areas that should receive full indirect lighting and lower values indicate no indirect lighting.
     /// The occlusion values are sampled from the red channel.
-    pub occlusion_texture: Option<Rc<Texture2D>>,
+    pub occlusion_texture: Option<Arc<Texture2D>>,
     /// Render states.
     pub render_states: RenderStates,
 }
@@ -29,10 +29,10 @@ impl ORMMaterial {
     pub fn new(context: &Context, cpu_material: &CpuMaterial) -> Self {
         let metallic_roughness_texture =
             if let Some(ref cpu_texture) = cpu_material.occlusion_metallic_roughness_texture {
-                Some(Rc::new(Texture2D::new(&context, cpu_texture)))
+                Some(Arc::new(Texture2D::new(&context, cpu_texture)))
             } else {
                 if let Some(ref cpu_texture) = cpu_material.metallic_roughness_texture {
-                    Some(Rc::new(Texture2D::new(&context, cpu_texture)))
+                    Some(Arc::new(Texture2D::new(&context, cpu_texture)))
                 } else {
                     None
                 }
@@ -41,7 +41,7 @@ impl ORMMaterial {
             metallic_roughness_texture.clone()
         } else {
             if let Some(ref cpu_texture) = cpu_material.occlusion_texture {
-                Some(Rc::new(Texture2D::new(&context, cpu_texture)))
+                Some(Arc::new(Texture2D::new(&context, cpu_texture)))
             } else {
                 None
             }

--- a/src/renderer/material/physical_material.rs
+++ b/src/renderer/material/physical_material.rs
@@ -1,6 +1,6 @@
 use crate::core::*;
 use crate::renderer::*;
-use std::rc::Rc;
+use std::sync::Arc;
 
 ///
 /// A physically-based material that renders a [Geometry] in an approximate correct physical manner based on Physically Based Rendering (PBR).
@@ -13,23 +13,23 @@ pub struct PhysicalMaterial {
     /// Albedo base color, also called diffuse color. Assumed to be in linear color space.
     pub albedo: Color,
     /// Texture with albedo base colors, also called diffuse color. Assumed to be in sRGB with or without an alpha channel.
-    pub albedo_texture: Option<Rc<Texture2D>>,
+    pub albedo_texture: Option<Arc<Texture2D>>,
     /// A value in the range `[0..1]` specifying how metallic the surface is.
     pub metallic: f32,
     /// A value in the range `[0..1]` specifying how rough the surface is.
     pub roughness: f32,
     /// Texture containing the metallic and roughness parameters which are multiplied with the [Self::metallic] and [Self::roughness] values in the shader.
     /// The metallic values are sampled from the blue channel and the roughness from the green channel.
-    pub metallic_roughness_texture: Option<Rc<Texture2D>>,
+    pub metallic_roughness_texture: Option<Arc<Texture2D>>,
     /// A scalar multiplier controlling the amount of occlusion applied from the [Self::occlusion_texture]. A value of 0.0 means no occlusion. A value of 1.0 means full occlusion.
     pub occlusion_strength: f32,
     /// An occlusion map. Higher values indicate areas that should receive full indirect lighting and lower values indicate no indirect lighting.
     /// The occlusion values are sampled from the red channel.
-    pub occlusion_texture: Option<Rc<Texture2D>>,
+    pub occlusion_texture: Option<Arc<Texture2D>>,
     /// A scalar multiplier applied to each normal vector of the [Self::normal_texture].
     pub normal_scale: f32,
     /// A tangent space normal map, also known as bump map.
-    pub normal_texture: Option<Rc<Texture2D>>,
+    pub normal_texture: Option<Arc<Texture2D>>,
     /// Render states.
     pub render_states: RenderStates,
     /// Whether this material should be treated as a transparent material (An object needs to be rendered differently depending on whether it is transparent or opaque).
@@ -37,7 +37,7 @@ pub struct PhysicalMaterial {
     /// Color of light shining from an object.
     pub emissive: Color,
     /// Texture with color of light shining from an object.
-    pub emissive_texture: Option<Rc<Texture2D>>,
+    pub emissive_texture: Option<Arc<Texture2D>>,
     /// The lighting model used when rendering this material
     pub lighting_model: LightingModel,
 }
@@ -70,16 +70,16 @@ impl PhysicalMaterial {
 
     fn new_internal(context: &Context, cpu_material: &CpuMaterial, is_transparent: bool) -> Self {
         let albedo_texture = if let Some(ref cpu_texture) = cpu_material.albedo_texture {
-            Some(Rc::new(Texture2D::new(&context, cpu_texture)))
+            Some(Arc::new(Texture2D::new(&context, cpu_texture)))
         } else {
             None
         };
         let metallic_roughness_texture =
             if let Some(ref cpu_texture) = cpu_material.occlusion_metallic_roughness_texture {
-                Some(Rc::new(Texture2D::new(&context, cpu_texture)))
+                Some(Arc::new(Texture2D::new(&context, cpu_texture)))
             } else {
                 if let Some(ref cpu_texture) = cpu_material.metallic_roughness_texture {
-                    Some(Rc::new(Texture2D::new(&context, cpu_texture)))
+                    Some(Arc::new(Texture2D::new(&context, cpu_texture)))
                 } else {
                     None
                 }
@@ -88,18 +88,18 @@ impl PhysicalMaterial {
             metallic_roughness_texture.clone()
         } else {
             if let Some(ref cpu_texture) = cpu_material.occlusion_texture {
-                Some(Rc::new(Texture2D::new(&context, cpu_texture)))
+                Some(Arc::new(Texture2D::new(&context, cpu_texture)))
             } else {
                 None
             }
         };
         let normal_texture = if let Some(ref cpu_texture) = cpu_material.normal_texture {
-            Some(Rc::new(Texture2D::new(&context, cpu_texture)))
+            Some(Arc::new(Texture2D::new(&context, cpu_texture)))
         } else {
             None
         };
         let emissive_texture = if let Some(ref cpu_texture) = cpu_material.emissive_texture {
-            Some(Rc::new(Texture2D::new(&context, cpu_texture)))
+            Some(Arc::new(Texture2D::new(&context, cpu_texture)))
         } else {
             None
         };

--- a/src/renderer/object.rs
+++ b/src/renderer/object.rs
@@ -97,7 +97,7 @@ impl<T: Object> Object for Box<T> {
     }
 }
 
-impl<T: Object> Object for std::rc::Rc<T> {
+impl<T: Object> Object for std::sync::Arc<T> {
     fn render(&self, camera: &Camera, lights: &[&dyn Light]) {
         self.as_ref().render(camera, lights)
     }
@@ -107,13 +107,13 @@ impl<T: Object> Object for std::rc::Rc<T> {
     }
 }
 
-impl<T: Object> Object for std::rc::Rc<std::cell::RefCell<T>> {
+impl<T: Object> Object for std::sync::Arc<std::sync::RwLock<T>> {
     fn render(&self, camera: &Camera, lights: &[&dyn Light]) {
-        self.borrow().render(camera, lights)
+        self.read().unwrap().render(camera, lights)
     }
 
     fn material_type(&self) -> MaterialType {
-        self.borrow().material_type()
+        self.read().unwrap().material_type()
     }
 }
 
@@ -165,7 +165,7 @@ impl<T: Object2D> Object2D for Box<T> {
     }
 }
 
-impl<T: Object2D> Object2D for std::rc::Rc<T> {
+impl<T: Object2D> Object2D for std::sync::Arc<T> {
     fn render(&self, viewport: Viewport) {
         self.as_ref().render(viewport)
     }
@@ -175,12 +175,12 @@ impl<T: Object2D> Object2D for std::rc::Rc<T> {
     }
 }
 
-impl<T: Object2D> Object2D for std::rc::Rc<std::cell::RefCell<T>> {
+impl<T: Object2D> Object2D for std::sync::Arc<std::sync::RwLock<T>> {
     fn render(&self, viewport: Viewport) {
-        self.borrow().render(viewport)
+        self.read().unwrap().render(viewport)
     }
 
     fn material_type(&self) -> MaterialType {
-        self.borrow().material_type()
+        self.read().unwrap().material_type()
     }
 }

--- a/src/renderer/object/axes.rs
+++ b/src/renderer/object/axes.rs
@@ -5,7 +5,7 @@ use crate::renderer::*;
 /// Used for easily debugging where objects are placed in the 3D world.
 ///
 pub struct Axes {
-    model: std::cell::RefCell<Gm<Mesh, ColorMaterial>>,
+    model: std::sync::RwLock<Gm<Mesh, ColorMaterial>>,
     aabb_local: AxisAlignedBoundingBox,
     aabb: AxisAlignedBoundingBox,
     transformation: Mat4,
@@ -28,7 +28,7 @@ impl Axes {
         aabb3.transform(&Mat4::from_angle_y(degrees(-90.0)));
         aabb.expand_with_aabb(&aabb3);
         Self {
-            model: std::cell::RefCell::new(model),
+            model: std::sync::RwLock::new(model),
             aabb: aabb.clone(),
             aabb_local: aabb,
             transformation: Mat4::identity(),
@@ -66,22 +66,28 @@ impl Geometry for Axes {
         lights: &[&dyn Light],
     ) {
         self.model
-            .borrow_mut()
+            .write()
+            .unwrap()
             .set_transformation(self.transformation);
         self.model
-            .borrow()
+            .read()
+            .unwrap()
             .render_with_material(&material, camera, lights);
         self.model
-            .borrow_mut()
+            .write()
+            .unwrap()
             .set_transformation(self.transformation * Mat4::from_angle_z(degrees(90.0)));
         self.model
-            .borrow()
+            .read()
+            .unwrap()
             .render_with_material(&material, camera, lights);
         self.model
-            .borrow_mut()
+            .write()
+            .unwrap()
             .set_transformation(self.transformation * Mat4::from_angle_y(degrees(-90.0)));
         self.model
-            .borrow()
+            .read()
+            .unwrap()
             .render_with_material(material, camera, lights);
     }
 }
@@ -89,9 +95,10 @@ impl Geometry for Axes {
 impl Object for Axes {
     fn render(&self, camera: &Camera, _lights: &[&dyn Light]) {
         self.model
-            .borrow_mut()
+            .write()
+            .unwrap()
             .set_transformation(self.transformation);
-        self.model.borrow().render_with_material(
+        self.model.read().unwrap().render_with_material(
             &ColorMaterial {
                 color: Color::RED,
                 ..Default::default()
@@ -100,9 +107,10 @@ impl Object for Axes {
             &[],
         );
         self.model
-            .borrow_mut()
+            .write()
+            .unwrap()
             .set_transformation(self.transformation * Mat4::from_angle_z(degrees(90.0)));
-        self.model.borrow().render_with_material(
+        self.model.read().unwrap().render_with_material(
             &ColorMaterial {
                 color: Color::GREEN,
                 ..Default::default()
@@ -111,9 +119,10 @@ impl Object for Axes {
             &[],
         );
         self.model
-            .borrow_mut()
+            .write()
+            .unwrap()
             .set_transformation(self.transformation * Mat4::from_angle_y(degrees(-90.0)));
-        self.model.borrow().render_with_material(
+        self.model.read().unwrap().render_with_material(
             &ColorMaterial {
                 color: Color::BLUE,
                 ..Default::default()

--- a/src/window/headless.rs
+++ b/src/window/headless.rs
@@ -17,7 +17,7 @@ impl Context {
                 headless_context.get_proc_address(s) as *const _
             })
         }))?;
-        c.glutin_context = Some(std::rc::Rc::new(headless_context));
+        c.glutin_context = Some(std::sync::Arc::new(headless_context));
         Ok(c)
     }
 }


### PR DESCRIPTION
This replaces all occurences of `std::rc::Rc` with `std::sync::Arc`
and all occurences of `std::cell::RefCell` with `std::sync::RwLock`.

This makes all structs Send and Sync, when the `glutin` features
is not enabled, allowing them to be passed along when the OpenGL
context is passed from one thread to another.

To make `Context` Send and Sync with `glutin` enabled, would require
making it generic over `glutin::ContextCurrentState`, which is problematic
with an optional feature. Perhaps it would be best to remove the `glutin_context`
field from `Context` and create a `HeadlessContext` which wraps `Context`?