### PR TITLE
Support matrices in vertex and instance buffers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,10 @@ name = "shapes"
 path = "examples/shapes/src/main.rs"
 
 [[example]]
+name = "instanced_core"
+path = "examples/instanced_core/src/main.rs"
+
+[[example]]
 name = "instanced_draw_order"
 path = "examples/instanced_draw_order/src/main.rs"
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -43,7 +43,7 @@ This is the recommended starting point for a gentle introduction to `three-d`.
 
 ## Triangle core [[code](https://github.com/asny/three-d/tree/master/examples/triangle_core/src/main.rs)] [[demo](https://asny.github.io/three-d/0.16/triangle_core.html)]
 
-This is the same as the `Triangle` example, except it only uses the core module and not the renderer module.
+This is the same as the `Triangle` example, except it only uses the [`core`][core-module] module and not the higher-level `renderer` module.
 
 ![Triangle core example](https://asny.github.io/three-d/0.16/triangle_core.png)
 
@@ -68,6 +68,12 @@ This example shows how depth ordering is currently working for `InstancedMesh` o
 ## Instanced Shapes [[code](https://github.com/asny/three-d/tree/master/examples/instanced_shapes/src/main.rs)] [[demo](https://asny.github.io/three-d/0.16/instanced_shapes.html)]
 
 ![Instanced Shapes example](https://asny.github.io/three-d/0.16/instanced_shapes.png)
+
+## Instanced core [[code](https://github.com/asny/three-d/tree/master/examples/instanced_core/src/main.rs)] [[demo](https://asny.github.io/three-d/0.16/instanced_core.html)]
+
+An example of how to do instanced drawing using the [`core`][core-module] module.
+
+![Instanced core example](https://asny.github.io/three-d/0.16/instanced_core.png)
 
 ## Screen [[code](https://github.com/asny/three-d/tree/master/examples/screen/src/main.rs)] [[demo](https://asny.github.io/three-d/0.16/screen.html)]
 
@@ -166,3 +172,5 @@ Shows how to create multiple [winit](https://crates.io/crates/winit) windows and
 ## Headless [[code](https://github.com/asny/three-d/tree/master/examples/headless/src/main.rs)]
 
 This example does not create a window but render directly to a render target and saves the result to disk. Therefore, this example does not work on web.
+
+[core-module]: https://docs.rs/three-d/latest/three_d/core/index.html

--- a/examples/instanced_core/Cargo.toml
+++ b/examples/instanced_core/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "instanced_core"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+three-d = { path = "../../" }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+log = "0.4"
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+console_error_panic_hook = "0.1"
+console_log = "0.2"

--- a/examples/instanced_core/src/cross.frag
+++ b/examples/instanced_core/src/cross.frag
@@ -1,0 +1,18 @@
+in vec4 v_color;
+out vec4 fragColor;
+
+vec3 srgb_from_rgb(vec3 rgb) {
+    vec3 a = vec3(0.055, 0.055, 0.055);
+    vec3 ap1 = vec3(1.0, 1.0, 1.0) + a;
+    vec3 g = vec3(2.4, 2.4, 2.4);
+    vec3 ginv = 1.0 / g;
+    vec3 select = step(vec3(0.0031308, 0.0031308, 0.0031308), rgb);
+    vec3 lo = rgb * 12.92;
+    vec3 hi = ap1 * pow(rgb, ginv) - a;
+    return mix(lo, hi, select);
+}
+
+void main() {
+    fragColor = v_color;
+    fragColor.rgb = srgb_from_rgb(fragColor.rgb);
+}

--- a/examples/instanced_core/src/cross.vert
+++ b/examples/instanced_core/src/cross.vert
@@ -1,0 +1,11 @@
+in vec3 position;
+in vec4 color;
+in mat4 instance;
+uniform mat4 viewProjection;
+out vec4 v_color;
+
+void main() {
+    gl_Position = viewProjection * instance * vec4(position, 1.0);
+
+    v_color = color;
+}

--- a/examples/instanced_core/src/lib.rs
+++ b/examples/instanced_core/src/lib.rs
@@ -1,0 +1,19 @@
+#![allow(special_module_name)]
+mod main;
+
+// Entry point for wasm
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen(start)]
+pub fn start() -> Result<(), JsValue> {
+    std::panic::set_hook(Box::new(console_error_panic_hook::hook));
+    console_log::init_with_level(log::Level::Debug).unwrap();
+
+    use log::info;
+    info!("Logging works!");
+
+    main::main();
+    Ok(())
+}

--- a/examples/instanced_core/src/main.rs
+++ b/examples/instanced_core/src/main.rs
@@ -1,9 +1,8 @@
 use three_d::core::{
-    degrees, radians, vec3, Camera, ClearState, Color, Context, ElementBuffer, Mat4, Program,
-    RenderStates, VertexBuffer,
+    degrees, radians, vec3, Camera, ClearState, Color, Context, ElementBuffer, InstanceBuffer,
+    Mat4, Program, RenderStates, VertexBuffer,
 };
 use three_d::window::{FrameOutput, Window, WindowSettings};
-use three_d::InstanceBuffer;
 
 pub fn main() {
     // Create a window (a canvas on web)
@@ -34,6 +33,7 @@ pub fn main() {
     );
     let indices = ElementBuffer::new_with_data(&context, &[0u16, 1, 2, 0, 2, 3, 4, 5, 6, 6, 5, 7]);
 
+    // Define 5 + instances
     let translations = vec![
         Mat4::from_translation(vec3(-0.5, 0.0, 0.0)),
         Mat4::from_translation(vec3(-0.25, 0.0, 0.1)),
@@ -41,6 +41,7 @@ pub fn main() {
         Mat4::from_translation(vec3(0.25, 0.0, 0.3)),
         Mat4::from_translation(vec3(0.5, 0.0, 0.4)),
     ];
+    // Create a mutable buffer which will hold frame-by-frame instance matrices
     let mut instances = translations.clone();
     let mut instance_buffer = InstanceBuffer::new_with_data(&context, &instances[..]);
     let instance_count = instances.len();

--- a/examples/instanced_core/src/main.rs
+++ b/examples/instanced_core/src/main.rs
@@ -1,0 +1,104 @@
+use three_d::core::{
+    degrees, radians, vec3, Camera, ClearState, Color, Context, ElementBuffer, Mat4, Program,
+    RenderStates, VertexBuffer,
+};
+use three_d::window::{FrameOutput, Window, WindowSettings};
+use three_d::InstanceBuffer;
+
+pub fn main() {
+    // Create a window (a canvas on web)
+    let window = Window::new(WindowSettings {
+        title: "Core Instances!".to_string(),
+        #[cfg(not(target_arch = "wasm32"))]
+        max_size: Some((1280, 720)),
+        ..Default::default()
+    })
+    .unwrap();
+
+    // Get the graphics context from the window
+    let context: Context = window.gl();
+
+    // Define a + shape
+    let vertices = VertexBuffer::new_with_data(
+        &context,
+        &[
+            vec3(-0.1, 0.4, 0.0),
+            vec3(-0.1, -0.4, 0.0),
+            vec3(0.1, -0.4, 0.0),
+            vec3(0.1, 0.4, 0.0),
+            vec3(-0.4, -0.1, 0.0),
+            vec3(0.4, -0.1, 0.0),
+            vec3(-0.4, 0.1, 0.0),
+            vec3(0.4, 0.1, 0.0),
+        ],
+    );
+    let indices = ElementBuffer::new_with_data(&context, &[0u16, 1, 2, 0, 2, 3, 4, 5, 6, 6, 5, 7]);
+
+    let translations = vec![
+        Mat4::from_translation(vec3(-0.5, 0.0, 0.0)),
+        Mat4::from_translation(vec3(-0.25, 0.0, 0.1)),
+        Mat4::from_translation(vec3(0.0, 0.0, 0.2)),
+        Mat4::from_translation(vec3(0.25, 0.0, 0.3)),
+        Mat4::from_translation(vec3(0.5, 0.0, 0.4)),
+    ];
+    let mut instances = translations.clone();
+    let mut instance_buffer = InstanceBuffer::new_with_data(&context, &instances[..]);
+    let instance_count = instances.len();
+    let colors = InstanceBuffer::new_with_data(
+        &context,
+        &[
+            Color::new_opaque(107, 144, 128),
+            Color::new_opaque(164, 195, 178),
+            Color::new_opaque(204, 227, 222),
+            Color::new_opaque(234, 244, 244),
+            Color::new_opaque(246, 255, 248),
+        ],
+    );
+
+    let program = Program::from_source(
+        &context,
+        include_str!("cross.vert"),
+        include_str!("cross.frag"),
+    )
+    .unwrap();
+
+    let mut camera = Camera::new_perspective(
+        window.viewport(),
+        vec3(0.0, 0.0, 2.0),
+        vec3(0.0, 0.0, 0.0),
+        vec3(0.0, 1.0, 0.0),
+        degrees(45.0),
+        0.1,
+        10.0,
+    );
+
+    window.render_loop(move |frame_input| {
+        camera.set_viewport(frame_input.viewport);
+
+        frame_input
+            .screen()
+            // Clear the color and depth of the screen render target
+            .clear(ClearState::color_and_depth(0.8, 0.8, 0.8, 1.0, 1.0))
+            .write(|| {
+                let time = frame_input.accumulated_time as f32;
+                for i in 0..instance_count {
+                    instances[i] = translations[i]
+                        * Mat4::from_angle_z(radians((i as f32 + 1.0) * 0.00005 * time));
+                }
+                instance_buffer.fill(&instances[..]);
+
+                program.use_uniform("viewProjection", camera.projection() * camera.view());
+                program.use_vertex_attribute("position", &vertices);
+                program.use_instance_attribute("instance", &instance_buffer);
+                program.use_instance_attribute("color", &colors);
+                program.draw_elements_instanced(
+                    RenderStates::default(),
+                    frame_input.viewport,
+                    &indices,
+                    instance_count as u32,
+                );
+            });
+
+        FrameOutput::default()
+    });
+}

--- a/src/core/buffer.rs
+++ b/src/core/buffer.rs
@@ -117,9 +117,11 @@ impl Buffer {
         self.attribute_count
     }
 
-    pub fn attribute_slots(&self) -> impl Iterator<Item = (u32, i32)> + '_ {
+    /// Iterate the `index` and `offset` values for each `vertex_attrib_pointer`
+    /// call which needs to be made for this buffer's data type.
+    pub fn attribute_slots(&self, loc: u32) -> impl Iterator<Item = (u32, i32)> + '_ {
         let local_stride = self.stride / self.attribute_slot_count as i32;
-        (0..self.attribute_slot_count).map(move |i| (i, i as i32 * local_stride))
+        (0..self.attribute_slot_count).map(move |i| (loc + i, i as i32 * local_stride))
     }
 
     pub fn bind(&self) {

--- a/src/core/buffer/instance_buffer.rs
+++ b/src/core/buffer/instance_buffer.rs
@@ -51,6 +51,14 @@ impl InstanceBuffer {
         self.buffer.attribute_count()
     }
 
+    pub(in crate::core) fn attribute_slots(&self) -> impl Iterator<Item = (u32, i32)> + '_ {
+        self.buffer.attribute_slots()
+    }
+
+    pub(in crate::core) fn stride(&self) -> i32 {
+        self.buffer.stride
+    }
+
     pub(in crate::core) fn bind(&self) {
         self.buffer.bind();
     }
@@ -60,7 +68,7 @@ impl InstanceBuffer {
     }
 
     pub(in crate::core) fn data_size(&self) -> u32 {
-        self.buffer.data_size
+        self.buffer.data_size / self.buffer.attribute_slot_count
     }
 
     pub(in crate::core) fn normalized(&self) -> bool {

--- a/src/core/buffer/instance_buffer.rs
+++ b/src/core/buffer/instance_buffer.rs
@@ -51,8 +51,13 @@ impl InstanceBuffer {
         self.buffer.attribute_count()
     }
 
-    pub(in crate::core) fn attribute_slots(&self) -> impl Iterator<Item = (u32, i32)> + '_ {
-        self.buffer.attribute_slots()
+    /// Iterate the `index` and `offset` values for each `vertex_attrib_pointer`
+    /// call which needs to be made for this buffer's data type.
+    pub(in crate::core) fn attribute_slots(
+        &self,
+        loc: u32,
+    ) -> impl Iterator<Item = (u32, i32)> + '_ {
+        self.buffer.attribute_slots(loc)
     }
 
     pub(in crate::core) fn stride(&self) -> i32 {

--- a/src/core/buffer/vertex_buffer.rs
+++ b/src/core/buffer/vertex_buffer.rs
@@ -51,6 +51,14 @@ impl VertexBuffer {
         self.buffer.attribute_count()
     }
 
+    pub(in crate::core) fn attribute_slots(&self) -> impl Iterator<Item = (u32, i32)> + '_ {
+        self.buffer.attribute_slots()
+    }
+
+    pub(in crate::core) fn stride(&self) -> i32 {
+        self.buffer.stride
+    }
+
     pub(in crate::core) fn bind(&self) {
         self.buffer.bind();
     }
@@ -60,7 +68,7 @@ impl VertexBuffer {
     }
 
     pub(in crate::core) fn data_size(&self) -> u32 {
-        self.buffer.data_size
+        self.buffer.data_size / self.buffer.attribute_slot_count
     }
 
     pub(in crate::core) fn normalized(&self) -> bool {

--- a/src/core/buffer/vertex_buffer.rs
+++ b/src/core/buffer/vertex_buffer.rs
@@ -51,8 +51,13 @@ impl VertexBuffer {
         self.buffer.attribute_count()
     }
 
-    pub(in crate::core) fn attribute_slots(&self) -> impl Iterator<Item = (u32, i32)> + '_ {
-        self.buffer.attribute_slots()
+    /// Iterate the `index` and `offset` values for each `vertex_attrib_pointer`
+    /// call which needs to be made for this buffer's data type.
+    pub(in crate::core) fn attribute_slots(
+        &self,
+        loc: u32,
+    ) -> impl Iterator<Item = (u32, i32)> + '_ {
+        self.buffer.attribute_slots(loc)
     }
 
     pub(in crate::core) fn stride(&self) -> i32 {

--- a/src/core/data_type.rs
+++ b/src/core/data_type.rs
@@ -12,16 +12,21 @@ pub enum UniformType {
 }
 
 pub trait PrimitiveDataType: DataType + Copy + Default {
+    const SIZE: u32;
+
     fn send_uniform_with_type(
         context: &Context,
         location: &UniformLocation,
         data: &[Self],
         type_: UniformType,
     );
+
     fn internal_format_with_size(size: u32) -> u32;
 }
 
 impl PrimitiveDataType for u8 {
+    const SIZE: u32 = std::mem::size_of::<Self>() as u32;
+
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R8,
@@ -43,6 +48,8 @@ impl PrimitiveDataType for u8 {
     }
 }
 impl PrimitiveDataType for u16 {
+    const SIZE: u32 = std::mem::size_of::<Self>() as u32;
+
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R16UI,
@@ -64,6 +71,8 @@ impl PrimitiveDataType for u16 {
     }
 }
 impl PrimitiveDataType for u32 {
+    const SIZE: u32 = std::mem::size_of::<Self>() as u32;
+
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R32UI,
@@ -92,6 +101,8 @@ impl PrimitiveDataType for u32 {
     }
 }
 impl PrimitiveDataType for i8 {
+    const SIZE: u32 = std::mem::size_of::<Self>() as u32;
+
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R8I,
@@ -113,6 +124,8 @@ impl PrimitiveDataType for i8 {
     }
 }
 impl PrimitiveDataType for i16 {
+    const SIZE: u32 = std::mem::size_of::<Self>() as u32;
+
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R16I,
@@ -134,6 +147,8 @@ impl PrimitiveDataType for i16 {
     }
 }
 impl PrimitiveDataType for i32 {
+    const SIZE: u32 = std::mem::size_of::<Self>() as u32;
+
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R32I,
@@ -162,6 +177,8 @@ impl PrimitiveDataType for i32 {
     }
 }
 impl PrimitiveDataType for f16 {
+    const SIZE: u32 = std::mem::size_of::<Self>() as u32;
+
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R16F,
@@ -183,6 +200,8 @@ impl PrimitiveDataType for f16 {
     }
 }
 impl PrimitiveDataType for f32 {
+    const SIZE: u32 = std::mem::size_of::<Self>() as u32;
+
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R32F,
@@ -222,7 +241,13 @@ impl PrimitiveDataType for f32 {
 pub trait DataType: std::fmt::Debug + Clone {
     fn internal_format() -> u32;
     fn data_type() -> u32;
+    /// The number of primitive values which this datatype occupies.
+    ///
+    /// For scalar types, this is `1`. For (e.g.) [`Vector3`], this is `3`; and
+    /// for [`Matrix4`] this is `16`.
     fn size() -> u32;
+    /// The size of this type, in bytes.
+    fn bytes() -> u32;
     fn normalized() -> bool {
         false
     }
@@ -238,6 +263,9 @@ impl<T: DataType + ?Sized> DataType for &T {
     }
     fn size() -> u32 {
         T::size()
+    }
+    fn bytes() -> u32 {
+        T::bytes()
     }
     fn normalized() -> bool {
         T::normalized()
@@ -265,6 +293,10 @@ impl DataType for u8 {
         1
     }
 
+    fn bytes() -> u32 {
+        <Self as PrimitiveDataType>::SIZE * Self::size()
+    }
+
     fn send_uniform(context: &Context, location: &UniformLocation, data: &[Self]) {
         Self::send_uniform_with_type(context, location, data, UniformType::Value)
     }
@@ -280,6 +312,10 @@ impl DataType for u16 {
 
     fn size() -> u32 {
         1
+    }
+
+    fn bytes() -> u32 {
+        <Self as PrimitiveDataType>::SIZE * Self::size()
     }
 
     fn send_uniform(context: &Context, location: &UniformLocation, data: &[Self]) {
@@ -300,6 +336,10 @@ impl DataType for u32 {
         1
     }
 
+    fn bytes() -> u32 {
+        <Self as PrimitiveDataType>::SIZE * Self::size()
+    }
+
     fn send_uniform(context: &Context, location: &UniformLocation, data: &[Self]) {
         Self::send_uniform_with_type(context, location, data, UniformType::Value)
     }
@@ -316,6 +356,10 @@ impl DataType for i8 {
 
     fn size() -> u32 {
         1
+    }
+
+    fn bytes() -> u32 {
+        <Self as PrimitiveDataType>::SIZE * Self::size()
     }
 
     fn send_uniform(context: &Context, location: &UniformLocation, data: &[Self]) {
@@ -336,6 +380,10 @@ impl DataType for i16 {
         1
     }
 
+    fn bytes() -> u32 {
+        <Self as PrimitiveDataType>::SIZE * Self::size()
+    }
+
     fn send_uniform(context: &Context, location: &UniformLocation, data: &[Self]) {
         Self::send_uniform_with_type(context, location, data, UniformType::Value)
     }
@@ -354,6 +402,10 @@ impl DataType for i32 {
         1
     }
 
+    fn bytes() -> u32 {
+        <Self as PrimitiveDataType>::SIZE * Self::size()
+    }
+
     fn send_uniform(context: &Context, location: &UniformLocation, data: &[Self]) {
         Self::send_uniform_with_type(context, location, data, UniformType::Value)
     }
@@ -369,6 +421,10 @@ impl DataType for f16 {
 
     fn size() -> u32 {
         1
+    }
+
+    fn bytes() -> u32 {
+        <Self as PrimitiveDataType>::SIZE * Self::size()
     }
 
     fn send_uniform(context: &Context, location: &UniformLocation, data: &[Self]) {
@@ -389,6 +445,10 @@ impl DataType for f32 {
         1
     }
 
+    fn bytes() -> u32 {
+        <Self as PrimitiveDataType>::SIZE * Self::size()
+    }
+
     fn send_uniform(context: &Context, location: &UniformLocation, data: &[Self]) {
         Self::send_uniform_with_type(context, location, data, UniformType::Value)
     }
@@ -405,6 +465,10 @@ impl<T: PrimitiveDataType> DataType for Vector2<T> {
 
     fn size() -> u32 {
         2
+    }
+
+    fn bytes() -> u32 {
+        T::SIZE * Self::size()
     }
 
     fn send_uniform(context: &Context, location: &UniformLocation, data: &[Self]) {
@@ -426,6 +490,10 @@ impl<T: PrimitiveDataType> DataType for [T; 2] {
         2
     }
 
+    fn bytes() -> u32 {
+        T::SIZE * Self::size()
+    }
+
     fn send_uniform(context: &Context, location: &UniformLocation, data: &[Self]) {
         let data = data.iter().flatten().copied().collect::<Vec<_>>();
         T::send_uniform_with_type(context, location, &data, UniformType::Vec2)
@@ -442,6 +510,10 @@ impl<T: PrimitiveDataType> DataType for Vector3<T> {
 
     fn size() -> u32 {
         3
+    }
+
+    fn bytes() -> u32 {
+        T::SIZE * Self::size()
     }
 
     fn send_uniform(context: &Context, location: &UniformLocation, data: &[Self]) {
@@ -465,6 +537,10 @@ impl<T: PrimitiveDataType> DataType for [T; 3] {
         3
     }
 
+    fn bytes() -> u32 {
+        T::SIZE * Self::size()
+    }
+
     fn send_uniform(context: &Context, location: &UniformLocation, data: &[Self]) {
         let data = data.iter().flatten().copied().collect::<Vec<_>>();
         T::send_uniform_with_type(context, location, &data, UniformType::Vec3)
@@ -482,6 +558,10 @@ impl<T: PrimitiveDataType> DataType for Vector4<T> {
 
     fn size() -> u32 {
         4
+    }
+
+    fn bytes() -> u32 {
+        T::SIZE * Self::size()
     }
 
     fn send_uniform(context: &Context, location: &UniformLocation, data: &[Self]) {
@@ -506,6 +586,10 @@ impl<T: PrimitiveDataType> DataType for [T; 4] {
         4
     }
 
+    fn bytes() -> u32 {
+        T::SIZE * Self::size()
+    }
+
     fn send_uniform(context: &Context, location: &UniformLocation, data: &[Self]) {
         let data = data.iter().flatten().copied().collect::<Vec<_>>();
         T::send_uniform_with_type(context, location, &data, UniformType::Vec4)
@@ -523,6 +607,10 @@ impl<T: PrimitiveDataType> DataType for Quaternion<T> {
 
     fn size() -> u32 {
         4
+    }
+
+    fn bytes() -> u32 {
+        T::SIZE * Self::size()
     }
 
     fn send_uniform(context: &Context, location: &UniformLocation, data: &[Self]) {
@@ -545,6 +633,10 @@ impl DataType for Color {
 
     fn size() -> u32 {
         4
+    }
+
+    fn bytes() -> u32 {
+        <u8 as PrimitiveDataType>::SIZE * Self::size()
     }
 
     fn normalized() -> bool {
@@ -580,6 +672,10 @@ impl<T: PrimitiveDataType> DataType for Matrix2<T> {
         4
     }
 
+    fn bytes() -> u32 {
+        T::SIZE * Self::size()
+    }
+
     fn send_uniform(context: &Context, location: &UniformLocation, data: &[Self]) {
         let data = data
             .iter()
@@ -600,6 +696,10 @@ impl<T: PrimitiveDataType> DataType for Matrix3<T> {
 
     fn size() -> u32 {
         9
+    }
+
+    fn bytes() -> u32 {
+        T::SIZE * Self::size()
     }
 
     fn send_uniform(context: &Context, location: &UniformLocation, data: &[Self]) {
@@ -626,6 +726,10 @@ impl<T: PrimitiveDataType> DataType for Matrix4<T> {
 
     fn size() -> u32 {
         16
+    }
+
+    fn bytes() -> u32 {
+        T::SIZE * Self::size()
     }
 
     fn send_uniform(context: &Context, location: &UniformLocation, data: &[Self]) {

--- a/src/core/data_type.rs
+++ b/src/core/data_type.rs
@@ -12,7 +12,7 @@ pub enum UniformType {
 }
 
 pub trait PrimitiveDataType: DataType + Copy + Default {
-    const SIZE: u32;
+    const SIZE: u32 = std::mem::size_of::<Self>() as u32;
 
     fn send_uniform_with_type(
         context: &Context,
@@ -25,8 +25,6 @@ pub trait PrimitiveDataType: DataType + Copy + Default {
 }
 
 impl PrimitiveDataType for u8 {
-    const SIZE: u32 = std::mem::size_of::<Self>() as u32;
-
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R8,
@@ -48,8 +46,6 @@ impl PrimitiveDataType for u8 {
     }
 }
 impl PrimitiveDataType for u16 {
-    const SIZE: u32 = std::mem::size_of::<Self>() as u32;
-
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R16UI,
@@ -71,8 +67,6 @@ impl PrimitiveDataType for u16 {
     }
 }
 impl PrimitiveDataType for u32 {
-    const SIZE: u32 = std::mem::size_of::<Self>() as u32;
-
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R32UI,
@@ -101,8 +95,6 @@ impl PrimitiveDataType for u32 {
     }
 }
 impl PrimitiveDataType for i8 {
-    const SIZE: u32 = std::mem::size_of::<Self>() as u32;
-
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R8I,
@@ -124,8 +116,6 @@ impl PrimitiveDataType for i8 {
     }
 }
 impl PrimitiveDataType for i16 {
-    const SIZE: u32 = std::mem::size_of::<Self>() as u32;
-
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R16I,
@@ -147,8 +137,6 @@ impl PrimitiveDataType for i16 {
     }
 }
 impl PrimitiveDataType for i32 {
-    const SIZE: u32 = std::mem::size_of::<Self>() as u32;
-
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R32I,
@@ -177,8 +165,6 @@ impl PrimitiveDataType for i32 {
     }
 }
 impl PrimitiveDataType for f16 {
-    const SIZE: u32 = std::mem::size_of::<Self>() as u32;
-
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R16F,
@@ -200,8 +186,6 @@ impl PrimitiveDataType for f16 {
     }
 }
 impl PrimitiveDataType for f32 {
-    const SIZE: u32 = std::mem::size_of::<Self>() as u32;
-
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R32F,

--- a/src/core/program.rs
+++ b/src/core/program.rs
@@ -330,36 +330,43 @@ impl Program {
     pub fn use_vertex_attribute(&self, name: &str, buffer: &VertexBuffer) {
         if buffer.count() > 0 {
             buffer.bind();
-            let loc = self.location(name);
-            unsafe {
-                self.context.bind_vertex_array(Some(self.context.vao));
-                self.context.enable_vertex_attrib_array(loc);
-                if !buffer.normalized()
-                    && (buffer.data_type() == crate::context::UNSIGNED_BYTE
-                        || buffer.data_type() == crate::context::BYTE
-                        || buffer.data_type() == crate::context::UNSIGNED_SHORT
-                        || buffer.data_type() == crate::context::SHORT
-                        || buffer.data_type() == crate::context::UNSIGNED_INT
-                        || buffer.data_type() == crate::context::INT)
-                {
-                    self.context.vertex_attrib_pointer_i32(
-                        loc,
-                        buffer.data_size() as i32,
-                        buffer.data_type(),
-                        0,
-                        0,
-                    );
-                } else {
-                    self.context.vertex_attrib_pointer_f32(
-                        loc,
-                        buffer.data_size() as i32,
-                        buffer.data_type(),
-                        buffer.normalized(),
-                        0,
-                        0,
-                    );
+            let base_loc = self.location(name);
+            let stride = buffer.stride();
+
+            for (i, offset) in buffer.attribute_slots() {
+                let loc = base_loc + i;
+                unsafe {
+                    self.context.bind_vertex_array(Some(self.context.vao));
+                    self.context.enable_vertex_attrib_array(loc);
+                    if !buffer.normalized()
+                        && (buffer.data_type() == crate::context::UNSIGNED_BYTE
+                            || buffer.data_type() == crate::context::BYTE
+                            || buffer.data_type() == crate::context::UNSIGNED_SHORT
+                            || buffer.data_type() == crate::context::SHORT
+                            || buffer.data_type() == crate::context::UNSIGNED_INT
+                            || buffer.data_type() == crate::context::INT)
+                    {
+                        self.context.vertex_attrib_pointer_i32(
+                            loc,
+                            buffer.data_size() as i32,
+                            buffer.data_type(),
+                            stride,
+                            offset,
+                        );
+                    } else {
+                        self.context.vertex_attrib_pointer_f32(
+                            loc,
+                            buffer.data_size() as i32,
+                            buffer.data_type(),
+                            buffer.normalized(),
+                            stride,
+                            offset,
+                        );
+                    }
+                    self.context.vertex_attrib_divisor(loc, 0);
                 }
-                self.context.vertex_attrib_divisor(loc, 0);
+            }
+            unsafe {
                 self.context.bind_buffer(crate::context::ARRAY_BUFFER, None);
             }
             self.unuse_program();
@@ -378,36 +385,43 @@ impl Program {
     pub fn use_instance_attribute(&self, name: &str, buffer: &InstanceBuffer) {
         if buffer.count() > 0 {
             buffer.bind();
-            let loc = self.location(name);
-            unsafe {
-                self.context.bind_vertex_array(Some(self.context.vao));
-                self.context.enable_vertex_attrib_array(loc);
-                if !buffer.normalized()
-                    && (buffer.data_type() == crate::context::UNSIGNED_BYTE
-                        || buffer.data_type() == crate::context::BYTE
-                        || buffer.data_type() == crate::context::UNSIGNED_SHORT
-                        || buffer.data_type() == crate::context::SHORT
-                        || buffer.data_type() == crate::context::UNSIGNED_INT
-                        || buffer.data_type() == crate::context::INT)
-                {
-                    self.context.vertex_attrib_pointer_i32(
-                        loc,
-                        buffer.data_size() as i32,
-                        buffer.data_type(),
-                        0,
-                        0,
-                    );
-                } else {
-                    self.context.vertex_attrib_pointer_f32(
-                        loc,
-                        buffer.data_size() as i32,
-                        buffer.data_type(),
-                        buffer.normalized(),
-                        0,
-                        0,
-                    );
+            let base_loc = self.location(name);
+            let stride = buffer.stride();
+
+            for (i, offset) in buffer.attribute_slots() {
+                let loc = base_loc + i;
+                unsafe {
+                    self.context.bind_vertex_array(Some(self.context.vao));
+                    self.context.enable_vertex_attrib_array(loc);
+                    if !buffer.normalized()
+                        && (buffer.data_type() == crate::context::UNSIGNED_BYTE
+                            || buffer.data_type() == crate::context::BYTE
+                            || buffer.data_type() == crate::context::UNSIGNED_SHORT
+                            || buffer.data_type() == crate::context::SHORT
+                            || buffer.data_type() == crate::context::UNSIGNED_INT
+                            || buffer.data_type() == crate::context::INT)
+                    {
+                        self.context.vertex_attrib_pointer_i32(
+                            loc,
+                            buffer.data_size() as i32,
+                            buffer.data_type(),
+                            stride,
+                            offset,
+                        );
+                    } else {
+                        self.context.vertex_attrib_pointer_f32(
+                            loc,
+                            buffer.data_size() as i32,
+                            buffer.data_type(),
+                            buffer.normalized(),
+                            stride,
+                            offset,
+                        );
+                    }
+                    self.context.vertex_attrib_divisor(loc, 1);
                 }
-                self.context.vertex_attrib_divisor(loc, 1);
+            }
+            unsafe {
                 self.context.bind_buffer(crate::context::ARRAY_BUFFER, None);
             }
             self.unuse_program();

--- a/src/core/program.rs
+++ b/src/core/program.rs
@@ -330,11 +330,9 @@ impl Program {
     pub fn use_vertex_attribute(&self, name: &str, buffer: &VertexBuffer) {
         if buffer.count() > 0 {
             buffer.bind();
-            let base_loc = self.location(name);
             let stride = buffer.stride();
 
-            for (i, offset) in buffer.attribute_slots() {
-                let loc = base_loc + i;
+            for (loc, offset) in buffer.attribute_slots(self.location(name)) {
                 unsafe {
                     self.context.bind_vertex_array(Some(self.context.vao));
                     self.context.enable_vertex_attrib_array(loc);
@@ -385,11 +383,9 @@ impl Program {
     pub fn use_instance_attribute(&self, name: &str, buffer: &InstanceBuffer) {
         if buffer.count() > 0 {
             buffer.bind();
-            let base_loc = self.location(name);
             let stride = buffer.stride();
 
-            for (i, offset) in buffer.attribute_slots() {
-                let loc = base_loc + i;
+            for (loc, offset) in buffer.attribute_slots(self.location(name)) {
                 unsafe {
                     self.context.bind_vertex_array(Some(self.context.vao));
                     self.context.enable_vertex_attrib_array(loc);


### PR DESCRIPTION
👋🏻 I’m working on my application which will perform instanced drawing with `core`, and (with my n00b naïveté) I was surprised that `BufferDataType` wasn’t implemented for `Mat4` or the other matrix types.

I learned that the `size` parameter of `vertexAttribPointer` only goes up to `4`, and if you want to pass in a matrix, you need to [use multiple pointers](https://stackoverflow.com/a/38853623). I also discovered that three-d’s `InstancedMesh` works around this by defining three `vec3` attributes `row1`, `row2`, and `row3`.

This PR implements `BufferDataType` for the matrix types. I did this by adding a new `ATTRIBUTE_SLOTS` associated constant, which is `1` except for matrix types. `DataType` also gets a `bytes()` method giving its size in bytes, so that it’s possible to specify the `vertexAttribPointer` `stride` explicitly.

`Program::use_instance_attribute` and `use_vertex_attribute` are then updated to make as many `vertexAttribPointer` calls as necessary, and `in mat4` (etc.) becomes possible to bind directly through `three_d::core`. 😄

This is my first attempt to add something to `core` so I hope it’s at least a starting point for something mergeable. 🙏🏻

To see if it works, I added a new `instanced_core` example which uses a `Mat4` instance buffer, by porting [a vanilla WebGL2 example](https://webgl2fundamentals.org/webgl/lessons/webgl-instanced-drawing.html) to three-d.

![crosses](https://user-images.githubusercontent.com/25393735/233226318-f78e79dd-92a2-401a-bf79-dd61398263f2.gif)

