### PR TITLE
fix(examples/fireworks): sample explosion_direction uniformly on 3d sphere

### DIFF
--- a/examples/fireworks/src/main.rs
+++ b/examples/fireworks/src/main.rs
@@ -117,12 +117,12 @@ pub fn run() {
             );
             let mut start_velocities = Vec::new();
             for _ in 0..300 {
-                let theta = rng.gen::<f32>() * std::f32::consts::PI;
+                let theta = rng.gen::<f32>() * 2.0 - 1.0;
                 let phi = rng.gen::<f32>() * 2.0 * std::f32::consts::PI;
                 let explosion_direction = vec3(
-                    theta.sin() * phi.cos(),
-                    theta.sin() * phi.sin(),
-                    theta.cos(),
+                    theta.acos().sin() * phi.cos(),
+                    theta.acos().sin() * phi.sin(),
+                    theta,
                 );
                 start_velocities
                     .push((rng.gen::<f32>() * 0.2 + 0.9) * explosion_speed * explosion_direction);


### PR DESCRIPTION
In `examples/fireworks/main.rs`, I believe `explosion_direction` is not sampled uniformly on the 3d sphere, resulting in non-uniform initial velocities of particles

Here is the result of the current sampling (I increased the number of particles to make it clearer):

<img width="808" alt="before" src="https://user-images.githubusercontent.com/8147163/188100928-36c7df11-6579-48d1-b72c-9c16c5b623c1.png">

The code I suggest returns the following:

<img width="604" alt="after" src="https://user-images.githubusercontent.com/8147163/188101171-8449af48-14da-4925-9402-678819bfb8f9.png">


The idea is to sample `theta` in `arcos(unif(-1, 1))` instead of `unif(0, pi)`. More details can be found here: https://stats.stackexchange.com/a/232256
