### PR TITLE
Add comments about default gravity in the particle system.

### DIFF
--- a/examples/fireworks/src/main.rs
+++ b/examples/fireworks/src/main.rs
@@ -28,7 +28,7 @@ impl Material for FireworksMaterial {
                 destination_rgb_multiplier: BlendMultiplierType::One,
                 destination_alpha_multiplier: BlendMultiplierType::One,
             },
-            depth_test: DepthTest::Always,
+            depth_test: DepthTest::LessOrEqual,
             write_mask: WriteMask::COLOR,
         }
     }

--- a/examples/fireworks/src/main.rs
+++ b/examples/fireworks/src/main.rs
@@ -79,8 +79,13 @@ pub fn run() {
     let mut square = CpuMesh::square();
     square.transform(&Mat4::from_scale(0.6)).unwrap();
 
-    // A particle system is created with a default acceleration of -9.82 in the y direction.
-    let particles = ParticleSystem::new(&context, &Particles::default(), &square);
+    // A particle system is created with an acceleration of -9.82 in the y direction to simulate gravity.
+    let particles = ParticleSystem::new(
+        &context,
+        &Particles::default(),
+        vec3(0.0, -9.82, 0.0),
+        &square,
+    );
     let fireworks_material = FireworksMaterial {
         color: colors[0],
         fade: 0.0,

--- a/examples/fireworks/src/main.rs
+++ b/examples/fireworks/src/main.rs
@@ -78,6 +78,8 @@ pub fn run() {
     ];
     let mut square = CpuMesh::square();
     square.transform(&Mat4::from_scale(0.6)).unwrap();
+
+    // A particle system is created with a default acceleration of -9.82 in the y direction.
     let particles = ParticleSystem::new(&context, &Particles::default(), &square);
     let fireworks_material = FireworksMaterial {
         color: colors[0],
@@ -86,14 +88,19 @@ pub fn run() {
     let mut fireworks = Gm::new(particles, fireworks_material);
 
     // main loop
-    fireworks.time = explosion_time + 100.0;
+    fireworks.time = explosion_time + 100.0; // Ensure initialisation on the first loop.
     let mut color_index = 0;
     window.render_loop(move |mut frame_input| {
         camera.set_viewport(frame_input.viewport);
 
         control.handle_events(&mut camera, &mut frame_input.events);
         let elapsed_time = (frame_input.elapsed_time * 0.001) as f32;
+
+        // Update the time in the particlesystem; this automatically integrates the velocity and
+        // the acceleration of each particle to calculate its new position.
         fireworks.time += elapsed_time;
+
+        // If the time exceeds the explosion duration, re-initialise the explosion.
         if fireworks.time > explosion_time {
             color_index = (color_index + 1) % colors.len();
             fireworks.material.color = colors[color_index];

--- a/src/renderer/geometry/particles.rs
+++ b/src/renderer/geometry/particles.rs
@@ -66,13 +66,14 @@ impl Particles {
 /// ```
 ///
 /// The particles will only move if the [ParticleSystem::time] variable is updated every frame.
+/// The acceleration defaults to -9.82 in the y direction.
 ///
 pub struct ParticleSystem {
     context: Context,
     vertex_buffers: HashMap<String, VertexBuffer>,
     instance_buffers: HashMap<String, InstanceBuffer>,
     index_buffer: Option<ElementBuffer>,
-    /// The acceleration applied to all particles defined in the world coordinate system. Default is gravity.
+    /// The acceleration applied to all particles defined in the world coordinate system. Default is gravity of -9.82 in the y direction.
     pub acceleration: Vec3,
     instance_count: u32,
     transformation: Mat4,

--- a/src/renderer/geometry/particles.rs
+++ b/src/renderer/geometry/particles.rs
@@ -66,14 +66,13 @@ impl Particles {
 /// ```
 ///
 /// The particles will only move if the [ParticleSystem::time] variable is updated every frame.
-/// The acceleration defaults to -9.82 in the y direction.
 ///
 pub struct ParticleSystem {
     context: Context,
     vertex_buffers: HashMap<String, VertexBuffer>,
     instance_buffers: HashMap<String, InstanceBuffer>,
     index_buffer: Option<ElementBuffer>,
-    /// The acceleration applied to all particles defined in the world coordinate system. Default is gravity of -9.82 in the y direction.
+    /// The acceleration applied to all particles defined in the world coordinate system.
     pub acceleration: Vec3,
     instance_count: u32,
     transformation: Mat4,
@@ -85,8 +84,14 @@ pub struct ParticleSystem {
 impl ParticleSystem {
     ///
     /// Creates a new particle system with the given geometry and the given attributes for each particle.
+    /// The acceleration is applied to all particles defined in the world coordinate system.
     ///
-    pub fn new(context: &Context, particles: &Particles, cpu_mesh: &CpuMesh) -> Self {
+    pub fn new(
+        context: &Context,
+        particles: &Particles,
+        acceleration: Vec3,
+        cpu_mesh: &CpuMesh,
+    ) -> Self {
         #[cfg(debug_assertions)]
         cpu_mesh.validate().expect("invalid cpu mesh");
 
@@ -95,7 +100,7 @@ impl ParticleSystem {
             index_buffer: super::index_buffer_from_mesh(context, cpu_mesh),
             vertex_buffers: super::vertex_buffers_from_mesh(context, cpu_mesh),
             instance_buffers: HashMap::new(),
-            acceleration: vec3(0.0, -9.82, 0.0),
+            acceleration,
             instance_count: 0,
             transformation: Mat4::identity(),
             texture_transform: Mat3::identity(),


### PR DESCRIPTION
Hi again, let me start this PR by saying; Thanks for this library, it's been a joy to work with so far!

Today I ran into the first surprise using it: I was trying to integrate the fireworks example into my own project; copied in some parts, modified the origin, scaling etc... then I noticed all particles were flying to the side by a few meters during the explosion time. Looking at the velocity generation from the example, I couldn't figure out how that could be the case...

After a while I discovered that there's a default gravity of `(0.0, -9.82, 0.0)` in the `ParticleSystem`. But that default doesn't work for me: I'm a roboticist and used to a coordinate system with x forward, y to the side and z being upwards. To be able to do all math and rendering in a familiar coordinate system my camera has an up vector of `(0.0, 0.0, 1.0)`, which meant that the default gravity of the particles makes everything fly off in the `y` direction.

This PR adds a bunch of comments throughout the fireworks example, including calling out the default gravity, currently that's not mentioned in the example. It also adds it to the main section of the [ParticleSystem](https://docs.rs/three-d/0.14.0/three_d/renderer/geometry/struct.ParticleSystem.html) documentation. Currently the default acceleration is mentioned for the acceleration field, but not in the main section. I think this is worth calling out, I at least found it surprising.

I'd even consider changing the default acceleration to be zero, happy to make that change, but thought that improving comments and docs would go a long way while being backwards compatible.

Edit: Discovered that to hide particles that are behind other geometries in my scene I had to set the `depth_test` RenderStates attribute to `LessOrEqual`. In the example that is set to [Always](https://github.com/asny/three-d/blob/17aae8dacf6072b1be845cf6d649577400cfc0ea/examples/fireworks/src/main.rs#L31), to me the example looks the same with that set to `DepthTest::LessOrEqual`. The [pipeline](https://github.com/asny/three-d/actions/runs/3528572683/jobs/5918819458) what looks like a flakey error retrieving a dependency, so going ahead and pushing a commit to change that to  `DepthTest::Always`.