### PR TITLE
Compute InstancedMesh' InstanceBuffers at render time based on distance from camera.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,10 @@ name = "shapes"
 path = "examples/shapes/src/main.rs"
 
 [[example]]
+name = "instanced_draw_order"
+path = "examples/instanced_draw_order/src/main.rs"
+
+[[example]]
 name = "instanced_shapes"
 path = "examples/instanced_shapes/src/main.rs"
 required-features = ["egui-gui"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -53,6 +53,12 @@ This is the recomended starting point for a gentle introduction to `three-d`.
 
 ![Shapes example](https://asny.github.io/three-d/0.15/shapes.png)
 
+## Instanced Draw Order [[code](https://github.com/asny/three-d/tree/master/examples/instanced_draw_order/src/main.rs)] [[demo](https://asny.github.io/three-d/0.15/instanced_draw_order.html)]
+
+This example shows how depth ordering is currently working for `InstancedMesh` objects with transparency.
+
+![Instanced Draw Order](https://asny.github.io/three-d/0.15/instanced_draw_order.png)
+
 ## Instanced Shapes [[code](https://github.com/asny/three-d/tree/master/examples/instanced_shapes/src/main.rs)] [[demo](https://asny.github.io/three-d/0.15/instanced_shapes.html)]
 
 ![Instanced Shapes example](https://asny.github.io/three-d/0.15/instanced_shapes.png)

--- a/examples/instanced_draw_order/Cargo.toml
+++ b/examples/instanced_draw_order/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "instanced_draw_order"
+version = "0.1.0"
+authors = ["Asger Nyman Christiansen <asgernyman@gmail.com>", "Ivor Wanders <ivor@iwanders.net>"]
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+three-d = { path = "../../" }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+log = "0.4"
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+console_error_panic_hook = "0.1"
+console_log = "0.2"

--- a/examples/instanced_draw_order/src/lib.rs
+++ b/examples/instanced_draw_order/src/lib.rs
@@ -1,0 +1,18 @@
+mod main;
+
+// Entry point for wasm
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen(start)]
+pub fn start() -> Result<(), JsValue> {
+    console_log::init_with_level(log::Level::Debug).unwrap();
+
+    use log::info;
+    info!("Logging works!");
+
+    std::panic::set_hook(Box::new(console_error_panic_hook::hook));
+    main::main();
+    Ok(())
+}

--- a/examples/instanced_draw_order/src/main.rs
+++ b/examples/instanced_draw_order/src/main.rs
@@ -1,0 +1,139 @@
+use three_d::*;
+
+/*
+    This example shows that for the InstancedMesh, instances are ordered by camera depth if the
+    material is transparent. Transparent materials need to be drawn back-to-front, failure to do so
+    results in rendering results that look incorrect. Currently, instances are ordered based on
+    their origin, this means that if two instances overlap, rendering artifacts occur, as can be
+    seen in the two panes that overlap, rotating the camera around that alternates which panel is
+    drawn over the other.
+*/
+
+pub fn main() {
+    let window = Window::new(WindowSettings {
+        title: "Instanced Draw Order".to_string(),
+        max_size: Some((1280, 720)),
+        ..Default::default()
+    })
+    .unwrap();
+    let context = window.gl();
+
+    let mut camera = Camera::new_perspective(
+        window.viewport(),
+        vec3(1.4933096, 4.8070683, -9.277165),  // position
+        vec3(0.14315122, 2.369473, -3.7785282), // target
+        vec3(0.0, 1.0, 0.0),                    // up
+        degrees(45.0),
+        0.1,
+        1000.0,
+    );
+    let mut control = OrbitControl::new(vec3(0.0, 0.0, -0.5), 0.1, 10.0);
+
+    // Shorthand for a 90 degree rotation about z.
+    let rot_z90 = Mat4::from_angle_z(Deg(90.0));
+
+    // Instances initially ordered such that drawing them in order without reordering is incorrect.
+    let transparent_instances = three_d::renderer::geometry::Instances {
+        transformations: vec![
+            Mat4::from_translation(vec3(0.0, 0.0, -2.0)),
+            Mat4::from_translation(vec3(0.0, 0.0, -1.0)),
+            Mat4::from_translation(vec3(0.0, 0.0, 0.0)),
+            Mat4::from_translation(vec3(0.0, 0.0, 1.0)),
+            // The next two cubes always intersect, even if ordered by depth, they will show
+            // rendering artifacts from one view-direction.
+            Mat4::from_translation(vec3(3.0, 0.0, 0.0)) * rot_z90 * Mat4::from_angle_x(Deg(45.0)),
+            Mat4::from_translation(vec3(3.0, 0.0, 0.5)) * rot_z90 * Mat4::from_angle_x(Deg(-45.0)),
+        ],
+        colors: Some(vec![
+            Color::new(0, 255, 0, 255),   // green, closest, should obscure everything.
+            Color::new(255, 0, 255, 255), // purple, behind green, second opaque plane.
+            Color::new(255, 0, 0, 128), // Red, third plane, should be behind two opaques, blend in front of blue.
+            Color::new(0, 0, 255, 128), // Furthest, blue layer.
+            // Next two always intersect.
+            Color::new(0, 128, 128, 128), // Limitation of ordering, cyan
+            Color::new(128, 128, 0, 128), // Limitation of ordering, yellow
+        ]),
+        ..Default::default()
+    };
+
+    let mut thin_cube = CpuMesh::cube();
+    thin_cube.transform(&Mat4::from_nonuniform_scale(1.0, 1.0, 0.1));
+
+    let transparent_meshes = Gm::new(
+        InstancedMesh::new(&context, &transparent_instances, &thin_cube),
+        PhysicalMaterial::new_transparent(
+            &context,
+            &CpuMaterial {
+                albedo: Color {
+                    r: 255,
+                    g: 255,
+                    b: 255,
+                    a: 255,
+                },
+                ..Default::default()
+            },
+        ),
+    );
+
+    // For opaque meshes, the draw order does not matter.
+    let opaque_instances = three_d::renderer::geometry::Instances {
+        transformations: transparent_instances.transformations,
+        colors: Some(
+            transparent_instances.colors
+                .as_ref()
+                .unwrap()
+                .iter()
+                .map(|c| Color {
+                    r: c.r,
+                    g: c.g,
+                    b: c.b,
+                    a: 255,
+                })
+                .collect(),
+        ),
+        ..Default::default()
+    };
+    let mut thin_cube_right = CpuMesh::cube();
+    thin_cube_right.transform(
+        &(Mat4::from_translation(vec3(-3.0, 0.0, 0.0)) * Mat4::from_nonuniform_scale(1.0, 1.0, 0.1)),
+    );
+
+    let mut opaque_meshes_opaque_instances = Gm::new(
+        InstancedMesh::new(&context, &opaque_instances, &thin_cube_right),
+        PhysicalMaterial::new_opaque(
+            &context,
+            &CpuMaterial {
+                albedo: Color {
+                    r: 255,
+                    g: 255,
+                    b: 255,
+                    a: 255,
+                },
+                ..Default::default()
+            },
+        ),
+    );
+    // Testing that changing the instance count still works as expected, blue should disappear.
+    opaque_meshes_opaque_instances.set_instance_count(3);
+
+    let light0 = DirectionalLight::new(&context, 1.0, Color::WHITE, &vec3(0.0, -0.5, -0.5));
+    let ambient_light = three_d::renderer::light::AmbientLight::new(&context, 0.1, Color::WHITE);
+
+    window.render_loop(move |mut frame_input: FrameInput| {
+        camera.set_viewport(frame_input.viewport);
+        control.handle_events(&mut camera, &mut frame_input.events);
+
+        frame_input
+            .screen()
+            .clear(ClearState::color_and_depth(0.8, 0.8, 0.8, 1.0, 1.0))
+            .render(
+                &camera,
+                transparent_meshes
+                    .into_iter()
+                    .chain(&opaque_meshes_opaque_instances),
+                &[&light0, &ambient_light],
+            );
+
+        FrameOutput::default()
+    });
+}

--- a/examples/instanced_draw_order/src/main.rs
+++ b/examples/instanced_draw_order/src/main.rs
@@ -79,7 +79,8 @@ pub fn main() {
     let opaque_instances = three_d::renderer::geometry::Instances {
         transformations: transparent_instances.transformations,
         colors: Some(
-            transparent_instances.colors
+            transparent_instances
+                .colors
                 .as_ref()
                 .unwrap()
                 .iter()
@@ -95,7 +96,8 @@ pub fn main() {
     };
     let mut thin_cube_right = CpuMesh::cube();
     thin_cube_right.transform(
-        &(Mat4::from_translation(vec3(-3.0, 0.0, 0.0)) * Mat4::from_nonuniform_scale(1.0, 1.0, 0.1)),
+        &(Mat4::from_translation(vec3(-3.0, 0.0, 0.0))
+            * Mat4::from_nonuniform_scale(1.0, 1.0, 0.1)),
     );
 
     let mut opaque_meshes_opaque_instances = Gm::new(

--- a/src/renderer/geometry/instanced_mesh.rs
+++ b/src/renderer/geometry/instanced_mesh.rs
@@ -117,7 +117,12 @@ impl InstancedMesh {
         let distances = self
             .instance_transforms
             .iter()
-            .map(|m| m.w.truncate().distance2(*camera.position()))
+            .map(|m| {
+                (self.transformation * m)
+                    .w
+                    .truncate()
+                    .distance2(*camera.position())
+            })
             .collect::<Vec<_>>();
         // Then, we can sort the indices based on those distances.
         let mut indices = (0..distances.len()).collect::<Vec<usize>>();

--- a/src/renderer/geometry/instanced_mesh.rs
+++ b/src/renderer/geometry/instanced_mesh.rs
@@ -252,10 +252,8 @@ impl InstancedMesh {
                 .collect::<Vec<_>>()
         };
 
-
         let indices = match sorting {
-            InstanceSorting::None => {
-                (0..self.instance_count as usize).collect::<Vec<usize>>()},
+            InstanceSorting::None => (0..self.instance_count as usize).collect::<Vec<usize>>(),
             InstanceSorting::BackToFront => {
                 // First, create a vector of distances from the camera to each instance.
                 let distances = distances();

--- a/src/renderer/geometry/instanced_mesh.rs
+++ b/src/renderer/geometry/instanced_mesh.rs
@@ -252,13 +252,15 @@ impl InstancedMesh {
                 .collect::<Vec<_>>()
         };
 
+
         let indices = match sorting {
-            InstanceSorting::None => (0..self.instance_transforms.len()).collect::<Vec<usize>>(),
+            InstanceSorting::None => {
+                (0..self.instance_count as usize).collect::<Vec<usize>>()},
             InstanceSorting::BackToFront => {
                 // First, create a vector of distances from the camera to each instance.
                 let distances = distances();
                 // Then, we can sort the indices based on those distances.
-                let mut indices = (0..distances.len()).collect::<Vec<usize>>();
+                let mut indices = (0..self.instance_count as usize).collect::<Vec<usize>>();
                 indices.sort_by(|a, b| {
                     distances[*b]
                         .partial_cmp(&distances[*a])
@@ -277,7 +279,7 @@ impl InstancedMesh {
                     vec![false; distances.len()]
                 };
                 // Then, we can sort the indices based on those distances.
-                let mut indices = (0..distances.len()).collect::<Vec<usize>>();
+                let mut indices = (0..self.instance_count as usize).collect::<Vec<usize>>();
                 indices.sort_by(|a, b| {
                     // If both opaque, ordering is equal.
                     if opaque_mask[*a] && opaque_mask[*b] {


### PR DESCRIPTION
Hi again!

So, I ran into a rendering problem with `InstancedMesh` displaying cubes with transparency. The rendering order of this was based on the order in which the instances are assigned, and this results in some undesirable visualisations.

I was working on an effect to 'deconstruct' a bunch of cubes into smaller cubes that fall to the ground and then fade out. The problem is that some of these instances were being drawn in front of instances they should have been behind: [vehicle_before](https://user-images.githubusercontent.com/1732289/205457987-779cf9e7-c5ba-41b6-a273-5b96e0b36ff6.png). The tracks should clearly be hidden behind the instances that make up the green body of the vehicle.

Searching in the issues, I think https://github.com/asny/three-d/issues/154 relates to this problem. Currently all objects are sorted by bounding box to determine the rendering order, but for the individual instances in the `InstancedMesh` this is not done.

In 27593777ce0167c5b86114866a8c8694fdd09e4e I tried to modify the instanced shapes example to show the problem, it's on branch [transparent-instancing-ordering-example](https://github.com/iwanders/asny-three-d/tree/transparent-instancing-ordering-example), the before screenshot of the example:
![before_Screenshot at 2022-12-03 13-57-40](https://user-images.githubusercontent.com/1732289/205458186-cd284d23-7933-4cd0-9176-6980a4f30c0b.png)

It's not super clear, but the green cube (behind the front cube) is drawn later than the front cube and it all ends up looking off.

With the changes proposed in this branch that example ends up looking like this:
![fixed_Screenshot at 2022-12-03 13-57-59](https://user-images.githubusercontent.com/1732289/205458229-d3fb1d3f-9684-4008-9767-d342c1cb443d.png)

The same vehicle screenshot from earlier ends up looking correct: [vehicle_after](https://user-images.githubusercontent.com/1732289/205458248-4434edc0-9434-4744-8e5d-6d217f8c70dc.png)

This works by:
- Storing the `instances` object as a private variable.
- Removed `instance_buffers` from `InstancedMesh`.
- Moved creation of the `instance_buffers` to a private function that also takes the camera.
- In this method we iterate through the instances based on their position origin. It won't be perfect, neither will this solve rendering if there's two `InstancedMesh` objects that overlap. While not perfect, it's an improvement over the current state.
- In `draw`, `render_with_material` and `render_with_postmaterial` we first calculate the instance buffers based on our camera position, allowing us to order the instances.

