### PR TITLE
Add free orbit camera

### DIFF
--- a/src/renderer/control.rs
+++ b/src/renderer/control.rs
@@ -10,6 +10,10 @@ mod orbit_control;
 #[doc(inline)]
 pub use orbit_control::*;
 
+mod free_orbit_control;
+#[doc(inline)]
+pub use free_orbit_control::*;
+
 mod first_person_control;
 #[doc(inline)]
 pub use first_person_control::*;

--- a/src/renderer/control/camera_control.rs
+++ b/src/renderer/control/camera_control.rs
@@ -19,6 +19,13 @@ pub enum CameraAction {
         /// The speed of the rotation.
         speed: f32,
     },
+    /// Freely orbits around the given target in the up direction as seen from the camera.
+    FreeOrbitUp {
+        /// The target of the rotation.
+        target: Vec3,
+        /// The speed of the rotation.
+        speed: f32,
+    },
     /// Rotate the camera around the vertical axis as seen from the camera.
     Yaw {
         /// The speed of the rotation.
@@ -26,6 +33,13 @@ pub enum CameraAction {
     },
     /// Orbits around the given target in the left direction as seen from the camera.
     OrbitLeft {
+        /// The target of the rotation.
+        target: Vec3,
+        /// The speed of the rotation.
+        speed: f32,
+    },
+    /// Freely orbits around the given target in the left direction as seen from the camera.
+    FreeOrbitLeft {
         /// The target of the rotation.
         target: Vec3,
         /// The speed of the rotation.
@@ -151,11 +165,17 @@ impl CameraControl {
             CameraAction::OrbitUp { speed, target } => {
                 camera.rotate_around_with_fixed_up(&target, 0.0, speed * x);
             }
+            CameraAction::FreeOrbitUp { speed, target } => {
+                camera.rotate_around(&target, 0.0, speed * x);
+            }
             CameraAction::Yaw { speed } => {
                 camera.yaw(radians(speed * x));
             }
             CameraAction::OrbitLeft { speed, target } => {
                 camera.rotate_around_with_fixed_up(&target, speed * x, 0.0);
+            }
+            CameraAction::FreeOrbitLeft { speed, target } => {
+                camera.rotate_around(&target, speed * x, 0.0);
             }
             CameraAction::Roll { speed } => {
                 camera.roll(radians(speed * x));

--- a/src/renderer/control/free_orbit_control.rs
+++ b/src/renderer/control/free_orbit_control.rs
@@ -37,9 +37,7 @@ impl FreeOrbitControl {
             let x = target.distance(*camera.position());
             *speed = 0.01 * x + 0.001;
         }
-        if let CameraAction::FreeOrbitUp { speed, target } =
-            &mut self.control.left_drag_vertical
-        {
+        if let CameraAction::FreeOrbitUp { speed, target } = &mut self.control.left_drag_vertical {
             let x = target.distance(*camera.position());
             *speed = 0.01 * x + 0.001;
         }

--- a/src/renderer/control/free_orbit_control.rs
+++ b/src/renderer/control/free_orbit_control.rs
@@ -1,0 +1,48 @@
+use crate::renderer::*;
+
+///
+/// A control that makes the camera orbit around a target, with no fixed up direction.
+///
+pub struct FreeOrbitControl {
+    control: CameraControl,
+}
+
+impl FreeOrbitControl {
+    /// Creates a new free orbit control with the given target and minimum and maximum distance to the target.
+    pub fn new(target: Vec3, min_distance: f32, max_distance: f32) -> Self {
+        Self {
+            control: CameraControl {
+                left_drag_horizontal: CameraAction::FreeOrbitLeft { target, speed: 0.1 },
+                left_drag_vertical: CameraAction::FreeOrbitUp { target, speed: 0.1 },
+                scroll_vertical: CameraAction::Zoom {
+                    min: min_distance,
+                    max: max_distance,
+                    speed: 0.1,
+                    target,
+                },
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Handles the events. Must be called each frame.
+    pub fn handle_events(&mut self, camera: &mut Camera, events: &mut [Event]) -> bool {
+        if let CameraAction::Zoom { speed, target, .. } = &mut self.control.scroll_vertical {
+            let x = target.distance(*camera.position());
+            *speed = 0.01 * x + 0.001;
+        }
+        if let CameraAction::FreeOrbitLeft { speed, target } =
+            &mut self.control.left_drag_horizontal
+        {
+            let x = target.distance(*camera.position());
+            *speed = 0.01 * x + 0.001;
+        }
+        if let CameraAction::FreeOrbitUp { speed, target } =
+            &mut self.control.left_drag_vertical
+        {
+            let x = target.distance(*camera.position());
+            *speed = 0.01 * x + 0.001;
+        }
+        self.control.handle_events(camera, events)
+    }
+}


### PR DESCRIPTION
The existing orbit camera preserves up direction. While in many cases that is useful in keeping a sense of direction, there are some cases where there is no up direction. This adds another camera control set similar to the existing orbit, but free to have any direction be up.