### PR TITLE
Add method to retrieve the winit Window

### DIFF
--- a/src/window/winit_window.rs
+++ b/src/window/winit_window.rs
@@ -309,6 +309,13 @@ impl Window {
     }
 
     ///
+    /// Returns the winit window.
+    ///
+    pub fn window(&self) -> &winit::window::Window {
+        &self.window
+    }
+
+    ///
     /// Returns the graphics context for this window.
     ///
     pub fn gl(&self) -> Context {


### PR DESCRIPTION
Added the `window` method to retrieve the `winit` `Window`.
This can be useful to be able to manage the window.
Like `focus_window`, `request_user_attention`, `set_title`, ...