### PR TITLE
get egui context

### DIFF
--- a/src/gui/egui_gui.rs
+++ b/src/gui/egui_gui.rs
@@ -40,6 +40,13 @@ impl GUI {
     }
 
     ///
+    /// Get the egui context.
+    ///
+    pub fn context(&self) -> &egui::Context {
+        &self.egui_context
+    }
+
+    ///
     /// Initialises a new frame of the GUI and handles events.
     /// Construct the GUI (Add panels, widgets etc.) using the [egui::Context] in the callback function.
     /// This function returns whether or not the GUI has changed, ie. if it consumes any events, and therefore needs to be rendered again.


### PR DESCRIPTION
PR to be able to get the egui context.
This is needed to be able to initialize some egui stuff before the render loop.