### PR TITLE
Adds helper function to go from control positions to viewport positions.

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -553,6 +553,7 @@ pub fn cmp_render_order(
 /// Finds the closest intersection between a ray from the given camera in the given pixel coordinate and the given geometries.
 /// The pixel coordinate must be in physical pixels, where (viewport.x, viewport.y) indicate the bottom left corner of the viewport
 /// and (viewport.x + viewport.width, viewport.y + viewport.height) indicate the top right corner.
+/// To convert from control input positions to the pixel (viewport) positions use [`crate::control::control_position_to_viewport_position`].
 /// Returns ```None``` if no geometry was hit between the near (`z_near`) and far (`z_far`) plane for this camera.
 ///
 pub fn pick(

--- a/src/renderer/control.rs
+++ b/src/renderer/control.rs
@@ -39,6 +39,8 @@ pub enum Event {
         /// The screen position in logical pixels, to get it in physical pixels, multiply it with the device pixel ratio.
         /// The first value defines the position on the horizontal axis with zero being at the left border of the window
         /// and the second on the vertical axis with zero being at the top edge of the window.
+        /// To convert this position into a position used by the camera methods, see
+        /// [`control_position_to_viewport_position`].
         position: (f64, f64),
         /// The state of modifiers.
         modifiers: Modifiers,
@@ -52,6 +54,8 @@ pub enum Event {
         /// The screen position in logical pixels, to get it in physical pixels, multiply it with the device pixel ratio.
         /// The first value defines the position on the horizontal axis with zero being at the left border of the window
         /// and the second on the vertical axis with zero being at the top edge of the window.
+        /// To convert this position into a position used by the camera methods, see
+        /// [`control_position_to_viewport_position`].
         position: (f64, f64),
         /// The state of modifiers.
         modifiers: Modifiers,
@@ -67,6 +71,8 @@ pub enum Event {
         /// The screen position in logical pixels, to get it in physical pixels, multiply it with the device pixel ratio.
         /// The first value defines the position on the horizontal axis with zero being at the left border of the window
         /// and the second on the vertical axis with zero being at the top edge of the window.
+        /// To convert this position into a position used by the camera methods, see
+        /// [`control_position_to_viewport_position`].
         position: (f64, f64),
         /// The state of modifiers.
         modifiers: Modifiers,
@@ -80,6 +86,8 @@ pub enum Event {
         /// The screen position in logical pixels, to get it in physical pixels, multiply it with the device pixel ratio.
         /// The first value defines the position on the horizontal axis with zero being at the left border of the window
         /// and the second on the vertical axis with zero being at the top edge of the window.
+        /// To convert this position into a position used by the camera methods, see
+        /// [`control_position_to_viewport_position`].
         position: (f64, f64),
         /// The state of modifiers.
         modifiers: Modifiers,
@@ -201,4 +209,29 @@ pub struct Modifiers {
     /// On Windows and Linux, set this to the same value as `ctrl`.
     /// On Mac, this should be set whenever one of the ⌘ Command keys are down.
     pub command: bool,
+}
+
+/// Convert a position provided by any of the control events into the viewport position
+///
+/// The viewport uses a flipped y direction, so the positions provided by control inputs need to be
+/// converted before they can be used with methods that requires viewport pixels, such as the
+/// [`crate::core::Camera::position_at_pixel`] and [`crate::core::Camera::view_direction_at_pixel`]
+/// methods.
+pub fn control_position_to_viewport_position(
+    pos: (f64, f64),
+    device_pixel_ratio: f64,
+    viewport: &crate::Viewport,
+) -> (f32, f32) {
+    // First, convert the logical pixels to physical pixels using the device pixel ratio.
+    let physical_x = pos.0 * device_pixel_ratio;
+    let physical_y = pos.1 * device_pixel_ratio;
+
+    // The logical pixels have an y that has zero being at the top edge of the window.
+    // The viewport pixels have viewport.y as bottom and (viewport.y + viewport.height) as top.
+
+    // To convert between the two, we need to flip the y axis around.
+    let viewport_y = viewport.y as f64 + (viewport.height as f64 - physical_y);
+    let viewport_x = viewport.x as f64 + physical_x;
+
+    (viewport_x as f32, viewport_y as f32)
 }


### PR DESCRIPTION
I was trying to add 'select' functionality in my project, I needed to convert the position from the [MousePress](https://docs.rs/three-d/latest/three_d/renderer/control/enum.Event.html#variant.MousePress) into 'world' coordinates, I found the [pick](https://docs.rs/three-d/latest/three_d/renderer/fn.pick.html) function, that function states:
> The pixel coordinate must be in physical pixels, where (viewport.x, viewport.y) indicate the bottom left corner of the viewport and (viewport.x + viewport.width, viewport.y + viewport.height) indicate the top right corner

The documentation for the `MousePress` position states:
> The screen position in logical pixels, to get it in physical pixels, multiply it with the device pixel ratio. The first value defines the position on the horizontal axis with zero being at the left border of the window and the second on the vertical axis with zero being at the top edge of the window.

Now, I saw the first line of the first function, was; `must be in physical` and the first line of the second function `to get it in physical pixels, multiply it with the device pixel ratio`. So I added the device pixel ratio, and started clicking around, sometimes this worked, sometimes it didn't.

After drawing the rays I noticed that the vertical axis is flipped between the two. Reading it again, this is definitely documented. But that the two physical pixels aren't the same still caused some confusion, I initially had this logic in-line in my own selection function, but thought it would be good to contribute it back and point to the new helper from the relevant functions?


Note, I did not branch off from 8074742837a198d1653664f5252e2df8f50722ea (current master) because that panics for me atm, instead I branched from a2a083e1823c6813e349d49547744ab375f8821b.