### PR TITLE
focus winit window on creation

### DIFF
--- a/src/window/winit_window.rs
+++ b/src/window/winit_window.rs
@@ -157,6 +157,7 @@ impl Window {
         };
 
         let winit_window = window_builder.build(&event_loop)?;
+        winit_window.focus_window();
         Self::from_winit_window(
             winit_window,
             event_loop,


### PR DESCRIPTION
As requested in #413, here is a PR to focus the winit window on creation.