### PR TITLE
Add Texture2D/Texture2DArray/Texture3D::number_of_mip_maps()

### DIFF
--- a/src/core/texture/texture2d.rs
+++ b/src/core/texture/texture2d.rs
@@ -160,6 +160,11 @@ impl Texture2D {
         self.height
     }
 
+    /// The number of mip maps of this texture.
+    pub fn number_of_mip_maps(&self) -> u32 {
+        self.number_of_mip_maps
+    }
+
     pub(crate) fn generate_mip_maps(&self) {
         if self.number_of_mip_maps > 1 {
             self.bind();

--- a/src/core/texture/texture2d_array.rs
+++ b/src/core/texture/texture2d_array.rs
@@ -281,6 +281,11 @@ impl Texture2DArray {
         self.depth
     }
 
+    /// The number of mip maps of this texture.
+    pub fn number_of_mip_maps(&self) -> u32 {
+        self.number_of_mip_maps
+    }
+
     pub(in crate::core) fn generate_mip_maps(&self) {
         if self.number_of_mip_maps > 1 {
             self.bind();

--- a/src/core/texture/texture3d.rs
+++ b/src/core/texture/texture3d.rs
@@ -163,6 +163,11 @@ impl Texture3D {
         self.depth
     }
 
+    /// The number of mip maps of this texture.
+    pub fn number_of_mip_maps(&self) -> u32 {
+        self.number_of_mip_maps
+    }
+
     fn generate_mip_maps(&self) {
         if self.number_of_mip_maps > 1 {
             self.bind();

--- a/src/core/texture/texture_cube_map.rs
+++ b/src/core/texture/texture_cube_map.rs
@@ -529,6 +529,11 @@ impl TextureCubeMap {
         self.height
     }
 
+    /// The number of mip maps of this texture.
+    pub fn number_of_mip_maps(&self) -> u32 {
+        self.number_of_mip_maps
+    }
+
     pub(in crate::core) fn generate_mip_maps(&self) {
         if self.number_of_mip_maps > 1 {
             self.bind();


### PR DESCRIPTION
Since there is no way of retrieving the configured number of mip maps from OpenGL, customizing them after texture creation would require guessing the number / or copy-pasting the three-d code that computes it.

This PR introduces a getter on all `Texture` structs which simply returns the number to avoid the guess work or copy-pasting of three-d code into the game / application.

In my case I need the number so I can easily switch out the higher mip map levels with custom textures.