### PR TITLE
Optimise full_screen_draw

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -67,6 +67,7 @@ pub(crate) fn full_screen_draw(
     render_states: RenderStates,
     viewport: Viewport,
 ) {
+    unsafe { context.bind_vertex_array(Some(context.vao)) };
     program.draw_arrays(render_states, viewport, 3);
 }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -67,25 +67,23 @@ pub(crate) fn full_screen_draw(
     render_states: RenderStates,
     viewport: Viewport,
 ) {
-    let position_buffer = VertexBuffer::new_with_data(
-        context,
-        &[
-            vec3(-3.0, -1.0, 0.0),
-            vec3(3.0, -1.0, 0.0),
-            vec3(0.0, 2.0, 0.0),
-        ],
-    );
-    program.use_vertex_attribute("position", &position_buffer);
     program.draw_arrays(render_states, viewport, 3);
 }
 
 pub(crate) fn full_screen_vertex_shader_source() -> &'static str {
     "
-        in vec3 position;
         out vec2 uvs;
         out vec4 col;
         void main()
         {
+            vec3 vertices[3] = vec3[3](
+                vec3(-3.0, -1.0, 0.0),
+                vec3(3.0, -1.0, 0.0),
+                vec3(0.0, 2.0, 0.0)
+            );
+
+            vec3 position = vertices[gl_VertexID];
+
             uvs = 0.5 * position.xy + 0.5;
             col = vec4(1.0);
             gl_Position = vec4(position, 1.0);

--- a/src/core/program.rs
+++ b/src/core/program.rs
@@ -429,6 +429,7 @@ impl Program {
         self.context.set_render_states(render_states);
         self.use_program();
         unsafe {
+            self.context.bind_vertex_array(Some(self.context.vao));
             self.context
                 .draw_arrays(crate::context::TRIANGLES, 0, count as i32);
             for location in self.attributes.values() {

--- a/src/core/program.rs
+++ b/src/core/program.rs
@@ -429,7 +429,6 @@ impl Program {
         self.context.set_render_states(render_states);
         self.use_program();
         unsafe {
-            self.context.bind_vertex_array(Some(self.context.vao));
             self.context
                 .draw_arrays(crate::context::TRIANGLES, 0, count as i32);
             for location in self.attributes.values() {


### PR DESCRIPTION
Get rid of the vertex buffer entirely, in favour of indexing vertex positions from an array within the vertex shader.

Before this patch full_screen_draw is taking 18% of my frame time (mostly in creating and destroying the vertex buffer multiple times per frame):
<img width="917" alt="Screenshot 2024-05-26 at 12 23 11" src="https://github.com/asny/three-d/assets/4706210/52268a92-df84-4f64-a580-d1ae4ad2d9af">

After the patch it is reduced to 6%:
<img width="906" alt="Screenshot 2024-05-26 at 12 24 07" src="https://github.com/asny/three-d/assets/4706210/e36d2b4a-8947-47c6-be9c-8fc3cfee7f46">

Note that my app is very heavy on post-process effects - I expect the majority of apps will not see quite such a major difference.