### PR TITLE
Add FrameInput::redraw_needed for handling window visibility changes

### DIFF
--- a/src/window/winit_window/frame_input_generator.rs
+++ b/src/window/winit_window/frame_input_generator.rs
@@ -28,6 +28,7 @@ pub struct FrameInputGenerator {
     secondary_finger_id: Option<u64>,
     modifiers: Modifiers,
     mouse_pressed: Option<MouseButton>,
+    redraw_needed: bool,
 }
 
 impl FrameInputGenerator {
@@ -52,6 +53,7 @@ impl FrameInputGenerator {
             secondary_finger_id: None,
             modifiers: Modifiers::default(),
             mouse_pressed: None,
+            redraw_needed: false,
         }
     }
 
@@ -83,9 +85,11 @@ impl FrameInputGenerator {
             device_pixel_ratio: self.device_pixel_ratio as f32,
             first_frame: self.first_frame,
             context: context.clone(),
+            redraw_needed: self.redraw_needed,
         };
         self.first_frame = false;
-
+        self.redraw_needed = false;
+        
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(exit_time) = option_env!("THREE_D_EXIT").map(|v| v.parse::<f64>().unwrap()) {
             if exit_time < frame_input.accumulated_time {
@@ -134,6 +138,9 @@ impl FrameInputGenerator {
                 let logical_size = new_inner_size.to_logical(self.device_pixel_ratio);
                 self.window_width = logical_size.width;
                 self.window_height = logical_size.height;
+            }
+            WindowEvent::Occluded(false) => {
+                self.redraw_needed = true;
             }
             WindowEvent::KeyboardInput { input, .. } => {
                 if let Some(keycode) = input.virtual_keycode {

--- a/src/window/winit_window/frame_input_generator.rs
+++ b/src/window/winit_window/frame_input_generator.rs
@@ -85,7 +85,7 @@ impl FrameInputGenerator {
             context: context.clone(),
         };
         self.first_frame = false;
-        
+
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(exit_time) = option_env!("THREE_D_EXIT").map(|v| v.parse::<f64>().unwrap()) {
             if exit_time < frame_input.accumulated_time {

--- a/src/window/winit_window/frame_input_generator.rs
+++ b/src/window/winit_window/frame_input_generator.rs
@@ -28,7 +28,6 @@ pub struct FrameInputGenerator {
     secondary_finger_id: Option<u64>,
     modifiers: Modifiers,
     mouse_pressed: Option<MouseButton>,
-    redraw_needed: bool,
 }
 
 impl FrameInputGenerator {
@@ -53,7 +52,6 @@ impl FrameInputGenerator {
             secondary_finger_id: None,
             modifiers: Modifiers::default(),
             mouse_pressed: None,
-            redraw_needed: false,
         }
     }
 
@@ -85,10 +83,8 @@ impl FrameInputGenerator {
             device_pixel_ratio: self.device_pixel_ratio as f32,
             first_frame: self.first_frame,
             context: context.clone(),
-            redraw_needed: self.redraw_needed,
         };
         self.first_frame = false;
-        self.redraw_needed = false;
         
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(exit_time) = option_env!("THREE_D_EXIT").map(|v| v.parse::<f64>().unwrap()) {
@@ -140,7 +136,7 @@ impl FrameInputGenerator {
                 self.window_height = logical_size.height;
             }
             WindowEvent::Occluded(false) => {
-                self.redraw_needed = true;
+                self.first_frame = true;
             }
             WindowEvent::KeyboardInput { input, .. } => {
                 if let Some(keycode) = input.virtual_keycode {

--- a/src/window/winit_window/frame_io.rs
+++ b/src/window/winit_window/frame_io.rs
@@ -38,6 +38,9 @@ pub struct FrameInput {
 
     /// The graphics context for the window.
     pub context: Context,
+
+    /// Whether or not a redraw is needed after the window becomes (partially) visible.
+    pub redraw_needed: bool,
 }
 
 impl FrameInput {

--- a/src/window/winit_window/frame_io.rs
+++ b/src/window/winit_window/frame_io.rs
@@ -33,14 +33,11 @@ pub struct FrameInput {
     /// Number of physical pixels for each logical pixel.
     pub device_pixel_ratio: f32,
 
-    /// Whether or not this is the first frame.
+    /// Whether or not this is the first frame. Note: also set after the window becomes (partially) visible.
     pub first_frame: bool,
 
     /// The graphics context for the window.
     pub context: Context,
-
-    /// Whether or not a redraw is needed after the window becomes (partially) visible.
-    pub redraw_needed: bool,
 }
 
 impl FrameInput {


### PR DESCRIPTION
This small PR adds a flag `redraw_needed` to `FrameInputGenerator/FrameInput` that is set on `WindowEvent::Occluded(false)`  event and cleared during the next `FrameInputGenerator::generate` call.

This is to allow the render loop to emit render calls after (partial) window visibility changes, like so:

```rust
    window.render_loop(
        move |mut frame_input| {
            let mut change = frame_input.first_frame | frame_input.redraw_needed;
```            

Without it the window doesn't get redrawn as it should e.g. on Alt+Tab (Linux/X11).

This is my first Rust PR, so let's hope I did not screw up :) 