### PR TITLE
priotirize osmesa over glutin conext builder

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,19 +71,19 @@ jobs:
             fi
           done
 
-headless:
-  runs-on: ubuntu-latest
-  steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/cargo@v1
-    - run: sudo apt-get update && sudo apt-get install -y xvfb
+  headless:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/cargo@v1
+      - run: sudo apt-get update && sudo apt-get install -y xvfb
 
-    - name: Install Rust Toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
 
-    - run: |
-        xvfb-run -a cargo run --example headless --features="headless"
+      - run: |
+          xvfb-run -a cargo run --example headless --features="headless"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,8 +75,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/cargo@v1
-      - run: sudo apt-get update && sudo apt-get install -y xvfb
 
       - name: Install Rust Toolchain
         uses: actions-rs/toolchain@v1
@@ -85,5 +83,8 @@ jobs:
           toolchain: stable
           override: true
 
-      - run: |
-          xvfb-run -a cargo run --example headless --features="headless"
+      - run: sudo apt-get update && sudo apt-get install -y xvfb
+
+      - name: Run
+        uses: actions-rs/cargo@v1
+        run: xvfb-run -a cargo run --example headless --features="headless"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions-rs/cargo@v1
 
       - name: Install Rust Toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,6 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions-rs/cargo@v1
 
       - name: Install Rust Toolchain
         uses: actions-rs/toolchain@v1
@@ -85,6 +86,4 @@ jobs:
 
       - run: sudo apt-get update && sudo apt-get install -y xvfb
 
-      - name: Run
-        uses: actions-rs/cargo@v1
-        run: xvfb-run -a cargo run --example headless --features="headless"
+      - run: xvfb-run -a cargo run --example headless --features="headless"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/cargo@v1
 
       - name: Install Rust Toolchain
         uses: actions-rs/toolchain@v1
@@ -76,7 +75,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/cargo@v1
 
       - name: Install Rust Toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,3 +70,20 @@ jobs:
               echo "::endgroup::"
             fi
           done
+
+headless:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/cargo@v1
+    - run: sudo apt-get update && sudo apt-get install -y xvfb
+
+    - name: Install Rust Toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+
+    - run: |
+        xvfb-run -a cargo run --example headless --features="headless"

