### PR TITLE
Add example that shows benefits of InstancedMesh.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,11 @@ name = "shapes"
 path = "examples/shapes/src/main.rs"
 
 [[example]]
+name = "instanced_shapes"
+path = "examples/instanced_shapes/src/main.rs"
+required-features = ["egui-gui"]
+
+[[example]]
 name = "sprites"
 path = "examples/sprites/src/main.rs"
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -53,6 +53,10 @@ This is the recomended starting point for a gentle introduction to `three-d`.
 
 ![Shapes example](https://asny.github.io/three-d/0.15/shapes.png)
 
+## Instanced Shapes [[code](https://github.com/asny/three-d/tree/master/examples/instanced_shapes/src/main.rs)] [[demo](https://asny.github.io/three-d/0.15/instanced_shapes.html)]
+
+![Instanced Shapes example](https://asny.github.io/three-d/0.15/instanced_shapes.png)
+
 ## Screen [[code](https://github.com/asny/three-d/tree/master/examples/screen/src/main.rs)] [[demo](https://asny.github.io/three-d/0.15/screen.html)]
 
 ![Screen example](https://asny.github.io/three-d/0.15/screen.png)

--- a/examples/instanced_shapes/Cargo.toml
+++ b/examples/instanced_shapes/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "instanced_shapes"
+version = "0.1.0"
+authors = ["Asger Nyman Christiansen <asgernyman@gmail.com>", "Ivor Wanders <ivor@iwanders.net>"]
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+three-d = { path = "../../", features=["egui-gui"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+log = "0.4"
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+console_error_panic_hook = "0.1"
+console_log = "0.2"

--- a/examples/instanced_shapes/src/lib.rs
+++ b/examples/instanced_shapes/src/lib.rs
@@ -1,0 +1,19 @@
+#[allow(dead_code)] // Prevent warning about the free functions in main.
+mod main;
+
+// Entry point for wasm
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen(start)]
+pub fn start() -> Result<(), JsValue> {
+    console_log::init_with_level(log::Level::Debug).unwrap();
+
+    use log::info;
+    info!("Logging works!");
+
+    std::panic::set_hook(Box::new(console_error_panic_hook::hook));
+    main::main();
+    Ok(())
+}

--- a/examples/instanced_shapes/src/lib.rs
+++ b/examples/instanced_shapes/src/lib.rs
@@ -1,4 +1,3 @@
-#[allow(dead_code)] // Prevent warning about the free functions in main.
 mod main;
 
 // Entry point for wasm

--- a/examples/instanced_shapes/src/main.rs
+++ b/examples/instanced_shapes/src/main.rs
@@ -1,99 +1,5 @@
 use three_d::*;
 
-/// Function to calculate the translation and rotation of each cube based on time and cube count.
-fn calculate_cube_transforms(count: usize, time: f32) -> Vec<(Vec3, Quaternion<f32>)> {
-    let mut result = Vec::with_capacity(count);
-    let cube_separation = 3.0; // distance between center of cubes.
-    let grid_side = ((count as f32).powf(1.0 / 3.0)) as usize; // cube root of count.
-    let mut x_index = 0;
-    let mut y_index = 0;
-    let mut z_index = 0;
-    for _i in 0..count {
-        // Calculate the actual position.
-        let x = x_index as f32 * cube_separation;
-        let y = y_index as f32 * cube_separation;
-        let z = z_index as f32 * cube_separation;
-        let translation = vec3(x, y, z);
-
-        // Rotate cubes based on time, this makes it easier to see performance.
-        let rotation = Mat3::from_angle_x(Rad(time)).into();
-        result.push((translation, rotation));
-
-        // Advance the row, column and layer indices.
-        x_index += 1;
-        if x_index >= grid_side {
-            x_index = 0;
-            y_index += 1;
-        }
-        if y_index >= grid_side {
-            x_index = 0;
-            y_index = 0;
-            z_index += 1;
-        }
-    }
-    result
-}
-
-/// Adjust the vector of normal cubes, and update their translations.
-fn adjust_normal_cubes(
-    context: &Context,
-    time: f32,
-    count: usize,
-    cubes: &mut Vec<Gm<Mesh, PhysicalMaterial>>,
-) {
-    // Ensure we have the correct number of cubes, does no work if already correctly sized.
-    cubes.resize_with(count, || {
-        Gm::new(
-            Mesh::new(&context, &CpuMesh::cube()),
-            PhysicalMaterial::new(
-                &context,
-                &CpuMaterial {
-                    albedo: Color {
-                        r: 128,
-                        g: 128,
-                        b: 128,
-                        a: 255,
-                    },
-                    ..Default::default()
-                },
-            ),
-        )
-    });
-
-    // Finally, calculate the cube transforms and update them.
-    let mut cube_transforms = calculate_cube_transforms(count, time);
-    for ((position, rotation), cube) in cube_transforms.drain(..).zip(cubes.iter_mut()) {
-        cube.set_transformation(Mat4::from_translation(position) * Mat4::from(rotation));
-    }
-}
-
-/// Adjust the instanced cubes with their new position and rotation.
-fn adjust_instanced_cubes(
-    _context: &Context,
-    time: f32,
-    count: usize,
-    cubes: &mut Gm<InstancedMesh, PhysicalMaterial>,
-) {
-    // Allocate vectors to set the instanced transforms.
-    let mut rotations = Vec::with_capacity(count);
-    let mut translations = Vec::with_capacity(count);
-
-    // Calculate the cube transforms and split these into rotation and translation.
-    let mut cube_transforms = calculate_cube_transforms(count, time);
-    for (position, rotation) in cube_transforms.drain(..) {
-        translations.push(position);
-        rotations.push(rotation);
-    }
-
-    // Create the new Instances object with these properties and assign it to the InstancedMesh.
-    let new_instances = three_d::renderer::geometry::Instances {
-        translations,
-        rotations: Some(rotations),
-        ..Default::default()
-    };
-    cubes.set_instances(&new_instances);
-}
-
 pub fn main() {
     let window = Window::new(WindowSettings {
         title: "Instanced Shapes!".to_string(),
@@ -118,12 +24,11 @@ pub fn main() {
     let light1 = DirectionalLight::new(&context, 1.0, Color::WHITE, &vec3(0.0, 0.5, 0.5));
 
     // Container for non instanced meshes.
-    let mut non_instanced_meshes: Vec<Gm<Mesh, PhysicalMaterial>> = vec![];
+    let mut non_instanced_meshes = Vec::new();
 
     // Instanced mesh object, initialise with empty instances.
-    let instances: three_d::renderer::geometry::Instances = Default::default();
-    let mut instanced_mesh: Gm<InstancedMesh, PhysicalMaterial> = Gm::new(
-        InstancedMesh::new(&context, &instances, &CpuMesh::cube()),
+    let mut instanced_mesh = Gm::new(
+        InstancedMesh::new(&context, &Instances::default(), &CpuMesh::cube()),
         PhysicalMaterial::new(
             &context,
             &CpuMaterial {
@@ -138,8 +43,8 @@ pub fn main() {
         ),
     );
 
-    // Initial properties of the example, 10 cubes and non instanced.
-    let mut cube_count = 10;
+    // Initial properties of the example, 2 cubes per side and non instanced.
+    let mut side_count = 2;
     let mut is_instanced = false;
 
     let mut gui = three_d::GUI::new(&context);
@@ -158,7 +63,9 @@ pub fn main() {
                 SidePanel::left("side_panel").show(gui_context, |ui| {
                     use three_d::egui::*;
                     ui.heading("Debug Panel");
-                    ui.add(Slider::new(&mut cube_count, 1..=10000).text("Number of cubes."));
+                    ui.add(
+                        Slider::new(&mut side_count, 1..=25).text("Number of cubes at each side."),
+                    );
                     ui.add(Checkbox::new(&mut is_instanced, "Use Instancing"));
                     ui.add(Label::new(
                         "Increase the cube count until the cubes don't rotate \
@@ -175,23 +82,58 @@ pub fn main() {
 
         // Time to move the cubes.
         let time = (frame_input.accumulated_time * 0.001) as f32;
+        let rotation = Quat::from_angle_x(Rad(time));
+        let count = side_count * side_count * side_count;
 
         // Always update the transforms for both the normal cubes as well as the instanced versions.
         // This shows that the difference in frame rate is not because of updating the transforms
         // and shows that the performance difference is not related to how we update the cubes.
 
-        adjust_normal_cubes(&context, time, cube_count, &mut non_instanced_meshes);
-        adjust_instanced_cubes(&context, time, cube_count, &mut instanced_mesh);
+        // Ensure we have the correct number of cubes, does no work if already correctly sized.
+        non_instanced_meshes.resize_with(count, || {
+            Gm::new(
+                Mesh::new(&context, &CpuMesh::cube()),
+                PhysicalMaterial::new(
+                    &context,
+                    &CpuMaterial {
+                        albedo: Color {
+                            r: 128,
+                            g: 128,
+                            b: 128,
+                            a: 255,
+                        },
+                        ..Default::default()
+                    },
+                ),
+            )
+        });
+
+        // Finally, calculate the cube transforms and update them.
+        let mut translations = Vec::new();
+        for (i, mesh) in non_instanced_meshes.iter_mut().enumerate() {
+            let x = (i % side_count) as f32;
+            let y = ((i as f32 / side_count as f32).floor() as usize % side_count) as f32;
+            let z = (i as f32 / side_count.pow(2) as f32).floor();
+            let translation = 3.0 * vec3(x, y, z);
+            translations.push(translation);
+            let transformation = Mat4::from_translation(translation) * Into::<Mat4>::into(rotation);
+            mesh.set_transformation(transformation);
+        }
+        instanced_mesh.set_instances(&Instances {
+            translations,
+            rotations: Some(vec![rotation; count]),
+            ..Default::default()
+        });
 
         // Then, based on whether or not we render the instanced cubes, collect the renderable
         // objects.
         let render_objects: Vec<&dyn Object> = if is_instanced {
-            instanced_mesh.into_iter().collect::<_>()
+            instanced_mesh.into_iter().collect()
         } else {
             non_instanced_meshes
                 .iter()
                 .map(|x| x as &dyn Object)
-                .collect::<_>()
+                .collect()
         };
 
         frame_input

--- a/examples/instanced_shapes/src/main.rs
+++ b/examples/instanced_shapes/src/main.rs
@@ -1,0 +1,205 @@
+use three_d::*;
+
+/// Function to calculate the translation and rotation of each cube based on time and cube count.
+fn calculate_cube_transforms(count: usize, time: f32) -> Vec<(Vec3, Quaternion<f32>)> {
+    let mut result = Vec::with_capacity(count);
+    let cube_separation = 3.0; // distance between center of cubes.
+    let grid_side = ((count as f32).powf(1.0 / 3.0)) as usize; // cube root of count.
+    let mut x_index = 0;
+    let mut y_index = 0;
+    let mut z_index = 0;
+    for _i in 0..count {
+        // Calculate the actual position.
+        let x = x_index as f32 * cube_separation;
+        let y = y_index as f32 * cube_separation;
+        let z = z_index as f32 * cube_separation;
+        let translation = vec3(x, y, z);
+
+        // Rotate cubes based on time, this makes it easier to see performance.
+        let rotation = Mat3::from_angle_x(Rad(time)).into();
+        result.push((translation, rotation));
+
+        // Advance the row, column and layer indices.
+        x_index += 1;
+        if x_index >= grid_side {
+            x_index = 0;
+            y_index += 1;
+        }
+        if y_index >= grid_side {
+            x_index = 0;
+            y_index = 0;
+            z_index += 1;
+        }
+    }
+    result
+}
+
+/// Adjust the vector of normal cubes, and update their translations.
+fn adjust_normal_cubes(
+    context: &Context,
+    time: f32,
+    count: usize,
+    cubes: &mut Vec<Gm<Mesh, PhysicalMaterial>>,
+) {
+    // Ensure we have the correct number of cubes, does no work if already correctly sized.
+    cubes.resize_with(count, || {
+        Gm::new(
+            Mesh::new(&context, &CpuMesh::cube()),
+            PhysicalMaterial::new(
+                &context,
+                &CpuMaterial {
+                    albedo: Color {
+                        r: 128,
+                        g: 128,
+                        b: 128,
+                        a: 255,
+                    },
+                    ..Default::default()
+                },
+            ),
+        )
+    });
+
+    // Finally, calculate the cube transforms and update them.
+    let mut cube_transforms = calculate_cube_transforms(count, time);
+    for ((position, rotation), cube) in cube_transforms.drain(..).zip(cubes.iter_mut()) {
+        cube.set_transformation(Mat4::from_translation(position) * Mat4::from(rotation));
+    }
+}
+
+/// Adjust the instanced cubes with their new position and rotation.
+fn adjust_instanced_cubes(
+    _context: &Context,
+    time: f32,
+    count: usize,
+    cubes: &mut Gm<InstancedMesh, PhysicalMaterial>,
+) {
+    // Allocate vectors to set the instanced transforms.
+    let mut rotations = Vec::with_capacity(count);
+    let mut translations = Vec::with_capacity(count);
+
+    // Calculate the cube transforms and split these into rotation and translation.
+    let mut cube_transforms = calculate_cube_transforms(count, time);
+    for (position, rotation) in cube_transforms.drain(..) {
+        translations.push(position);
+        rotations.push(rotation);
+    }
+
+    // Create the new Instances object with these properties and assign it to the InstancedMesh.
+    let new_instances = three_d::renderer::geometry::Instances {
+        translations,
+        rotations: Some(rotations),
+        ..Default::default()
+    };
+    cubes.set_instances(&new_instances);
+}
+
+pub fn main() {
+    let window = Window::new(WindowSettings {
+        title: "Instanced Shapes!".to_string(),
+        max_size: Some((1280, 720)),
+        ..Default::default()
+    })
+    .unwrap();
+    let context = window.gl();
+
+    let mut camera = Camera::new_perspective(
+        window.viewport(),
+        vec3(120.00, 97.0, 122.0),   // camera position
+        vec3(115.000, 93.25, 118.5), // camera target
+        vec3(0.0, 1.0, 0.0),         // camera up
+        degrees(45.0),
+        0.1,
+        1000.0,
+    );
+    let mut control = FlyControl::new(1.0);
+
+    let light0 = DirectionalLight::new(&context, 1.0, Color::WHITE, &vec3(0.0, -0.5, -0.5));
+    let light1 = DirectionalLight::new(&context, 1.0, Color::WHITE, &vec3(0.0, 0.5, 0.5));
+
+    // Container for non instanced meshes.
+    let mut non_instanced_meshes: Vec<Gm<Mesh, PhysicalMaterial>> = vec![];
+
+    // Instanced mesh object, initialise with empty instances.
+    let instances: three_d::renderer::geometry::Instances = Default::default();
+    let mut instanced_mesh: Gm<InstancedMesh, PhysicalMaterial> = Gm::new(
+        InstancedMesh::new(&context, &instances, &CpuMesh::cube()),
+        PhysicalMaterial::new(
+            &context,
+            &CpuMaterial {
+                albedo: Color {
+                    r: 128,
+                    g: 128,
+                    b: 128,
+                    a: 255,
+                },
+                ..Default::default()
+            },
+        ),
+    );
+
+    // Initial properties of the example, 10 cubes and non instanced.
+    let mut cube_count = 10;
+    let mut is_instanced = false;
+
+    let mut gui = three_d::GUI::new(&context);
+    window.render_loop(move |mut frame_input: FrameInput| {
+        camera.set_viewport(frame_input.viewport);
+
+        // Gui panel to control the number of cubes and whether or not instancing is turned on.
+        let mut panel_width = 0.0;
+        gui.update(
+            &mut frame_input.events,
+            frame_input.accumulated_time,
+            frame_input.viewport,
+            frame_input.device_pixel_ratio,
+            |gui_context| {
+                use three_d::egui::*;
+                SidePanel::left("side_panel").show(gui_context, |ui| {
+                    use three_d::egui::*;
+                    ui.heading("Debug Panel");
+                    ui.add(Slider::new(&mut cube_count, 1..=10000).text("Number of cubes."));
+                    ui.add(Checkbox::new(&mut is_instanced, "Use Instancing"));
+                    ui.add(Label::new(
+                        "Increase the cube count until the cubes don't rotate \
+                                       smoothly anymore, then toggle on instancing. The rotations \
+                                       should become smooth again.",
+                    ));
+                });
+                panel_width = gui_context.used_rect().width() as f64;
+            },
+        );
+
+        // Camera control must be after the gui update.
+        control.handle_events(&mut camera, &mut frame_input.events);
+
+        // Time to move the cubes.
+        let time = (frame_input.accumulated_time * 0.001) as f32;
+
+        // Always update the transforms for both the normal cubes as well as the instanced versions.
+        // This shows that the difference in frame rate is not because of updating the transforms
+        // and shows that the performance difference is not related to how we update the cubes.
+
+        adjust_normal_cubes(&context, time, cube_count, &mut non_instanced_meshes);
+        adjust_instanced_cubes(&context, time, cube_count, &mut instanced_mesh);
+
+        // Then, based on whether or not we render the instanced cubes, collect the renderable
+        // objects.
+        let render_objects: Vec<&dyn Object> = if is_instanced {
+            instanced_mesh.into_iter().collect::<_>()
+        } else {
+            non_instanced_meshes
+                .iter()
+                .map(|x| x as &dyn Object)
+                .collect::<_>()
+        };
+
+        frame_input
+            .screen()
+            .clear(ClearState::color_and_depth(0.8, 0.8, 0.8, 1.0, 1.0))
+            .render(&camera, render_objects, &[&light0, &light1])
+            .write(|| gui.render());
+
+        FrameOutput::default()
+    });
+}


### PR DESCRIPTION
Discussed briefly in https://github.com/asny/three-d/pull/294.

This proposes an example that renders a large number of rotating cubes, allowing the user to toggle between normal rendering of the cubes and instancing.

![Screenshot at 2022-11-27 20-37-34](https://user-images.githubusercontent.com/1732289/204173724-bd37416f-62a6-4075-9898-8a4e99a29881.png)

It has become a bit longer than I hoped, but there's clear comments for anyone to follow along. The actual work of updating the transforms is in all cases done for both the instanced mesh as well as the non instanced cubes.

~Intentionally didn't update the main examples readme yet, will do that after incorporating feedback.~

> error: no example target named `instanced_shapes`.

Failed the pipeline, turns out there's all kinds of things happening to automagically create the thumbnail, so fancy! I've tried to add the new example to the example readme and main cargo file :crossed_fingers: .