### PR TITLE
Custom `Event::UserEvent(T)` support

### DIFF
--- a/examples/instanced_draw_order/src/main.rs
+++ b/examples/instanced_draw_order/src/main.rs
@@ -125,7 +125,7 @@ pub fn main() {
     let light0 = DirectionalLight::new(&context, 1.0, Color::WHITE, &vec3(0.0, -0.5, -0.5));
     let ambient_light = three_d::renderer::light::AmbientLight::new(&context, 0.1, Color::WHITE);
 
-    window.render_loop(move |mut frame_input: FrameInput| {
+    window.render_loop(move |mut frame_input| {
         camera.set_viewport(frame_input.viewport);
         control.handle_events(&mut camera, &mut frame_input.events);
 

--- a/examples/instanced_shapes/src/main.rs
+++ b/examples/instanced_shapes/src/main.rs
@@ -49,7 +49,7 @@ pub fn main() {
     let mut is_instanced = false;
 
     let mut gui = three_d::GUI::new(&context);
-    window.render_loop(move |mut frame_input: FrameInput| {
+    window.render_loop(move |mut frame_input| {
         // Gui panel to control the number of cubes and whether or not instancing is turned on.
         let mut panel_width = 0.0;
         gui.update(

--- a/examples/logo/src/main.rs
+++ b/examples/logo/src/main.rs
@@ -58,7 +58,7 @@ pub async fn run() {
     // Construct a model, with a default color material, thereby transferring the mesh data to the GPU
     let model = Gm::new(Mesh::new(&context, &cpu_mesh), ColorMaterial::default());
 
-    window.render_loop(move |frame_input: FrameInput| {
+    window.render_loop(move |frame_input| {
         let viewport = Viewport {
             x: (frame_input.viewport.width / 2 - frame_input.viewport.height / 2) as i32,
             y: 0,

--- a/examples/multisample/src/main.rs
+++ b/examples/multisample/src/main.rs
@@ -75,7 +75,7 @@ pub fn main() {
 
     let mut gui = three_d::GUI::new(&context);
 
-    window.render_loop(move |mut frame_input: FrameInput| {
+    window.render_loop(move |mut frame_input| {
         camera.set_viewport(frame_input.viewport);
 
         let mut panel_width = 0.0;

--- a/examples/screen/src/main.rs
+++ b/examples/screen/src/main.rs
@@ -38,7 +38,7 @@ pub fn main() {
     let mut gui = three_d::GUI::new(&context);
     let mut viewport_zoom = 1.0;
     let mut scissor_zoom = 1.0;
-    window.render_loop(move |mut frame_input: FrameInput| {
+    window.render_loop(move |mut frame_input| {
         model.set_transformation(Mat4::from_angle_y(radians(
             (frame_input.accumulated_time * 0.005) as f32,
         )));

--- a/examples/shapes/src/main.rs
+++ b/examples/shapes/src/main.rs
@@ -95,7 +95,7 @@ pub fn main() {
     let light0 = DirectionalLight::new(&context, 1.0, Color::WHITE, &vec3(0.0, -0.5, -0.5));
     let light1 = DirectionalLight::new(&context, 1.0, Color::WHITE, &vec3(0.0, 0.5, 0.5));
 
-    window.render_loop(move |mut frame_input: FrameInput| {
+    window.render_loop(move |mut frame_input| {
         camera.set_viewport(frame_input.viewport);
         control.handle_events(&mut camera, &mut frame_input.events);
 

--- a/examples/shapes2d/src/main.rs
+++ b/examples/shapes2d/src/main.rs
@@ -39,7 +39,7 @@ pub fn main() {
         },
     );
 
-    window.render_loop(move |frame_input: FrameInput| {
+    window.render_loop(move |frame_input| {
         for event in frame_input.events.iter() {
             match event {
                 Event::MousePress {

--- a/examples/sprites/src/main.rs
+++ b/examples/sprites/src/main.rs
@@ -72,7 +72,7 @@ pub async fn run() {
 
     let ambient = AmbientLight::new(&context, 1.0, Color::WHITE);
 
-    window.render_loop(move |mut frame_input: FrameInput| {
+    window.render_loop(move |mut frame_input| {
         camera.set_viewport(frame_input.viewport);
         control.handle_events(&mut camera, &mut frame_input.events);
 

--- a/examples/triangle/src/main.rs
+++ b/examples/triangle/src/main.rs
@@ -48,7 +48,7 @@ pub fn main() {
 
     // Start the main render loop
     window.render_loop(
-        move |frame_input: FrameInput| // Begin a new frame with an updated frame input
+        move |frame_input| // Begin a new frame with an updated frame input
     {
         // Ensure the viewport matches the current window viewport which changes if the window is resized
         camera.set_viewport(frame_input.viewport);

--- a/src/gui/egui_gui.rs
+++ b/src/gui/egui_gui.rs
@@ -44,9 +44,9 @@ impl GUI {
     /// Construct the GUI (Add panels, widgets etc.) using the [egui::Context] in the callback function.
     /// This function returns whether or not the GUI has changed, ie. if it consumes any events, and therefore needs to be rendered again.
     ///
-    pub fn update(
+    pub fn update<T: 'static + Clone>(
         &mut self,
-        events: &mut [Event],
+        events: &mut [Event<T>],
         accumulated_time_in_ms: f64,
         viewport: Viewport,
         device_pixel_ratio: f64,

--- a/src/renderer/control.rs
+++ b/src/renderer/control.rs
@@ -31,7 +31,7 @@ pub enum MouseButton {
 
 /// An input event (from mouse, keyboard or similar).
 #[derive(Clone, Debug)]
-pub enum Event {
+pub enum Event<T: 'static + Clone> {
     /// Fired when a button is pressed or the screen is touched.
     MousePress {
         /// Type of button
@@ -115,6 +115,8 @@ pub enum Event {
     },
     /// Fires when some text has been written.
     Text(String),
+    /// User created custom event.
+    UserEvent(T),
 }
 
 /// Keyboard key input.

--- a/src/renderer/control/camera_control.rs
+++ b/src/renderer/control/camera_control.rs
@@ -102,7 +102,10 @@ impl CameraControl {
     }
 
     /// Handles the events. Must be called each frame.
-    pub fn handle_events(&mut self, camera: &mut Camera, events: &mut [Event]) -> bool {
+    pub fn handle_events<T>(&mut self, camera: &mut Camera, events: &mut [Event<T>]) -> bool
+    where
+        T: 'static + Clone,
+    {
         let mut change = false;
         for event in events.iter_mut() {
             match event {

--- a/src/renderer/control/first_person_control.rs
+++ b/src/renderer/control/first_person_control.rs
@@ -26,7 +26,10 @@ impl FirstPersonControl {
     }
 
     /// Handles the events. Must be called each frame.
-    pub fn handle_events(&mut self, camera: &mut Camera, events: &mut [Event]) -> bool {
+    pub fn handle_events<T>(&mut self, camera: &mut Camera, events: &mut [Event<T>]) -> bool
+    where
+        T: 'static + Clone,
+    {
         self.control.handle_events(camera, events)
     }
 }

--- a/src/renderer/control/fly_control.rs
+++ b/src/renderer/control/fly_control.rs
@@ -28,7 +28,10 @@ impl FlyControl {
     }
 
     /// Handles the events. Must be called each frame.
-    pub fn handle_events(&mut self, camera: &mut Camera, events: &mut [Event]) -> bool {
+    pub fn handle_events<T>(&mut self, camera: &mut Camera, events: &mut [Event<T>]) -> bool
+    where
+        T: 'static + Clone,
+    {
         self.control.handle_events(camera, events)
     }
 }

--- a/src/renderer/control/orbit_control.rs
+++ b/src/renderer/control/orbit_control.rs
@@ -27,7 +27,10 @@ impl OrbitControl {
     }
 
     /// Handles the events. Must be called each frame.
-    pub fn handle_events(&mut self, camera: &mut Camera, events: &mut [Event]) -> bool {
+    pub fn handle_events<T>(&mut self, camera: &mut Camera, events: &mut [Event<T>]) -> bool
+    where
+        T: 'static + Clone,
+    {
         if let CameraAction::Zoom {
             speed,
             target,

--- a/src/window/test_window.rs
+++ b/src/window/test_window.rs
@@ -14,9 +14,9 @@ pub use inner_mod::FrameOutput;
 /// Input from the window to the rendering (and whatever else needs it) each frame.
 ///
 #[derive(Clone)]
-pub struct FrameInput<'a> {
+pub struct FrameInput<'a, T: 'static + Clone> {
     /// A list of [events](crate::Event) which has occurred since last frame.
-    pub events: Vec<Event>,
+    pub events: Vec<Event<T>>,
 
     /// Milliseconds since last frame.
     pub elapsed_time: f64,
@@ -46,13 +46,19 @@ pub struct FrameInput<'a> {
     pub render_target: std::rc::Rc<RenderTarget<'a>>,
 }
 
-impl<'a> FrameInput<'a> {
+impl<'a, T> FrameInput<'a, T>
+where
+    T: 'static + Clone,
+{
     pub fn screen(&'a self) -> &'a RenderTarget {
         self.render_target.as_ref()
     }
 }
 
-impl std::fmt::Debug for FrameInput<'_> {
+impl<T> std::fmt::Debug for FrameInput<'_, T>
+where
+    T: 'static + Clone,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut d = f.debug_struct("FrameInput");
         d.finish()
@@ -75,7 +81,10 @@ impl Window {
         })
     }
 
-    pub fn render_loop(self, mut callback: impl 'static + FnMut(FrameInput) -> FrameOutput) {
+    pub fn render_loop<T>(self, mut callback: impl 'static + FnMut(FrameInput<T>) -> FrameOutput)
+    where
+        T: 'static + Clone,
+    {
         let exit_time = if let Ok(v) = std::env::var("THREE_D_EXIT") {
             v.parse::<f64>().unwrap()
         } else {

--- a/src/window/test_window.rs
+++ b/src/window/test_window.rs
@@ -68,20 +68,24 @@ where
 ///
 /// Only for testing purposes!
 ///
-pub struct Window {
+pub struct Window<T> {
     context: HeadlessContext,
     size: (u32, u32),
+    phantom: std::marker::PhantomData<T>,
 }
 
-impl Window {
-    pub fn new(window_settings: WindowSettings) -> Result<Self, HeadlessError> {
-        Ok(Self {
+impl Window<()> {
+    pub fn new(window_settings: WindowSettings) -> Result<Window<()>, HeadlessError> {
+        Ok(Window::<()> {
             context: HeadlessContext::new()?,
             size: window_settings.max_size.unwrap_or(window_settings.min_size),
+            phantom: std::marker::PhantomData,
         })
     }
+}
 
-    pub fn render_loop<T>(self, mut callback: impl 'static + FnMut(FrameInput<T>) -> FrameOutput)
+impl<T> Window<T> {
+    pub fn render_loop(self, mut callback: impl 'static + FnMut(FrameInput<T>) -> FrameOutput)
     where
         T: 'static + Clone,
     {

--- a/src/window/winit_window/frame_io.rs
+++ b/src/window/winit_window/frame_io.rs
@@ -5,9 +5,9 @@ use crate::core::*;
 /// Input from the window to the rendering (and whatever else needs it) each frame.
 ///
 #[derive(Clone, Debug)]
-pub struct FrameInput {
+pub struct FrameInput<T: 'static + Clone> {
     /// A list of [events](crate::Event) which has occurred since last frame.
-    pub events: Vec<Event>,
+    pub events: Vec<Event<T>>,
 
     /// Milliseconds since last frame.
     pub elapsed_time: f64,
@@ -34,7 +34,7 @@ pub struct FrameInput {
     pub context: Context,
 }
 
-impl FrameInput {
+impl<T: 'static + Clone> FrameInput<T> {
     ///
     /// Returns the screen render target, which is used for drawing to the screen, for this window.
     /// Same as


### PR DESCRIPTION
RE: #320 - Winit custom event support

This PR adds support for sending custom events into the winit `EventLoop`. This is handy when you want to wake up the event loop from another thread (eg. in response to some IO).

* Plain old `new` constructors return `Window<()>`, so existing code still works.
* `Window::from_winit_window` can be used to create a `Window` from winit and an event loop, with or without a custom event.
* add `control::Event::<T>::UserEvent(T)` variant
* `CameraControl::handle_events` ->  `handle_events<T>`
* `FirstPersonControl::handle_events` -> `handle_events<T>`
* `GUI::update` -> `GUI::update<T>`
* `FlyControl::handle_events` -> `handle_events<T>`
* `OrbitControl::handle_events` -> `handle_events<T>`
* Handle `Event::UserEvent` in `Window::render_loop`
* `FrameInput` -> `FrameInput<T>` required removing a few type annotations from some examples. Type annotations might break with this change.
* add `Window::event_loop_proxy` method
* add `Window::from_event_loop`, allowing the caller to supply an existing `winit::event_loop::EventLoop`