--- a/src/core/render_target.rs
+++ b/src/core/render_target.rs
@@ -585,6 +585,8 @@ macro_rules! impl_render_target_core_extensions {
 impl_render_target_core_extensions!(RenderTarget<'a>);
 impl_render_target_core_extensions!(ColorTarget<'a>);
 impl_render_target_core_extensions!(DepthTarget<'a>);
-impl_render_target_core_extensions!(RenderTargetMultisample<C: TextureDataType, D: DepthTextureDataType>);
+impl_render_target_core_extensions!(
+    RenderTargetMultisample<C: TextureDataType, D: DepthTextureDataType>
+);
 impl_render_target_core_extensions!(ColorTargetMultisample<C: TextureDataType>);
 impl_render_target_core_extensions!(DepthTargetMultisample<D: DepthTextureDataType>);

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -357,7 +357,9 @@ macro_rules! impl_render_target_extensions {
 impl_render_target_extensions!(RenderTarget<'a>);
 impl_render_target_extensions!(ColorTarget<'a>);
 impl_render_target_extensions!(DepthTarget<'a>);
-impl_render_target_extensions!(RenderTargetMultisample<C: TextureDataType, D: DepthTextureDataType>);
+impl_render_target_extensions!(
+    RenderTargetMultisample<C: TextureDataType, D: DepthTextureDataType>
+);
 impl_render_target_extensions!(ColorTargetMultisample<C: TextureDataType>);
 impl_render_target_extensions!(DepthTargetMultisample<D: DepthTextureDataType>);
 

--- a/src/window/headless.rs
+++ b/src/window/headless.rs
@@ -88,7 +88,7 @@ fn build_context_osmesa<T1: ContextCurrentState>(
 #[cfg(target_os = "linux")]
 fn build_context<T1: ContextCurrentState>(
     cb: ContextBuilder<T1>,
-) -> Result<(glutin_029::Context<NotCurrent>), CreationError> {
+) -> Result<glutin_029::Context<NotCurrent>, CreationError> {
     // On unix operating systems, you should always try for surfaceless first,
     // and if that does not work, headless (pbuffers), and if that too fails,
     // finally osmesa.
@@ -96,13 +96,13 @@ fn build_context<T1: ContextCurrentState>(
     // If willing, you could attempt to use hidden windows instead of os mesa,
     // but note that you must handle events for the window that come on the
     // events loop.
-    
+
     /*
     let err1 = match build_context_surfaceless(cb.clone(), &el) {
         Ok(ctx) => return Ok((ctx, el)),
         Err(err) => err,
     };*/
-    
+
     let _err3 = match build_context_osmesa(cb.clone()) {
         Ok(ctx) => return Ok(ctx),
         Err(err) => err,

--- a/src/window/headless.rs
+++ b/src/window/headless.rs
@@ -121,7 +121,7 @@ fn build_context<T1: ContextCurrentState>(
 #[cfg(not(target_os = "linux"))]
 fn build_context<T1: ContextCurrentState>(
     cb: ContextBuilder<T1>,
-) -> Result<(glutin_029::Context<NotCurrent>, EventLoop<()>), CreationError> {
+) -> Result<glutin_029::Context<NotCurrent>, CreationError> {
     let el = EventLoop::new();
-    build_context_headless(cb.clone(), &el).map(|ctx| (ctx, el))
+    build_context_headless(cb.clone(), &el)
 }

--- a/src/window/headless.rs
+++ b/src/window/headless.rs
@@ -38,7 +38,7 @@ impl HeadlessContext {
     #[allow(unsafe_code)]
     pub fn new() -> Result<Self, HeadlessError> {
         let cb = ContextBuilder::new();
-        let (glutin_context, _el) = build_context(cb)?;
+        let glutin_context = build_context(cb)?;
         let glutin_context = unsafe { glutin_context.make_current().map_err(|(_, e)| e)? };
         let context = Context::from_gl_context(std::sync::Arc::new(unsafe {
             crate::context::Context::from_loader_function(|s| {
@@ -88,7 +88,7 @@ fn build_context_osmesa<T1: ContextCurrentState>(
 #[cfg(target_os = "linux")]
 fn build_context<T1: ContextCurrentState>(
     cb: ContextBuilder<T1>,
-) -> Result<(glutin_029::Context<NotCurrent>, EventLoop<()>), CreationError> {
+) -> Result<(glutin_029::Context<NotCurrent>), CreationError> {
     // On unix operating systems, you should always try for surfaceless first,
     // and if that does not work, headless (pbuffers), and if that too fails,
     // finally osmesa.
@@ -96,21 +96,22 @@ fn build_context<T1: ContextCurrentState>(
     // If willing, you could attempt to use hidden windows instead of os mesa,
     // but note that you must handle events for the window that come on the
     // events loop.
-    let el = EventLoop::new();
-
+    
     /*
     let err1 = match build_context_surfaceless(cb.clone(), &el) {
         Ok(ctx) => return Ok((ctx, el)),
         Err(err) => err,
     };*/
-
-    let err2 = match build_context_headless(cb.clone(), &el) {
-        Ok(ctx) => return Ok((ctx, el)),
+    
+    let _err3 = match build_context_osmesa(cb.clone()) {
+        Ok(ctx) => return Ok(ctx),
         Err(err) => err,
     };
 
-    let _err3 = match build_context_osmesa(cb) {
-        Ok(ctx) => return Ok((ctx, el)),
+    let el = EventLoop::new();
+
+    let err2 = match build_context_headless(cb, &el) {
+        Ok(ctx) => return Ok(ctx),
         Err(err) => err,
     };
 


### PR DESCRIPTION
From manual testing on a machine without a display backend, attempting to create `EventLoop` will cause a panic, thus preventing it from attempting to create an osmesa instance which could work without a display backend. Simply reordering the lines (and removing unnecessary passing of the event loop back to the caller) fixes the issue and it does attempt osmesa first.