### PR TITLE
Fix #317 - Crash in `Mesh::draw`

### DIFF
--- a/src/renderer/geometry/instanced_mesh.rs
+++ b/src/renderer/geometry/instanced_mesh.rs
@@ -278,13 +278,17 @@ impl InstancedMesh {
         camera: &Camera,
         instance_buffers: &HashMap<String, InstanceBuffer>,
     ) {
+        if program.requires_uniform("normalMatrix") {
+            if let Some(inverse) = self.current_transformation.invert() {
+                program.use_uniform("normalMatrix", inverse.transpose());
+            } else {
+                // determinant is float zero
+                return;
+            }
+        }
         program.use_uniform("viewProjection", camera.projection() * camera.view());
         program.use_uniform("modelMatrix", &self.current_transformation);
         program.use_uniform_if_required("textureTransform", &self.texture_transform);
-        program.use_uniform_if_required(
-            "normalMatrix",
-            &self.current_transformation.invert().unwrap().transpose(),
-        );
 
         for attribute_name in ["position", "normal", "tangent", "color", "uv_coordinates"] {
             if program.requires_attribute(attribute_name) {

--- a/src/renderer/geometry/mesh.rs
+++ b/src/renderer/geometry/mesh.rs
@@ -98,13 +98,16 @@ impl Mesh {
     }
 
     fn draw(&self, program: &Program, render_states: RenderStates, camera: &Camera) {
+        if let Some(inverse) = self.current_transformation.invert() {
+            program.use_uniform_if_required("normalMatrix", inverse.transpose());
+        } else {
+            // determinant is float zero
+            return;
+        }
+
         program.use_uniform("viewProjection", camera.projection() * camera.view());
         program.use_uniform("modelMatrix", self.current_transformation);
         program.use_uniform_if_required("textureTransform", self.texture_transform);
-        program.use_uniform_if_required(
-            "normalMatrix",
-            self.current_transformation.invert().unwrap().transpose(),
-        );
 
         for attribute_name in ["position", "normal", "tangent", "color", "uv_coordinates"] {
             if program.requires_attribute(attribute_name) {

--- a/src/renderer/geometry/mesh.rs
+++ b/src/renderer/geometry/mesh.rs
@@ -98,11 +98,13 @@ impl Mesh {
     }
 
     fn draw(&self, program: &Program, render_states: RenderStates, camera: &Camera) {
-        if let Some(inverse) = self.current_transformation.invert() {
-            program.use_uniform_if_required("normalMatrix", inverse.transpose());
-        } else {
-            // determinant is float zero
-            return;
+        if program.requires_uniform("normalMatrix") {
+            if let Some(inverse) = self.current_transformation.invert() {
+                program.use_uniform("normalMatrix", inverse.transpose());
+            } else {
+                // determinant is float zero
+                return;
+            }
         }
 
         program.use_uniform("viewProjection", camera.projection() * camera.view());


### PR DESCRIPTION
* `Mesh::draw` now returns early if the determinant of `self.current_transformation` is float zero, since this was causing a panic.

Fixes #317 