### PR TITLE
Pick instance feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,10 @@ name = "picking"
 path = "examples/picking/src/main.rs"
 
 [[example]]
+name = "picking_instances"
+path = "examples/picking_instances/src/main.rs"
+
+[[example]]
 name = "environment"
 path = "examples/environment/src/main.rs"
 required-features = ["egui-gui"]

--- a/examples/picking_instances/Cargo.toml
+++ b/examples/picking_instances/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "picking_instances"
+version = "0.1.0"
+authors = [
+    "Asger Nyman Christiansen <asgernyman@gmail.com>",
+    "Alan Everett <thatcomputerguy0101@gmail.com>",
+]
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+three-d = { path = "../../" }
+three-d-asset = {version = "0.7",features = ["obj", "http"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+log = "0.4"
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+console_error_panic_hook = "0.1"
+console_log = "1"

--- a/examples/picking_instances/src/lib.rs
+++ b/examples/picking_instances/src/lib.rs
@@ -1,0 +1,19 @@
+#![allow(special_module_name)]
+mod main;
+
+// Entry point for wasm
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen(start)]
+pub async fn start() -> Result<(), JsValue> {
+    console_log::init_with_level(log::Level::Debug).unwrap();
+
+    use log::info;
+    info!("Logging works!");
+
+    std::panic::set_hook(Box::new(console_error_panic_hook::hook));
+    main::run().await;
+    Ok(())
+}

--- a/examples/picking_instances/src/main.rs
+++ b/examples/picking_instances/src/main.rs
@@ -97,14 +97,23 @@ pub async fn run() {
                         cube.into_iter().chain(&spheres).chain(&monkey),
                     ) {
                         if pick.index == 0 {
+                            #[cfg(not(target_arch = "wasm32"))]
                             println!("Clicked cube");
+                            #[cfg(target_arch = "wasm32")]
+                            log::info!("Clicked cube");
                             cube.material.albedo = Srgba::GREEN;
                         } else {
                             cube.material.albedo = Srgba::WHITE;
                         }
 
                         if pick.index == 1 {
+                            #[cfg(not(target_arch = "wasm32"))]
                             println!(
+                                "Clicked sphere {}",
+                                pick.instance.map_or("N/A".to_string(), |i| i.to_string())
+                            );
+                            #[cfg(target_arch = "wasm32")]
+                            log::info!(
                                 "Clicked sphere {}",
                                 pick.instance.map_or("N/A".to_string(), |i| i.to_string())
                             );
@@ -128,7 +137,10 @@ pub async fn run() {
                         spheres.set_instances(&sphere_instances);
 
                         if pick.index > 1 && pick.index <= 1 + monkey.len() {
+                            #[cfg(not(target_arch = "wasm32"))]
                             println!("Clicked monkey");
+                            #[cfg(target_arch = "wasm32")]
+                            log::info!("Clicked monkey");
                             monkey
                                 .iter_mut()
                                 .for_each(|m| m.material.albedo = monkey_color);
@@ -140,7 +152,10 @@ pub async fn run() {
 
                         change = true;
                     } else {
-                        println!("Nothing Clicked!")
+                        #[cfg(not(target_arch = "wasm32"))]
+                        println!("Nothing Clicked!");
+                        #[cfg(target_arch = "wasm32")]
+                        log::info!("Nothing Clicked!");
                     }
                 }
             }

--- a/examples/picking_instances/src/main.rs
+++ b/examples/picking_instances/src/main.rs
@@ -1,0 +1,168 @@
+// Entry point for non-wasm
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::main]
+async fn main() {
+    run().await;
+}
+
+use three_d::*;
+
+pub async fn run() {
+    let window = Window::new(WindowSettings {
+        title: "Picking Instances!".to_string(),
+        max_size: Some((1280, 720)),
+        ..Default::default()
+    })
+    .unwrap();
+    let context = window.gl();
+
+    let mut camera = Camera::new_perspective(
+        window.viewport(),
+        vec3(4.0, 4.0, 5.0),
+        vec3(0.0, 0.0, 0.0),
+        vec3(0.0, 1.0, 0.0),
+        degrees(45.0),
+        0.1,
+        1000.0,
+    );
+    let mut control = OrbitControl::new(*camera.target(), 1.0, 100.0);
+
+    let mut cube_mesh = CpuMesh::cube();
+    cube_mesh
+        .transform(&(Mat4::from_translation(vec3(-2.0, 0.0, 0.0)) * Mat4::from_scale(0.5)))
+        .unwrap();
+    let mut cube = Gm::new(
+        Mesh::new(&context, &cube_mesh),
+        PhysicalMaterial::new_opaque(
+            &context,
+            &mut CpuMaterial {
+                albedo: Srgba::WHITE,
+                ..Default::default()
+            },
+        ),
+    );
+
+    let mut sphere_instances = Instances {
+        transformations: [
+            Mat4::from_translation(vec3(2.0, 0.0, 0.0)),
+            Mat4::from_translation(vec3(4.0, 0.0, 0.0)),
+        ]
+        .to_vec(),
+        ..Default::default()
+    };
+
+    let mut sphere_mesh = CpuMesh::sphere(8);
+    sphere_mesh.transform(&Mat4::from_scale(0.5)).unwrap();
+    let mut spheres = Gm::new(
+        InstancedMesh::new(&context, &sphere_instances, &sphere_mesh),
+        PhysicalMaterial::new_opaque(
+            &context,
+            &CpuMaterial {
+                albedo: Srgba::WHITE,
+                ..Default::default()
+            },
+        ),
+    );
+
+    let ambient = AmbientLight::new(&context, 0.4, Srgba::WHITE);
+    let directional = DirectionalLight::new(&context, 2.0, Srgba::WHITE, &vec3(-1.0, -0.8, -1.2));
+
+    let mut loaded = three_d_asset::io::load_async(&["examples/assets/suzanne.obj"])
+        .await
+        .unwrap();
+
+    let model = loaded.deserialize("suzanne.obj").unwrap();
+    let mut monkey = Model::<PhysicalMaterial>::new(&context, &model).unwrap();
+    let monkey_color = monkey[0].material.albedo;
+    monkey.iter_mut().for_each(|m| {
+        m.material.albedo = Srgba::WHITE;
+        m.material.render_states.cull = Cull::Back;
+    });
+
+    // main loop
+    window.render_loop(move |mut frame_input| {
+        let mut change = frame_input.first_frame;
+        change |= camera.set_viewport(frame_input.viewport);
+
+        for event in frame_input.events.iter() {
+            if let Event::MousePress {
+                button, position, ..
+            } = *event
+            {
+                if button == MouseButton::Left {
+                    if let Some(pick) = pick_instance(
+                        &context,
+                        &camera,
+                        position,
+                        cube.into_iter().chain(&spheres).chain(&monkey),
+                    ) {
+                        if pick.index == 0 {
+                            println!("Clicked cube");
+                            cube.material.albedo = Srgba::GREEN;
+                        } else {
+                            cube.material.albedo = Srgba::WHITE;
+                        }
+
+                        if pick.index == 1 {
+                            println!(
+                                "Clicked sphere {}",
+                                pick.instance.map_or("N/A".to_string(), |i| i.to_string())
+                            );
+                            sphere_instances.colors = Some(
+                                sphere_instances
+                                    .transformations
+                                    .iter()
+                                    .enumerate()
+                                    .map(|(i, _)| {
+                                        if Some(i) == pick.instance {
+                                            Srgba::RED
+                                        } else {
+                                            Srgba::WHITE
+                                        }
+                                    })
+                                    .collect(),
+                            );
+                        } else {
+                            sphere_instances.colors = None;
+                        }
+                        spheres.set_instances(&sphere_instances);
+
+                        if pick.index > 1 && pick.index <= 1 + monkey.len() {
+                            println!("Clicked monkey");
+                            monkey
+                                .iter_mut()
+                                .for_each(|m| m.material.albedo = monkey_color);
+                        } else {
+                            monkey
+                                .iter_mut()
+                                .for_each(|m| m.material.albedo = Srgba::WHITE);
+                        }
+
+                        change = true;
+                    } else {
+                        println!("Nothing Clicked!")
+                    }
+                }
+            }
+        }
+
+        change |= control.handle_events(&mut camera, &mut frame_input.events);
+
+        // draw
+        if change {
+            frame_input
+                .screen()
+                .clear(ClearState::color_and_depth(1.0, 1.0, 1.0, 1.0, 1.0))
+                .render(
+                    &camera,
+                    monkey.into_iter().chain(&cube).chain(&spheres),
+                    &[&ambient, &directional],
+                );
+        }
+
+        FrameOutput {
+            swap_buffers: change,
+            ..Default::default()
+        }
+    });
+}

--- a/src/core.rs
+++ b/src/core.rs
@@ -127,8 +127,7 @@ fn normalized_format_from_data_type<T: DataType>() -> u32 {
 fn format_from_data_type<T: DataType>() -> u32 {
     if T::data_type() == crate::context::FLOAT || T::data_type() == crate::context::HALF_FLOAT {
         normalized_format_from_data_type::<T>()
-    }
-    else {
+    } else {
         match T::size() {
             1 => crate::context::RED_INTEGER,
             2 => crate::context::RG_INTEGER,

--- a/src/core.rs
+++ b/src/core.rs
@@ -114,7 +114,7 @@ fn from_byte_slice<T: DataType>(data: &[u8]) -> &[T] {
     }
 }
 
-fn format_from_data_type<T: DataType>() -> u32 {
+fn normalized_format_from_data_type<T: DataType>() -> u32 {
     match T::size() {
         1 => crate::context::RED,
         2 => crate::context::RG,
@@ -124,7 +124,22 @@ fn format_from_data_type<T: DataType>() -> u32 {
     }
 }
 
-fn flip_y<T: TextureDataType>(pixels: &mut [T], width: usize, height: usize) {
+fn format_from_data_type<T: DataType>() -> u32 {
+    if T::data_type() == crate::context::FLOAT || T::data_type() == crate::context::HALF_FLOAT {
+        normalized_format_from_data_type::<T>()
+    }
+    else {
+        match T::size() {
+            1 => crate::context::RED_INTEGER,
+            2 => crate::context::RG_INTEGER,
+            3 => crate::context::RGB_INTEGER,
+            4 => crate::context::RGBA_INTEGER,
+            _ => unreachable!(),
+        }
+    }
+}
+
+fn flip_y<T: BufferDataType>(pixels: &mut [T], width: usize, height: usize) {
     for row in 0..height / 2 {
         for col in 0..width {
             let index0 = width * row + col;

--- a/src/core/data_type.rs
+++ b/src/core/data_type.rs
@@ -11,17 +11,31 @@ pub enum UniformType {
     Mat4,
 }
 
-pub trait PrimitiveDataType: DataType + Copy + Default {
+pub trait PrimitiveDataType: DataType + Copy + Default + Zero {
+    fn max() -> Self;
+
     fn send_uniform_with_type(
         context: &Context,
         location: &UniformLocation,
         data: &[Self],
         type_: UniformType,
     );
+
+    unsafe fn clear_buffer_with_type(
+        context: &Context,
+        target: u32,
+        buffer: u32,
+        values: &[Self],
+    );
+
     fn internal_format_with_size(size: u32) -> u32;
 }
 
 impl PrimitiveDataType for u8 {
+    fn max() -> Self {
+        Self::MAX
+    }
+
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R8,
@@ -41,8 +55,21 @@ impl PrimitiveDataType for u8 {
         let data = data.iter().map(|v| *v as u32).collect::<Vec<_>>();
         u32::send_uniform_with_type(context, location, &data, type_)
     }
+
+    unsafe fn clear_buffer_with_type(
+        context: &Context,
+        target: u32,
+        buffer: u32,
+        values: &[Self],
+    ) {
+        context.clear_buffer_u32_slice(target, buffer, &values.iter().map(|v| *v as u32).collect::<Vec<_>>());
+    }
 }
 impl PrimitiveDataType for u16 {
+    fn max() -> Self {
+        Self::MAX
+    }
+
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R16UI,
@@ -62,8 +89,21 @@ impl PrimitiveDataType for u16 {
         let data = data.iter().map(|v| *v as u32).collect::<Vec<_>>();
         u32::send_uniform_with_type(context, location, &data, type_)
     }
+
+    unsafe fn clear_buffer_with_type(
+        context: &Context,
+        target: u32,
+        buffer: u32,
+        values: &[Self],
+    ) {
+        context.clear_buffer_u32_slice(target, buffer, &values.iter().map(|v| *v as u32).collect::<Vec<_>>());
+    }
 }
 impl PrimitiveDataType for u32 {
+    fn max() -> Self {
+        Self::MAX
+    }
+    
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R32UI,
@@ -90,8 +130,21 @@ impl PrimitiveDataType for u32 {
             }
         }
     }
+
+    unsafe fn clear_buffer_with_type(
+        context: &Context,
+        target: u32,
+        buffer: u32,
+        values: &[Self],
+    ) {
+        context.clear_buffer_u32_slice(target, buffer, values);
+    }
 }
 impl PrimitiveDataType for i8 {
+    fn max() -> Self {
+        Self::MAX
+    }
+
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R8I,
@@ -111,8 +164,21 @@ impl PrimitiveDataType for i8 {
         let data = data.iter().map(|v| *v as i32).collect::<Vec<_>>();
         i32::send_uniform_with_type(context, location, &data, type_)
     }
+
+    unsafe fn clear_buffer_with_type(
+        context: &Context,
+        target: u32,
+        buffer: u32,
+        values: &[Self],
+    ) {
+        context.clear_buffer_i32_slice(target, buffer, &values.iter().map(|v| *v as i32).collect::<Vec<_>>());
+    }
 }
 impl PrimitiveDataType for i16 {
+    fn max() -> Self {
+        Self::MAX
+    }
+
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R16I,
@@ -132,8 +198,21 @@ impl PrimitiveDataType for i16 {
         let data = data.iter().map(|v| *v as i32).collect::<Vec<_>>();
         i32::send_uniform_with_type(context, location, &data, type_)
     }
+
+    unsafe fn clear_buffer_with_type(
+        context: &Context,
+        target: u32,
+        buffer: u32,
+        values: &[Self],
+    ) {
+        context.clear_buffer_i32_slice(target, buffer, &values.iter().map(|v| *v as i32).collect::<Vec<_>>());
+    }
 }
 impl PrimitiveDataType for i32 {
+    fn max() -> Self {
+        Self::MAX
+    }
+
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R32I,
@@ -160,8 +239,21 @@ impl PrimitiveDataType for i32 {
             }
         }
     }
+
+    unsafe fn clear_buffer_with_type(
+        context: &Context,
+        target: u32,
+        buffer: u32,
+        values: &[Self],
+    ) {
+        context.clear_buffer_i32_slice(target, buffer, values);
+    }
 }
 impl PrimitiveDataType for f16 {
+    fn max() -> Self {
+        Self::one()
+    }
+
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R16F,
@@ -181,8 +273,21 @@ impl PrimitiveDataType for f16 {
         let data = data.iter().map(|v| v.to_f32()).collect::<Vec<_>>();
         f32::send_uniform_with_type(context, location, &data, type_)
     }
+
+    unsafe fn clear_buffer_with_type(
+        context: &Context,
+        target: u32,
+        buffer: u32,
+        values: &[Self],
+    ) {
+        context.clear_buffer_f32_slice(target, buffer, &values.iter().map(|v| v.to_f32()).collect::<Vec<_>>());
+    }
 }
 impl PrimitiveDataType for f32 {
+    fn max() -> Self {
+        Self::one()
+    }
+
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R32F,
@@ -216,6 +321,15 @@ impl PrimitiveDataType for f32 {
                 }
             }
         }
+    }
+
+    unsafe fn clear_buffer_with_type(
+        context: &Context,
+        target: u32,
+        buffer: u32,
+        values: &[Self],
+    ) {
+        context.clear_buffer_f32_slice(target, buffer, values);
     }
 }
 

--- a/src/core/data_type.rs
+++ b/src/core/data_type.rs
@@ -21,12 +21,7 @@ pub trait PrimitiveDataType: DataType + Copy + Default + Zero {
         type_: UniformType,
     );
 
-    unsafe fn clear_buffer_with_type(
-        context: &Context,
-        target: u32,
-        buffer: u32,
-        values: &[Self],
-    );
+    unsafe fn clear_buffer_with_type(context: &Context, target: u32, buffer: u32, values: &[Self]);
 
     fn internal_format_with_size(size: u32) -> u32;
 }
@@ -56,13 +51,12 @@ impl PrimitiveDataType for u8 {
         u32::send_uniform_with_type(context, location, &data, type_)
     }
 
-    unsafe fn clear_buffer_with_type(
-        context: &Context,
-        target: u32,
-        buffer: u32,
-        values: &[Self],
-    ) {
-        context.clear_buffer_u32_slice(target, buffer, &values.iter().map(|v| *v as u32).collect::<Vec<_>>());
+    unsafe fn clear_buffer_with_type(context: &Context, target: u32, buffer: u32, values: &[Self]) {
+        context.clear_buffer_u32_slice(
+            target,
+            buffer,
+            &values.iter().map(|v| *v as u32).collect::<Vec<_>>(),
+        );
     }
 }
 impl PrimitiveDataType for u16 {
@@ -90,20 +84,19 @@ impl PrimitiveDataType for u16 {
         u32::send_uniform_with_type(context, location, &data, type_)
     }
 
-    unsafe fn clear_buffer_with_type(
-        context: &Context,
-        target: u32,
-        buffer: u32,
-        values: &[Self],
-    ) {
-        context.clear_buffer_u32_slice(target, buffer, &values.iter().map(|v| *v as u32).collect::<Vec<_>>());
+    unsafe fn clear_buffer_with_type(context: &Context, target: u32, buffer: u32, values: &[Self]) {
+        context.clear_buffer_u32_slice(
+            target,
+            buffer,
+            &values.iter().map(|v| *v as u32).collect::<Vec<_>>(),
+        );
     }
 }
 impl PrimitiveDataType for u32 {
     fn max() -> Self {
         Self::MAX
     }
-    
+
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R32UI,
@@ -131,12 +124,7 @@ impl PrimitiveDataType for u32 {
         }
     }
 
-    unsafe fn clear_buffer_with_type(
-        context: &Context,
-        target: u32,
-        buffer: u32,
-        values: &[Self],
-    ) {
+    unsafe fn clear_buffer_with_type(context: &Context, target: u32, buffer: u32, values: &[Self]) {
         context.clear_buffer_u32_slice(target, buffer, values);
     }
 }
@@ -165,13 +153,12 @@ impl PrimitiveDataType for i8 {
         i32::send_uniform_with_type(context, location, &data, type_)
     }
 
-    unsafe fn clear_buffer_with_type(
-        context: &Context,
-        target: u32,
-        buffer: u32,
-        values: &[Self],
-    ) {
-        context.clear_buffer_i32_slice(target, buffer, &values.iter().map(|v| *v as i32).collect::<Vec<_>>());
+    unsafe fn clear_buffer_with_type(context: &Context, target: u32, buffer: u32, values: &[Self]) {
+        context.clear_buffer_i32_slice(
+            target,
+            buffer,
+            &values.iter().map(|v| *v as i32).collect::<Vec<_>>(),
+        );
     }
 }
 impl PrimitiveDataType for i16 {
@@ -199,13 +186,12 @@ impl PrimitiveDataType for i16 {
         i32::send_uniform_with_type(context, location, &data, type_)
     }
 
-    unsafe fn clear_buffer_with_type(
-        context: &Context,
-        target: u32,
-        buffer: u32,
-        values: &[Self],
-    ) {
-        context.clear_buffer_i32_slice(target, buffer, &values.iter().map(|v| *v as i32).collect::<Vec<_>>());
+    unsafe fn clear_buffer_with_type(context: &Context, target: u32, buffer: u32, values: &[Self]) {
+        context.clear_buffer_i32_slice(
+            target,
+            buffer,
+            &values.iter().map(|v| *v as i32).collect::<Vec<_>>(),
+        );
     }
 }
 impl PrimitiveDataType for i32 {
@@ -240,12 +226,7 @@ impl PrimitiveDataType for i32 {
         }
     }
 
-    unsafe fn clear_buffer_with_type(
-        context: &Context,
-        target: u32,
-        buffer: u32,
-        values: &[Self],
-    ) {
+    unsafe fn clear_buffer_with_type(context: &Context, target: u32, buffer: u32, values: &[Self]) {
         context.clear_buffer_i32_slice(target, buffer, values);
     }
 }
@@ -274,13 +255,12 @@ impl PrimitiveDataType for f16 {
         f32::send_uniform_with_type(context, location, &data, type_)
     }
 
-    unsafe fn clear_buffer_with_type(
-        context: &Context,
-        target: u32,
-        buffer: u32,
-        values: &[Self],
-    ) {
-        context.clear_buffer_f32_slice(target, buffer, &values.iter().map(|v| v.to_f32()).collect::<Vec<_>>());
+    unsafe fn clear_buffer_with_type(context: &Context, target: u32, buffer: u32, values: &[Self]) {
+        context.clear_buffer_f32_slice(
+            target,
+            buffer,
+            &values.iter().map(|v| v.to_f32()).collect::<Vec<_>>(),
+        );
     }
 }
 impl PrimitiveDataType for f32 {
@@ -323,12 +303,7 @@ impl PrimitiveDataType for f32 {
         }
     }
 
-    unsafe fn clear_buffer_with_type(
-        context: &Context,
-        target: u32,
-        buffer: u32,
-        values: &[Self],
-    ) {
+    unsafe fn clear_buffer_with_type(context: &Context, target: u32, buffer: u32, values: &[Self]) {
         context.clear_buffer_f32_slice(target, buffer, values);
     }
 }

--- a/src/core/render_target.rs
+++ b/src/core/render_target.rs
@@ -116,7 +116,11 @@ impl<'a> RenderTarget<'a> {
     ///
     /// Clears the color and depth of the part of this render target that is inside the given scissor box, in the given data type.
     ///
-    pub fn clear_buffer_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
+    pub fn clear_buffer_partially(
+        &self,
+        scissor_box: ScissorBox,
+        clear_state: ClearState<impl PrimitiveDataType>,
+    ) -> &Self {
         self.context.set_scissor(scissor_box);
         self.bind(crate::context::DRAW_FRAMEBUFFER);
         clear_state.apply_buffer(&self.context);
@@ -208,8 +212,12 @@ impl<'a> RenderTarget<'a> {
 
     ///
     /// Common function used to implement read_color, read_buffer, and _partially variants
-    /// 
-    fn read_formatted_buffer_partially<T: BufferDataType>(&self, format: u32, scissor_box: ScissorBox) -> Vec<T> {
+    ///
+    fn read_formatted_buffer_partially<T: BufferDataType>(
+        &self,
+        format: u32,
+        scissor_box: ScissorBox,
+    ) -> Vec<T> {
         if self.id.is_some() && self.color.is_none() {
             panic!("Cannot read color from a render target without a color target");
         }

--- a/src/core/render_target/clear_state.rs
+++ b/src/core/render_target/clear_state.rs
@@ -109,8 +109,7 @@ impl<T: PrimitiveDataType> ClearState<T> {
         }
     }
 
-    pub(in crate::core) fn apply_buffer(&self, context: &Context)
-    {
+    pub(in crate::core) fn apply_buffer(&self, context: &Context) {
         context.set_write_mask(WriteMask {
             red: self.red.is_some(),
             green: self.green.is_some(),
@@ -124,7 +123,10 @@ impl<T: PrimitiveDataType> ClearState<T> {
                 || self.blue.is_some()
                 || self.alpha.is_some();
             if clear_color {
-                T::clear_buffer_with_type(context, crate::context::COLOR, 0, 
+                T::clear_buffer_with_type(
+                    context,
+                    crate::context::COLOR,
+                    0,
                     &[
                         self.red.unwrap_or_else(T::zero),
                         self.green.unwrap_or_else(T::zero),

--- a/src/core/render_target/clear_state.rs
+++ b/src/core/render_target/clear_state.rs
@@ -1,3 +1,5 @@
+use data_type::PrimitiveDataType;
+
 use crate::core::*;
 
 ///
@@ -5,20 +7,20 @@ use crate::core::*;
 /// If `None` then the channel is not cleared and if `Some(value)` the channel is cleared to that value (the value must be between 0 and 1).
 ///
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub struct ClearState {
+pub struct ClearState<T: PrimitiveDataType> {
     /// Defines the clear value for the red channel.
-    pub red: Option<f32>,
+    pub red: Option<T>,
     /// Defines the clear value for the green channel.
-    pub green: Option<f32>,
+    pub green: Option<T>,
     /// Defines the clear value for the blue channel.
-    pub blue: Option<f32>,
+    pub blue: Option<T>,
     /// Defines the clear value for the alpha channel.
-    pub alpha: Option<f32>,
+    pub alpha: Option<T>,
     /// Defines the clear value for the depth channel. A value of 1 means a depth value equal to the far plane and 0 means a depth value equal to the near plane.
     pub depth: Option<f32>,
 }
 
-impl ClearState {
+impl ClearState<f32> {
     ///
     /// Nothing will be cleared.
     ///
@@ -41,32 +43,6 @@ impl ClearState {
             green: None,
             blue: None,
             alpha: None,
-            depth: Some(depth),
-        }
-    }
-
-    ///
-    /// The color channels (red, green, blue and alpha) will be cleared to the given values.
-    ///
-    pub const fn color(red: f32, green: f32, blue: f32, alpha: f32) -> Self {
-        Self {
-            red: Some(red),
-            green: Some(green),
-            blue: Some(blue),
-            alpha: Some(alpha),
-            depth: None,
-        }
-    }
-
-    ///
-    /// Both the color channels (red, green, blue and alpha) and depth will be cleared to the given values.
-    ///
-    pub const fn color_and_depth(red: f32, green: f32, blue: f32, alpha: f32, depth: f32) -> Self {
-        Self {
-            red: Some(red),
-            green: Some(green),
-            blue: Some(blue),
-            alpha: Some(alpha),
             depth: Some(depth),
         }
     }
@@ -106,7 +82,65 @@ impl ClearState {
     }
 }
 
-impl Default for ClearState {
+impl<T: PrimitiveDataType> ClearState<T> {
+    ///
+    /// The color channels (red, green, blue and alpha) will be cleared to the given values.
+    ///
+    pub const fn color(red: T, green: T, blue: T, alpha: T) -> Self {
+        Self {
+            red: Some(red),
+            green: Some(green),
+            blue: Some(blue),
+            alpha: Some(alpha),
+            depth: None,
+        }
+    }
+
+    ///
+    /// Both the color channels (red, green, blue and alpha) and depth will be cleared to the given values.
+    ///
+    pub const fn color_and_depth(red: T, green: T, blue: T, alpha: T, depth: f32) -> Self {
+        Self {
+            red: Some(red),
+            green: Some(green),
+            blue: Some(blue),
+            alpha: Some(alpha),
+            depth: Some(depth),
+        }
+    }
+
+    pub(in crate::core) fn apply_buffer(&self, context: &Context)
+    {
+        context.set_write_mask(WriteMask {
+            red: self.red.is_some(),
+            green: self.green.is_some(),
+            blue: self.blue.is_some(),
+            alpha: self.alpha.is_some(),
+            depth: self.depth.is_some(),
+        });
+        unsafe {
+            let clear_color = self.red.is_some()
+                || self.green.is_some()
+                || self.blue.is_some()
+                || self.alpha.is_some();
+            if clear_color {
+                T::clear_buffer_with_type(context, crate::context::COLOR, 0, 
+                    &[
+                        self.red.unwrap_or_else(T::zero),
+                        self.green.unwrap_or_else(T::zero),
+                        self.blue.unwrap_or_else(T::zero),
+                        self.alpha.unwrap_or_else(T::max),
+                    ],
+                );
+            }
+            if let Some(depth) = self.depth {
+                context.clear_buffer_f32_slice(crate::context::DEPTH, 0, &[depth]);
+            }
+        }
+    }
+}
+
+impl Default for ClearState<f32> {
     fn default() -> Self {
         Self::color_and_depth(0.0, 0.0, 0.0, 1.0, 1.0)
     }

--- a/src/core/render_target/color_target.rs
+++ b/src/core/render_target/color_target.rs
@@ -73,14 +73,14 @@ impl<'a> ColorTarget<'a> {
     ///
     /// Clears the color of this color target as defined by the given clear state.
     ///
-    pub fn clear(&self, clear_state: ClearState) -> &Self {
+    pub fn clear(&self, clear_state: ClearState<f32>) -> &Self {
         self.clear_partially(self.scissor_box(), clear_state)
     }
 
     ///
     /// Clears the color of the part of this color target that is inside the given scissor box.
     ///
-    pub fn clear_partially(&self, scissor_box: ScissorBox, clear_state: ClearState) -> &Self {
+    pub fn clear_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<f32>) -> &Self {
         self.as_render_target().clear_partially(
             scissor_box,
             ClearState {
@@ -88,6 +88,22 @@ impl<'a> ColorTarget<'a> {
                 ..clear_state
             },
         );
+        self
+    }
+
+    ///
+    /// Clears the color of this color target as defined by the given clear state and data type.
+    ///
+    pub fn clear_buffer(&self, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
+        self.clear_buffer_partially(self.scissor_box(), clear_state)
+    }
+
+    ///
+    /// Clears the color of the part of this color target that is inside the given scissor box, in the given data type.
+    ///
+    pub fn clear_buffer_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
+        self.as_render_target()
+            .clear_buffer_partially(scissor_box, clear_state);
         self
     }
 
@@ -144,6 +160,28 @@ impl<'a> ColorTarget<'a> {
     ///
     pub fn read_partially<T: TextureDataType>(&self, scissor_box: ScissorBox) -> Vec<T> {
         self.as_render_target().read_color_partially(scissor_box)
+    }
+
+    ///
+    /// Returns the underlying buffer data of this color target.
+    /// The number of channels per pixel and the data format for each channel returned from this function is specified by the generic parameter `T`.
+    ///
+    /// **Note:**
+    /// The base type of the generic parameter `T` must match the base type of the render target, for example if the render targets base type is `u8`, the base type of `T` must also be `u8`.
+    ///
+    pub fn read_buffer<T: BufferDataType>(&self) -> Vec<T> {
+        self.read_buffer_partially(self.scissor_box())
+    }
+
+    ///
+    /// Returns the underlying buffer data of this color target inside the given scissor box.
+    /// The number of channels per pixel and the data format for each channel returned from this function is specified by the generic parameter `T`.
+    ///
+    /// **Note:**
+    /// The base type of the generic parameter `T` must match the base type of the render target, for example if the render targets base type is `u8`, the base type of `T` must also be `u8`.
+    ///
+    pub fn read_buffer_partially<T: BufferDataType>(&self, scissor_box: ScissorBox) -> Vec<T> {
+        self.as_render_target().read_buffer_partially(scissor_box)
     }
 
     ///

--- a/src/core/render_target/color_target.rs
+++ b/src/core/render_target/color_target.rs
@@ -101,7 +101,11 @@ impl<'a> ColorTarget<'a> {
     ///
     /// Clears the color of the part of this color target that is inside the given scissor box, in the given data type.
     ///
-    pub fn clear_buffer_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
+    pub fn clear_buffer_partially(
+        &self,
+        scissor_box: ScissorBox,
+        clear_state: ClearState<impl PrimitiveDataType>,
+    ) -> &Self {
         self.as_render_target()
             .clear_buffer_partially(scissor_box, clear_state);
         self

--- a/src/core/render_target/color_target_multisample.rs
+++ b/src/core/render_target/color_target_multisample.rs
@@ -1,3 +1,5 @@
+use data_type::PrimitiveDataType;
+
 use crate::core::*;
 
 ///
@@ -8,7 +10,7 @@ use crate::core::*;
 ///
 /// Also see [RenderTargetMultisample] and [DepthTargetMultisample].
 ///
-pub struct ColorTargetMultisample<C: TextureDataType> {
+pub struct ColorTargetMultisample<C: BufferDataType> {
     pub(crate) context: Context,
     color: Texture2DMultisample,
     _c: std::marker::PhantomData<C>,
@@ -32,7 +34,7 @@ impl<C: TextureDataType> ColorTargetMultisample<C> {
     ///
     /// Clears the color of this target as defined by the given clear state.
     ///
-    pub fn clear(&self, clear_state: ClearState) -> &Self {
+    pub fn clear(&self, clear_state: ClearState<f32>) -> &Self {
         self.clear_partially(
             ScissorBox::new_at_origo(self.width(), self.height()),
             clear_state,
@@ -42,7 +44,7 @@ impl<C: TextureDataType> ColorTargetMultisample<C> {
     ///
     /// Clears the color of the part of this target that is inside the given scissor box.
     ///
-    pub fn clear_partially(&self, scissor_box: ScissorBox, clear_state: ClearState) -> &Self {
+    pub fn clear_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<f32>) -> &Self {
         self.as_render_target().clear_partially(
             scissor_box,
             ClearState {
@@ -50,6 +52,22 @@ impl<C: TextureDataType> ColorTargetMultisample<C> {
                 ..clear_state
             },
         );
+        self
+    }
+
+    ///
+    /// Clears the color of this target as defined by the given clear state and data type.
+    ///
+    pub fn clear_buffer(&self, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
+        self.clear_buffer_partially(self.scissor_box(), clear_state)
+    }
+
+    ///
+    /// Clears the color of the part of this target that is inside the given scissor box, in the given data type.
+    ///
+    pub fn clear_buffer_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
+        self.as_render_target()
+            .clear_buffer_partially(scissor_box, clear_state);
         self
     }
 

--- a/src/core/render_target/color_target_multisample.rs
+++ b/src/core/render_target/color_target_multisample.rs
@@ -65,7 +65,11 @@ impl<C: TextureDataType> ColorTargetMultisample<C> {
     ///
     /// Clears the color of the part of this target that is inside the given scissor box, in the given data type.
     ///
-    pub fn clear_buffer_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
+    pub fn clear_buffer_partially(
+        &self,
+        scissor_box: ScissorBox,
+        clear_state: ClearState<impl PrimitiveDataType>,
+    ) -> &Self {
         self.as_render_target()
             .clear_buffer_partially(scissor_box, clear_state);
         self

--- a/src/core/render_target/depth_target.rs
+++ b/src/core/render_target/depth_target.rs
@@ -60,14 +60,14 @@ impl<'a> DepthTarget<'a> {
     ///
     /// Clears the depth of this depth target as defined by the given clear state.
     ///
-    pub fn clear(&self, clear_state: ClearState) -> &Self {
+    pub fn clear(&self, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
         self.clear_partially(self.scissor_box(), clear_state)
     }
 
     ///
     /// Clears the depth of the part of this depth target that is inside the given scissor box.
     ///
-    pub fn clear_partially(&self, scissor_box: ScissorBox, clear_state: ClearState) -> &Self {
+    pub fn clear_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
         self.as_render_target().clear_partially(
             scissor_box,
             ClearState {

--- a/src/core/render_target/depth_target.rs
+++ b/src/core/render_target/depth_target.rs
@@ -67,7 +67,11 @@ impl<'a> DepthTarget<'a> {
     ///
     /// Clears the depth of the part of this depth target that is inside the given scissor box.
     ///
-    pub fn clear_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
+    pub fn clear_partially(
+        &self,
+        scissor_box: ScissorBox,
+        clear_state: ClearState<impl PrimitiveDataType>,
+    ) -> &Self {
         self.as_render_target().clear_partially(
             scissor_box,
             ClearState {

--- a/src/core/render_target/depth_target_multisample.rs
+++ b/src/core/render_target/depth_target_multisample.rs
@@ -40,7 +40,11 @@ impl<D: DepthTextureDataType> DepthTargetMultisample<D> {
     ///
     /// Clears the color and depth of the part of this target that is inside the given scissor box.
     ///
-    pub fn clear_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
+    pub fn clear_partially(
+        &self,
+        scissor_box: ScissorBox,
+        clear_state: ClearState<impl PrimitiveDataType>,
+    ) -> &Self {
         self.as_render_target().clear_partially(
             scissor_box,
             ClearState {

--- a/src/core/render_target/depth_target_multisample.rs
+++ b/src/core/render_target/depth_target_multisample.rs
@@ -1,4 +1,5 @@
 use crate::core::*;
+use data_type::PrimitiveDataType;
 
 ///
 /// A multisample render target for depth data. Use this if you want to avoid aliasing, ie. jagged edges, when rendering to a [DepthTarget].
@@ -32,14 +33,14 @@ impl<D: DepthTextureDataType> DepthTargetMultisample<D> {
     ///
     /// Clears the color and depth of this target as defined by the given clear state.
     ///
-    pub fn clear(&self, clear_state: ClearState) -> &Self {
+    pub fn clear(&self, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
         self.clear_partially(self.scissor_box(), clear_state)
     }
 
     ///
     /// Clears the color and depth of the part of this target that is inside the given scissor box.
     ///
-    pub fn clear_partially(&self, scissor_box: ScissorBox, clear_state: ClearState) -> &Self {
+    pub fn clear_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
         self.as_render_target().clear_partially(
             scissor_box,
             ClearState {

--- a/src/core/render_target/multisample.rs
+++ b/src/core/render_target/multisample.rs
@@ -61,7 +61,11 @@ impl<C: TextureDataType, D: DepthTextureDataType> RenderTargetMultisample<C, D> 
     ///
     /// Clears the color and depth of the part of this target that is inside the given scissor box, in the given data type.
     ///
-    pub fn clear_buffer_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
+    pub fn clear_buffer_partially(
+        &self,
+        scissor_box: ScissorBox,
+        clear_state: ClearState<impl PrimitiveDataType>,
+    ) -> &Self {
         self.as_render_target()
             .clear_buffer_partially(scissor_box, clear_state);
         self

--- a/src/core/render_target/multisample.rs
+++ b/src/core/render_target/multisample.rs
@@ -1,4 +1,5 @@
 use crate::core::*;
+use data_type::PrimitiveDataType;
 
 ///
 /// A multisampled render target for color and depth data. Use this if you want to avoid aliasing, ie. jagged edges, when rendering to a [RenderTarget].
@@ -9,7 +10,7 @@ use crate::core::*;
 ///
 /// Also see [ColorTargetMultisample] and [DepthTargetMultisample].
 ///
-pub struct RenderTargetMultisample<C: TextureDataType, D: DepthTextureDataType> {
+pub struct RenderTargetMultisample<C: BufferDataType, D: DepthTextureDataType> {
     pub(crate) context: Context,
     color: Texture2DMultisample,
     depth: DepthTexture2DMultisample,
@@ -37,16 +38,32 @@ impl<C: TextureDataType, D: DepthTextureDataType> RenderTargetMultisample<C, D> 
     ///
     /// Clears the color and depth of this target as defined by the given clear state.
     ///
-    pub fn clear(&self, clear_state: ClearState) -> &Self {
+    pub fn clear(&self, clear_state: ClearState<f32>) -> &Self {
         self.clear_partially(self.scissor_box(), clear_state)
     }
 
     ///
     /// Clears the color and depth of the part of this target that is inside the given scissor box.
     ///
-    pub fn clear_partially(&self, scissor_box: ScissorBox, clear_state: ClearState) -> &Self {
+    pub fn clear_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<f32>) -> &Self {
         self.as_render_target()
             .clear_partially(scissor_box, clear_state);
+        self
+    }
+
+    ///
+    /// Clears the color and depth of this target as defined by the given clear state and data type.
+    ///
+    pub fn clear_buffer(&self, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
+        self.clear_buffer_partially(self.scissor_box(), clear_state)
+    }
+
+    ///
+    /// Clears the color and depth of the part of this target that is inside the given scissor box, in the given data type.
+    ///
+    pub fn clear_buffer_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
+        self.as_render_target()
+            .clear_buffer_partially(scissor_box, clear_state);
         self
     }
 

--- a/src/core/texture.rs
+++ b/src/core/texture.rs
@@ -349,13 +349,13 @@ fn set_parameters(
     }
 }
 
-fn calculate_number_of_mip_maps<T: TextureDataType>(
+fn calculate_number_of_mip_maps<T: DataType>(
     mip_map_filter: Option<Interpolation>,
     width: u32,
     height: u32,
     depth: Option<u32>,
 ) -> u32 {
-    // Cannot generate mip maps for RGB textures using non-normalized data formats on web (OpenGL ES3.0 Table 3.13, https://registry.khronos.org/webgl/extensions/EXT_color_buffer_float/)
+    // Cannot generate mip maps for RGB textures using non-byte data formats on web (OpenGL ES3.0 Table 3.13, https://registry.khronos.org/webgl/extensions/EXT_color_buffer_float/)
     if T::size() == 3 && T::data_type() != crate::context::UNSIGNED_BYTE {
         return 1;
     }
@@ -389,7 +389,7 @@ fn interpolation_from(interpolation: Interpolation) -> i32 {
     }) as i32
 }
 
-fn check_data_length<T: TextureDataType>(
+fn check_data_length<T: DataType>(
     width: u32,
     height: u32,
     depth: u32,

--- a/src/core/texture.rs
+++ b/src/core/texture.rs
@@ -42,8 +42,8 @@ pub use three_d_asset::texture::{
     Interpolation, Texture2D as CpuTexture, Texture3D as CpuTexture3D, TextureData, Wrapping,
 };
 
-/// The basic data type used for each channel of each pixel in a texture.
-pub trait TextureDataType: DataType {}
+/// The basic data type used for each channel of each pixel in a normalized texture.
+pub trait TextureDataType: BufferDataType {}
 impl TextureDataType for u8 {}
 impl TextureDataType for f16 {}
 impl TextureDataType for f32 {}
@@ -355,10 +355,8 @@ fn calculate_number_of_mip_maps<T: TextureDataType>(
     height: u32,
     depth: Option<u32>,
 ) -> u32 {
-    // Cannot generate mip maps for RGB16F or RGB32F textures on web (https://registry.khronos.org/webgl/extensions/EXT_color_buffer_float/)
-    if (T::data_type() == crate::context::FLOAT || T::data_type() == crate::context::HALF_FLOAT)
-        && T::size() == 3
-    {
+    // Cannot generate mip maps for RGB textures using non-normalized data formats on web (OpenGL ES3.0 Table 3.13, https://registry.khronos.org/webgl/extensions/EXT_color_buffer_float/)
+    if T::size() == 3 && T::data_type() != crate::context::UNSIGNED_BYTE {
         return 1;
     }
 

--- a/src/core/texture/texture2d.rs
+++ b/src/core/texture/texture2d.rs
@@ -61,7 +61,7 @@ impl Texture2D {
     ///
     /// **Note:** Mip maps will not be generated for RGB16F and RGB32F format, even if `mip_map_filter` is specified.
     ///
-    pub fn new_empty<T: TextureDataType>(
+    pub fn new_empty<T: BufferDataType>(
         context: &Context,
         width: u32,
         height: u32,
@@ -118,6 +118,21 @@ impl Texture2D {
     /// It is therefore necessary to create a new texture if the texture size or format has changed.
     ///
     pub fn fill<T: TextureDataType>(&mut self, data: &[T]) {
+        self.fill_format(data, normalized_format_from_data_type::<T>())
+    }
+
+    ///
+    /// Fills this texture with the given data, using the given data type.
+    ///
+    /// # Panic
+    /// Will panic if the length of the data does not correspond to the width, height and format specified at construction.
+    /// It is therefore necessary to create a new texture if the texture size or format has changed.
+    ///
+    pub fn fill_buffer<T: BufferDataType>(&mut self, data: &[T]) {
+        self.fill_format(data, format_from_data_type::<T>())
+    }
+
+    fn fill_format<T: BufferDataType>(&mut self, data: &[T], format: u32) {
         check_data_length::<T>(self.width, self.height, 1, self.data_byte_size, data.len());
         self.bind();
         let mut data = data.to_owned();
@@ -130,7 +145,7 @@ impl Texture2D {
                 0,
                 self.width as i32,
                 self.height as i32,
-                normalized_format_from_data_type::<T>(),
+                format,
                 T::data_type(),
                 crate::context::PixelUnpackData::Slice(to_byte_slice(&data)),
             );

--- a/src/core/texture/texture2d.rs
+++ b/src/core/texture/texture2d.rs
@@ -130,7 +130,7 @@ impl Texture2D {
                 0,
                 self.width as i32,
                 self.height as i32,
-                format_from_data_type::<T>(),
+                normalized_format_from_data_type::<T>(),
                 T::data_type(),
                 crate::context::PixelUnpackData::Slice(to_byte_slice(&data)),
             );

--- a/src/core/texture/texture2d_array.rs
+++ b/src/core/texture/texture2d_array.rs
@@ -242,7 +242,7 @@ impl Texture2DArray {
                 self.width as i32,
                 self.height as i32,
                 1,
-                format_from_data_type::<T>(),
+                normalized_format_from_data_type::<T>(),
                 T::data_type(),
                 crate::context::PixelUnpackData::Slice(to_byte_slice(&data)),
             );

--- a/src/core/texture/texture2d_array.rs
+++ b/src/core/texture/texture2d_array.rs
@@ -215,6 +215,19 @@ impl Texture2DArray {
     }
 
     ///
+    /// Fills the texture array with the given pixel data in the given format.
+    ///
+    /// # Panic
+    /// Will panic if the data does not correspond to the width, height, depth and format specified at construction.
+    /// It is therefore necessary to create a new texture if the texture size or format has changed.
+    ///
+    pub fn fill_buffer<T: BufferDataType>(&mut self, data: &[&[T]]) {
+        for (i, data) in data.iter().enumerate() {
+            self.fill_layer_buffer(i as u32, data);
+        }
+    }
+
+    ///
     /// Fills the given layer in the texture array with the given pixel data.
     ///
     /// # Panic
@@ -222,6 +235,21 @@ impl Texture2DArray {
     /// It is therefore necessary to create a new texture if the texture size or format has changed.
     ///
     pub fn fill_layer<T: TextureDataType>(&mut self, layer: u32, data: &[T]) {
+        self.fill_layer_format(layer, data, normalized_format_from_data_type::<T>());
+    }
+
+    ///
+    /// Fills the given layer in the texture array with the given pixel data in the given format.
+    ///
+    /// # Panic
+    /// Will panic if the layer number is bigger than the number of layers or if the data does not correspond to the width, height and format specified at construction.
+    /// It is therefore necessary to create a new texture if the texture size or format has changed.
+    ///
+    pub fn fill_layer_buffer<T: BufferDataType>(&mut self, layer: u32, data: &[T]) {
+        self.fill_layer_format(layer, data, format_from_data_type::<T>());
+    }
+
+    fn fill_layer_format<T: BufferDataType>(&mut self, layer: u32, data: &[T], format: u32) {
         if layer >= self.depth {
             panic!(
                 "cannot fill the layer {} with data, since there are only {} layers in the texture array",
@@ -242,7 +270,7 @@ impl Texture2DArray {
                 self.width as i32,
                 self.height as i32,
                 1,
-                normalized_format_from_data_type::<T>(),
+                format,
                 T::data_type(),
                 crate::context::PixelUnpackData::Slice(to_byte_slice(&data)),
             );

--- a/src/core/texture/texture2d_multisample.rs
+++ b/src/core/texture/texture2d_multisample.rs
@@ -9,7 +9,7 @@ pub struct Texture2DMultisample {
 }
 
 impl Texture2DMultisample {
-    pub fn new<T: TextureDataType>(
+    pub fn new<T: BufferDataType>(
         context: &Context,
         width: u32,
         height: u32,

--- a/src/core/texture/texture3d.rs
+++ b/src/core/texture/texture3d.rs
@@ -140,7 +140,7 @@ impl Texture3D {
                 self.width as i32,
                 self.height as i32,
                 self.depth as i32,
-                format_from_data_type::<T>(),
+                normalized_format_from_data_type::<T>(),
                 T::data_type(),
                 crate::context::PixelUnpackData::Slice(to_byte_slice(data)),
             );

--- a/src/core/texture/texture3d.rs
+++ b/src/core/texture/texture3d.rs
@@ -61,7 +61,7 @@ impl Texture3D {
     ///
     /// **Note:** Mip maps will not be generated for RGB16F and RGB32F format, even if `mip_map_filter` is specified.
     ///
-    pub fn new_empty<T: TextureDataType>(
+    pub fn new_empty<T: BufferDataType>(
         context: &Context,
         width: u32,
         height: u32,
@@ -122,6 +122,21 @@ impl Texture3D {
     /// It is therefore necessary to create a new texture if the texture size or format has changed.
     ///
     pub fn fill<T: TextureDataType>(&mut self, data: &[T]) {
+        self.fill_format(data, normalized_format_from_data_type::<T>());
+    }
+
+    ///
+    /// Fills this texture with the given data in the given data format.
+    ///
+    /// # Panic
+    /// Will panic if the length of the data does not correspond to the width, height, depth and format specified at construction.
+    /// It is therefore necessary to create a new texture if the texture size or format has changed.
+    ///
+    pub fn fill_buffer<T: TextureDataType>(&mut self, data: &[T]) {
+        self.fill_format(data, format_from_data_type::<T>());
+    }
+
+    fn fill_format<T: TextureDataType>(&mut self, data: &[T], format: u32) {
         check_data_length::<T>(
             self.width,
             self.height,
@@ -140,7 +155,7 @@ impl Texture3D {
                 self.width as i32,
                 self.height as i32,
                 self.depth as i32,
-                normalized_format_from_data_type::<T>(),
+                format,
                 T::data_type(),
                 crate::context::PixelUnpackData::Slice(to_byte_slice(data)),
             );

--- a/src/core/texture/texture_cube_map.rs
+++ b/src/core/texture/texture_cube_map.rs
@@ -369,7 +369,15 @@ impl TextureCubeMap {
         front_data: &[T],
         back_data: &[T],
     ) {
-        self.fill_format(right_data, left_data, top_data, bottom_data, front_data, back_data, normalized_format_from_data_type::<T>());
+        self.fill_format(
+            right_data,
+            left_data,
+            top_data,
+            bottom_data,
+            front_data,
+            back_data,
+            normalized_format_from_data_type::<T>(),
+        );
     }
 
     ///
@@ -388,9 +396,17 @@ impl TextureCubeMap {
         front_data: &[T],
         back_data: &[T],
     ) {
-        self.fill_format(right_data, left_data, top_data, bottom_data, front_data, back_data, format_from_data_type::<T>());
+        self.fill_format(
+            right_data,
+            left_data,
+            top_data,
+            bottom_data,
+            front_data,
+            back_data,
+            format_from_data_type::<T>(),
+        );
     }
-    
+
     fn fill_format<T: BufferDataType>(
         &mut self,
         right_data: &[T],

--- a/src/core/texture/texture_cube_map.rs
+++ b/src/core/texture/texture_cube_map.rs
@@ -430,7 +430,7 @@ impl TextureCubeMap {
                     0,
                     self.width as i32,
                     self.height as i32,
-                    format_from_data_type::<T>(),
+                    normalized_format_from_data_type::<T>(),
                     T::data_type(),
                     crate::context::PixelUnpackData::Slice(to_byte_slice(data)),
                 );

--- a/src/core/texture/texture_cube_map.rs
+++ b/src/core/texture/texture_cube_map.rs
@@ -303,7 +303,7 @@ impl TextureCubeMap {
     ///
     /// **Note:** Mip maps will not be generated for RGB16F and RGB32F format, even if `mip_map_filter` is specified.
     ///
-    pub fn new_empty<T: TextureDataType>(
+    pub fn new_empty<T: BufferDataType>(
         context: &Context,
         width: u32,
         height: u32,
@@ -369,6 +369,38 @@ impl TextureCubeMap {
         front_data: &[T],
         back_data: &[T],
     ) {
+        self.fill_format(right_data, left_data, top_data, bottom_data, front_data, back_data, normalized_format_from_data_type::<T>());
+    }
+
+    ///
+    /// Fills the cube map texture with the given pixel data in the given format for the 6 images.
+    ///
+    /// # Panic
+    /// Will panic if the length of the data for all 6 images does not correspond to the width, height and format specified at construction.
+    /// It is therefore necessary to create a new texture if the texture size or format has changed.
+    ///
+    pub fn fill_buffer<T: BufferDataType>(
+        &mut self,
+        right_data: &[T],
+        left_data: &[T],
+        top_data: &[T],
+        bottom_data: &[T],
+        front_data: &[T],
+        back_data: &[T],
+    ) {
+        self.fill_format(right_data, left_data, top_data, bottom_data, front_data, back_data, format_from_data_type::<T>());
+    }
+    
+    fn fill_format<T: BufferDataType>(
+        &mut self,
+        right_data: &[T],
+        left_data: &[T],
+        top_data: &[T],
+        bottom_data: &[T],
+        front_data: &[T],
+        back_data: &[T],
+        format: u32,
+    ) {
         check_data_length::<T>(
             self.width,
             self.height,
@@ -430,7 +462,7 @@ impl TextureCubeMap {
                     0,
                     self.width as i32,
                     self.height as i32,
-                    normalized_format_from_data_type::<T>(),
+                    format,
                     T::data_type(),
                     crate::context::PixelUnpackData::Slice(to_byte_slice(data)),
                 );

--- a/src/renderer/geometry/instanced_mesh.rs
+++ b/src/renderer/geometry/instanced_mesh.rs
@@ -268,7 +268,7 @@ impl Geometry for InstancedMesh {
     fn vertex_shader_source(&self, required_attributes: FragmentAttributes) -> String {
         let instance_buffers = &self.instance_buffers.read().unwrap().0;
         format!(
-            "{}{}{}{}{}{}{}{}{}",
+            "{}{}{}{}{}{}{}{}{}{}",
             if required_attributes.normal {
                 "#define USE_NORMALS\n"
             } else {
@@ -304,6 +304,11 @@ impl Geometry for InstancedMesh {
             } else {
                 ""
             },
+            if required_attributes.instance_id {
+                "#define USE_INSTANCE_ID"
+            } else {
+                ""
+            },
             include_str!("../../core/shared.frag"),
             include_str!("shaders/mesh.vert"),
         )
@@ -323,6 +328,7 @@ impl Geometry for InstancedMesh {
             required_attributes.color && instance_buffers.contains_key("instance_color"),
             instance_buffers.contains_key("instance_translation"),
             required_attributes.uv && instance_buffers.contains_key("tex_transform_row1"),
+            required_attributes.instance_id,
         )
     }
 

--- a/src/renderer/geometry/particles.rs
+++ b/src/renderer/geometry/particles.rs
@@ -195,12 +195,13 @@ impl Geometry for ParticleSystem {
             required_attributes.color && self.base_mesh.colors.is_some(),
             required_attributes.color && self.instance_buffers.contains_key("instance_color"),
             required_attributes.uv && self.instance_buffers.contains_key("tex_transform_row1"),
+            required_attributes.instance_id,
         )
     }
 
     fn vertex_shader_source(&self, required_attributes: FragmentAttributes) -> String {
         format!(
-            "#define PARTICLES\n{}{}{}{}{}{}{}{}",
+            "#define PARTICLES\n{}{}{}{}{}{}{}{}{}",
             if required_attributes.normal {
                 "#define USE_NORMALS\n"
             } else {
@@ -228,6 +229,11 @@ impl Geometry for ParticleSystem {
             },
             if required_attributes.uv && self.instance_buffers.contains_key("tex_transform_row1") {
                 "#define USE_INSTANCE_TEXTURE_TRANSFORMATION\n"
+            } else {
+                ""
+            },
+            if required_attributes.instance_id {
+                "#define USE_INSTANCE_ID"
             } else {
                 ""
             },

--- a/src/renderer/geometry/shaders/mesh.vert
+++ b/src/renderer/geometry/shaders/mesh.vert
@@ -117,4 +117,9 @@ void main()
 #ifdef USE_INSTANCE_COLORS
     col *= instance_color;
 #endif
+
+    // *** IDs ***
+#ifdef USE_INSTANCE_ID
+    col.x = -float(gl_InstanceID);
+#endif
 }

--- a/src/renderer/geometry/shaders/mesh.vert
+++ b/src/renderer/geometry/shaders/mesh.vert
@@ -22,12 +22,12 @@ in vec4 row3;
 
 out vec3 pos;
 
-#ifdef USE_NORMALS 
+#ifdef USE_NORMALS
 uniform mat4 normalMatrix;
 in vec3 normal;
 out vec3 nor;
 
-#ifdef USE_TANGENTS 
+#ifdef USE_TANGENTS
 in vec4 tangent;
 out vec3 tang;
 out vec3 bitang;
@@ -36,7 +36,7 @@ out vec3 bitang;
 #endif
 
 
-#ifdef USE_UVS 
+#ifdef USE_UVS
 #ifdef USE_INSTANCE_TEXTURE_TRANSFORMATION
 in vec3 tex_transform_row1;
 in vec3 tex_transform_row2;
@@ -45,7 +45,7 @@ in vec2 uv_coordinates;
 out vec2 uvs;
 #endif
 
-#ifdef USE_VERTEX_COLORS 
+#ifdef USE_VERTEX_COLORS
 in vec4 color;
 #endif
 #ifdef USE_INSTANCE_COLORS
@@ -53,6 +53,8 @@ in vec4 instance_color;
 #endif
 
 out vec4 col;
+
+flat out int instanceID;
 
 void main()
 {
@@ -73,7 +75,7 @@ void main()
 #ifdef PARTICLES
     worldPosition.xyz += start_position + start_velocity * time + 0.5 * acceleration * time * time;
 #endif
-#ifdef USE_INSTANCE_TRANSLATIONS 
+#ifdef USE_INSTANCE_TRANSLATIONS
     worldPosition.xyz += instance_translation;
 #endif
     gl_Position = viewProjection * worldPosition;
@@ -81,7 +83,7 @@ void main()
     pos = worldPosition.xyz;
 
     // *** NORMAL ***
-#ifdef USE_NORMALS 
+#ifdef USE_NORMALS
 #ifdef USE_INSTANCE_TRANSFORMS
     mat3 normalMat = mat3(transpose(inverse(local2World)));
 #else
@@ -89,7 +91,7 @@ void main()
 #endif
     nor = normalize(normalMat * normal);
 
-#ifdef USE_TANGENTS 
+#ifdef USE_TANGENTS
     tang = normalize(normalMat * tangent.xyz);
     bitang = normalize(cross(nor, tang) * tangent.w);
 #endif
@@ -97,7 +99,7 @@ void main()
 #endif
 
     // *** UV ***
-#ifdef USE_UVS 
+#ifdef USE_UVS
 #ifdef USE_INSTANCE_TEXTURE_TRANSFORMATION
     mat3 texTransform;
     texTransform[0] = vec3(tex_transform_row1.x, tex_transform_row2.x, 0.0);
@@ -111,7 +113,7 @@ void main()
 
     // *** COLOR ***
     col = vec4(1.0);
-#ifdef USE_VERTEX_COLORS 
+#ifdef USE_VERTEX_COLORS
     col *= color;
 #endif
 #ifdef USE_INSTANCE_COLORS
@@ -120,6 +122,8 @@ void main()
 
     // *** IDs ***
 #ifdef USE_INSTANCE_ID
-    col.x = -float(gl_InstanceID);
+    instanceID = gl_InstanceID;
+#else
+    instanceID = -1;
 #endif
 }

--- a/src/renderer/material.rs
+++ b/src/renderer/material.rs
@@ -74,6 +74,10 @@ mod isosurface_material;
 #[doc(inline)]
 pub use isosurface_material::*;
 
+mod geometry_instance_material;
+#[doc(inline)]
+pub use geometry_instance_material::*;
+
 use std::{ops::Deref, sync::Arc};
 
 ///
@@ -158,6 +162,8 @@ pub struct FragmentAttributes {
     pub uv: bool,
     /// Color: `in vec4 col;`
     pub color: bool,
+    /// Instance ID: `in uint instanceID`
+    pub instance_id: bool,
 }
 
 impl FragmentAttributes {
@@ -168,6 +174,7 @@ impl FragmentAttributes {
         tangents: true,
         uv: true,
         color: true,
+        instance_id: true,
     };
     /// No attributes
     pub const NONE: Self = Self {
@@ -176,6 +183,7 @@ impl FragmentAttributes {
         tangents: false,
         uv: false,
         color: false,
+        instance_id: false,
     };
 }
 

--- a/src/renderer/material.rs
+++ b/src/renderer/material.rs
@@ -162,7 +162,7 @@ pub struct FragmentAttributes {
     pub uv: bool,
     /// Color: `in vec4 col;`
     pub color: bool,
-    /// Instance ID: `in uint instanceID`
+    /// Instance ID: `in int instanceID`
     pub instance_id: bool,
 }
 

--- a/src/renderer/material/deferred_physical_material.rs
+++ b/src/renderer/material/deferred_physical_material.rs
@@ -240,6 +240,7 @@ impl Material for DeferredPhysicalMaterial {
                 || self.emissive_texture.is_some()
                 || self.alpha_cutout.is_some(),
             tangents: self.normal_texture.is_some(),
+            ..FragmentAttributes::NONE
         }
     }
 

--- a/src/renderer/material/geometry_instance_material.rs
+++ b/src/renderer/material/geometry_instance_material.rs
@@ -1,0 +1,50 @@
+use crate::core::*;
+use crate::renderer::*;
+
+///
+/// Used for rendering a unique color for each instance of an object with this material,
+/// as to allow uniquely determining which pixels belong to which object instance.
+///
+#[derive(Default, Clone)]
+pub struct GeometryInstanceMaterial {
+    /// Geometry ID
+    pub id: usize,
+    /// Render states.
+    pub render_states: RenderStates,
+}
+
+impl FromCpuMaterial for GeometryInstanceMaterial {
+    fn from_cpu_material(_context: &Context, _cpu_material: &CpuMaterial) -> Self {
+        Self::default()
+    }
+}
+
+impl Material for GeometryInstanceMaterial {
+    fn id(&self) -> EffectMaterialId {
+        EffectMaterialId::GeometryInstanceMaterial
+    }
+
+    fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {
+        include_str!("shaders/geometry_instance_material.frag").to_string()
+    }
+
+    fn fragment_attributes(&self) -> FragmentAttributes {
+        FragmentAttributes {
+            instance_id: true,
+            ..FragmentAttributes::NONE
+        }
+    }
+
+    fn use_uniforms(&self, program: &Program, camera: &Camera, _lights: &[&dyn Light]) {
+        program.use_uniform("id", self.id as f32);
+        program.use_uniform("eye", camera.position());
+    }
+
+    fn render_states(&self) -> RenderStates {
+        self.render_states
+    }
+
+    fn material_type(&self) -> MaterialType {
+        MaterialType::Opaque
+    }
+}

--- a/src/renderer/material/geometry_instance_material.rs
+++ b/src/renderer/material/geometry_instance_material.rs
@@ -30,13 +30,14 @@ impl Material for GeometryInstanceMaterial {
 
     fn fragment_attributes(&self) -> FragmentAttributes {
         FragmentAttributes {
+            position: true,
             instance_id: true,
             ..FragmentAttributes::NONE
         }
     }
 
     fn use_uniforms(&self, program: &Program, camera: &Camera, _lights: &[&dyn Light]) {
-        program.use_uniform("id", self.id as f32);
+        program.use_uniform("id", self.id as i32);
         program.use_uniform("eye", camera.position());
     }
 

--- a/src/renderer/material/physical_material.rs
+++ b/src/renderer/material/physical_material.rs
@@ -202,6 +202,7 @@ impl Material for PhysicalMaterial {
                 || self.occlusion_texture.is_some()
                 || self.emissive_texture.is_some(),
             tangents: self.normal_texture.is_some(),
+            ..FragmentAttributes::NONE
         }
     }
 

--- a/src/renderer/material/shaders/geometry_instance_material.frag
+++ b/src/renderer/material/shaders/geometry_instance_material.frag
@@ -1,15 +1,14 @@
-uniform float id;
+uniform int id;
 uniform vec3 eye;
 
+flat in int instanceID;
+
 in vec3 pos;
-in vec4 col;
 
 layout (location = 0) out vec4 outColor;
 
 void main()
 {
-    float instanceID = -col.x;
-
     float dist = distance(pos, eye);
-    outColor = vec4(dist, id, instanceID, 1.0);
+    outColor = vec4(dist, float(id), float(instanceID), 1.0);
 }

--- a/src/renderer/material/shaders/geometry_instance_material.frag
+++ b/src/renderer/material/shaders/geometry_instance_material.frag
@@ -1,0 +1,15 @@
+uniform float id;
+uniform vec3 eye;
+
+in vec3 pos;
+in vec4 col;
+
+layout (location = 0) out vec4 outColor;
+
+void main()
+{
+    float instanceID = -col.x;
+
+    float dist = distance(pos, eye);
+    outColor = vec4(dist, id, instanceID, 1.0);
+}

--- a/src/renderer/material/shaders/geometry_instance_material.frag
+++ b/src/renderer/material/shaders/geometry_instance_material.frag
@@ -5,10 +5,10 @@ flat in int instanceID;
 
 in vec3 pos;
 
-layout (location = 0) out vec4 outColor;
+layout (location = 0) out ivec4 outColor;
 
 void main()
 {
     float dist = distance(pos, eye);
-    outColor = vec4(dist, float(id), float(instanceID), 1.0);
+    outColor = ivec4(floatBitsToInt(dist), id, instanceID, -1);
 }

--- a/src/renderer/shader_ids.rs
+++ b/src/renderer/shader_ids.rs
@@ -98,8 +98,8 @@ pub enum GeometryId {
     Sprites = 0x8004,
     WaterPatch = 0x8005,
     MeshBase = 0x8010,           // To 0x801F
-    ParticleSystemBase = 0x8040, // To 0x807F
-    InstancedMeshBase = 0x8080,  // To 0x80FF
+    ParticleSystemBase = 0x8080, // To 0x80FF
+    InstancedMeshBase = 0x8100,  // To 0x81FF
 }
 
 impl GeometryId {
@@ -107,7 +107,15 @@ impl GeometryId {
     enum_bitfield!(MeshBase, Mesh(normal, tangents, uv, color));
     enum_bitfield!(
         ParticleSystemBase,
-        ParticleSystem(normal, tangents, uv, color, instance_color, instance_uv)
+        ParticleSystem(
+            normal,
+            tangents,
+            uv,
+            color,
+            instance_color,
+            instance_uv,
+            instance_id,
+        )
     );
     enum_bitfield!(
         InstancedMeshBase,
@@ -119,6 +127,7 @@ impl GeometryId {
             instance_color,
             instance_transformation,
             instance_uv,
+            instance_id,
         )
     );
 }
@@ -144,6 +153,7 @@ pub enum EffectMaterialId {
     SkyboxMaterial = 0x8004,
     UVMaterial = 0x8005,
     NormalMaterialBase = 0x8006, // To 0x8007
+    GeometryInstanceMaterial = 0x800B,
     IsosurfaceMaterial = 0x800C,
     ImpostersMaterial = 0x800D,
     BrdfMaterial = 0x800E,

--- a/web/index.html
+++ b/web/index.html
@@ -4,6 +4,5 @@
   </head>
   <body>
     <canvas style="position: absolute;top:0;bottom: 0;left: 0;right: 0;margin:auto;"></canvas>
-    <canvas style="position: absolute;top:0;bottom: 0;left: 600;right: 0;margin:auto;"></canvas>
   </body>
 </html>


### PR DESCRIPTION
This adds `pick_instance` and `ray_intersect_instance` functions to allow detecting which geometry instance a ray intersects with. There is a new example `picking_instances` that demonstrates this capability for basic geometry, instanced geometry, and imported models. The additional example has yet to be added to the examples README. This closes #467.

Additionally, the shader IDs have been separated out to simplify keeping track of which ID's were used, and a few ID overlaps were corrected. The shader IDs internally make use of `open_enum` types, which could be changed to also be the public type signature in a breaking release. The shader ID changes can be seen individually at https://github.com/thatcomputerguy0101/three-d/tree/shader_ID_refactor, and I can create a separate pull request for that or remove those changes if desired.