### PR TITLE
Expose texture IDs as an escape-hatch for non-standard texture sources

### DIFF
--- a/src/core/texture/depth_texture2d.rs
+++ b/src/core/texture/depth_texture2d.rs
@@ -59,6 +59,11 @@ impl DepthTexture2D {
         DepthTarget::new_texture2d(&self.context, self)
     }
 
+    /// The id of this texture.
+    pub fn id(&self) -> crate::context::Texture {
+        self.id
+    }
+
     /// The width of this texture.
     pub fn width(&self) -> u32 {
         self.width

--- a/src/core/texture/depth_texture2d_array.rs
+++ b/src/core/texture/depth_texture2d_array.rs
@@ -63,6 +63,11 @@ impl DepthTexture2DArray {
         DepthTarget::new_texture_2d_array(&self.context, self, layer)
     }
 
+    /// The id of this texture.
+    pub fn id(&self) -> crate::context::Texture {
+        self.id
+    }
+
     /// The width of this texture.
     pub fn width(&self) -> u32 {
         self.width

--- a/src/core/texture/depth_texture_cube_map.rs
+++ b/src/core/texture/depth_texture_cube_map.rs
@@ -60,6 +60,11 @@ impl DepthTextureCubeMap {
         DepthTarget::new_texture_cube_map(&self.context, self, side)
     }
 
+    /// The id of this texture.
+    pub fn id(&self) -> crate::context::Texture {
+        self.id
+    }
+
     /// The width of this texture.
     pub fn width(&self) -> u32 {
         self.width

--- a/src/core/texture/texture2d.rs
+++ b/src/core/texture/texture2d.rs
@@ -145,6 +145,11 @@ impl Texture2D {
         ColorTarget::new_texture2d(&self.context, self, mip_level)
     }
 
+    /// The id of this texture.
+    pub fn id(&self) -> crate::context::Texture {
+        self.id
+    }
+
     /// The width of this texture.
     pub fn width(&self) -> u32 {
         self.width

--- a/src/core/texture/texture2d_array.rs
+++ b/src/core/texture/texture2d_array.rs
@@ -261,6 +261,11 @@ impl Texture2DArray {
         ColorTarget::new_texture_2d_array(&self.context, self, layers, mip_level)
     }
 
+    /// The id of this texture.
+    pub fn id(&self) -> crate::context::Texture {
+        self.id
+    }
+
     /// The width of this texture.
     pub fn width(&self) -> u32 {
         self.width

--- a/src/core/texture/texture3d.rs
+++ b/src/core/texture/texture3d.rs
@@ -144,6 +144,11 @@ impl Texture3D {
         self.generate_mip_maps();
     }
 
+    /// The id of this texture.
+    pub fn id(&self) -> crate::context::Texture {
+        self.id
+    }
+
     /// The width of this texture.
     pub fn width(&self) -> u32 {
         self.width

--- a/src/core/texture/texture_cube_map.rs
+++ b/src/core/texture/texture_cube_map.rs
@@ -462,9 +462,9 @@ impl TextureCubeMap {
             uniform vec3 up;
 
             in vec2 uvs;
-            
+
             layout (location = 0) out vec4 outColor;
-            
+
             void main()
             {
                 vec3 right = cross(direction, up);
@@ -510,6 +510,11 @@ impl TextureCubeMap {
         mip_level: Option<u32>,
     ) -> ColorTarget<'a> {
         ColorTarget::new_texture_cube_map(&self.context, self, sides, mip_level)
+    }
+
+    /// The id of this texture.
+    pub fn id(&self) -> crate::context::Texture {
+        self.id
     }
 
     /// The width of this texture.


### PR DESCRIPTION
This will allow binding of non-standard texture sources (e.g. `HtmlVideoElement`, `HtmlImageElement`, and `VideoFrame` on web) by calling the lower-level context operations outside of the texture struct's implementation, but keeping the management of textures consistent with the mid-level API.