### PR TITLE
Add explicit canvas size on web

### DIFF
--- a/src/window/winit_window/settings.rs
+++ b/src/window/winit_window/settings.rs
@@ -40,6 +40,22 @@ pub struct SurfaceSettings {
     /// Specify whether or not hardware acceleration is preferred, required, or
     /// off. The default is [HardwareAcceleration::Preferred].
     pub hardware_acceleration: HardwareAcceleration,
+    /// The fixed size which will be applied to the [canvas][WindowSettings::canvas], in logical pixels.
+    /// If `None` is specified, the canvas will be resized to the same size as
+    /// the owner `Window`'s inner width and height.
+    #[cfg(target_arch = "wasm32")]
+    pub size: Option<(u32, u32)>,
+}
+
+#[cfg(target_arch = "wasm32")]
+impl SurfaceSettings {
+    /// If `true`, the underlying [canvas element][web_sys::HtmlCanvasElement]
+    /// should be resized to cover the whole window. If `false`, the canvas
+    /// should not be resized.
+    #[inline]
+    pub(crate) fn cover_window(&self) -> bool {
+        self.size.is_none()
+    }
 }
 
 impl Default for SurfaceSettings {
@@ -50,6 +66,8 @@ impl Default for SurfaceSettings {
             stencil_buffer: 0,
             multisamples: 4,
             hardware_acceleration: HardwareAcceleration::Preferred,
+            #[cfg(target_arch = "wasm32")]
+            size: None,
         }
     }
 }
@@ -63,11 +81,12 @@ pub struct WindowSettings {
     ///
     /// On web this has no effect.
     pub title: String,
-    /// The minimum size of the window (width, height).
+    /// The minimum size of the window `(width, height)`, in logical pixels.
     ///
     /// On web this has no effect.
     pub min_size: (u32, u32),
-    /// The maximum size of the window (width, height). If None is specified, the window is maximized.
+    /// The maximum size of the window `(width, height)`, in logical pixels.
+    /// If `None` is specified, the window is maximized.
     ///
     /// On web this has no effect.
     pub max_size: Option<(u32, u32)>,
@@ -75,8 +94,8 @@ pub struct WindowSettings {
     ///
     /// On web this has no effect.
     pub borderless: bool,
-    /// An optional Canvas for using as winit window
-    /// if this is None, the DOM (`index.html`) must contain a canvas element
+    /// An optional [canvas element][web_sys::HtmlCanvasElement] for using as winit window.
+    /// If this is `None`, the DOM (`index.html`) must contain a canvas element
     #[cfg(target_arch = "wasm32")]
     pub canvas: Option<web_sys::HtmlCanvasElement>,
 

--- a/src/window/winit_window/windowed_context.rs
+++ b/src/window/winit_window/windowed_context.rs
@@ -35,20 +35,19 @@ mod inner {
         ) -> Result<Self, WindowError> {
             let canvas = window.canvas();
 
-            window.set_inner_size(winit::dpi::Size::Logical(winit::dpi::LogicalSize {
-                width: web_sys::window()
-                    .unwrap()
-                    .inner_width()
-                    .unwrap()
-                    .as_f64()
-                    .unwrap(),
-                height: web_sys::window()
-                    .unwrap()
-                    .inner_height()
-                    .unwrap()
-                    .as_f64()
-                    .unwrap(),
-            }));
+            if settings.cover_window() {
+                let html_canvas = window.canvas();
+                let browser_window = html_canvas
+                    .owner_document()
+                    .and_then(|doc| doc.default_view())
+                    .or_else(web_sys::window)
+                    .unwrap();
+
+                window.set_inner_size(winit::dpi::LogicalSize {
+                    width: browser_window.inner_width().unwrap().as_f64().unwrap(),
+                    height: browser_window.inner_height().unwrap().as_f64().unwrap(),
+                });
+            }
 
             // get webgl context and verify extensions
             let webgl_context = canvas


### PR DESCRIPTION
This is the minimal change I could figure out to make (other than completely deleting the `set_inner_size` calls) which lets me set a specific canvas size, and have the canvas not cover the entire browser window.

I ended up adding `size` to `SurfaceSettings`, as that’s the only type available both during `Window` setup and `WindowedContext` setup. I don‘t think this is a great API change by any means; just a concrete starting point.

Closes #339.