### PR TITLE
Fix screen example depth clipping issue in small viewport

### DIFF
--- a/examples/screen/src/main.rs
+++ b/examples/screen/src/main.rs
@@ -108,7 +108,7 @@ pub fn main() {
             .screen()
             .clear_partially(
                 secondary_viewport.into(),
-                ClearState::color(0.3, 0.3, 0.3, 1.0),
+                ClearState::color_and_depth(0.3, 0.3, 0.3, 1.0, 1.0),
             )
             .render_partially(secondary_viewport.into(), &camera, &model, &[]);
 


### PR DESCRIPTION
When resizing the window, at certain situations the depth buffer of the background will cause parts of the foreground viewport to be hidden. This happens because the depth buffer is not properly cleared.