### PR TITLE
Add separate initial window size

### DIFF
--- a/src/window/winit_window/settings.rs
+++ b/src/window/winit_window/settings.rs
@@ -67,13 +67,16 @@ pub struct WindowSettings {
     ///
     /// On web this has no effect.
     pub min_size: (u32, u32),
-    /// The maximum and initial size of the window `(width, height)`, in logical pixels.
-    /// If `None` is specified, the window is maximized.
+    /// The maximum size of the window `(width, height)`, in logical pixels.
+    /// If `None` is specified, the window can be maximized.
+    pub max_size: Option<(u32, u32)>,
+    /// The initial size of the window `(width, height)`, in logical pixels.
+    /// If `None` is specified, defaults to max_size.
     ///
     /// On web, the size will be applied to the [canvas][WindowSettings::canvas], in logical pixels.
-    /// If `None` is specified, the canvas will be resized to the same size as
-    /// the owner `Window`'s inner width and height.
-    pub max_size: Option<(u32, u32)>,
+    /// If `None` is specified on both this and max_size, the canvas will be
+    /// resized to the same size as the owner `Window`'s inner width and height.
+    pub initial_size: Option<(u32, u32)>,
     /// Borderless mode.
     ///
     /// On web this has no effect.
@@ -92,6 +95,7 @@ impl Default for WindowSettings {
             title: "".to_string(),
             min_size: (2, 2),
             max_size: None,
+            initial_size: None,
             borderless: false,
             #[cfg(target_arch = "wasm32")]
             canvas: None,


### PR DESCRIPTION
This separates the initial window size from the max size setting, allowing a window to be created at a smaller size than its maximum. If the initial size is unspecified, it falls back on the max size, maintaining compatibility with existing configurations.

On web, the window is created from the initial size setting (falling back to max size). This may be undesired for most use cases, so a possible modification would be for the web version to ignore the initial size parameter and only use max size. However, applications can work around this by putting a platform macro on the incoming window configuration, so I felt it was likely unnecessary to create that difference in behavior.