### PR TITLE
Shader ID refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ winit = {version = "0.28", optional = true}
 egui = { version = "0.28", optional = true }
 egui_glow = { version = "0.28", optional = true }
 getrandom = { version = "0.2", features = ["js"], optional = true }
+open-enum = "0.5"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 glutin = { version = "0.30", optional = true }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -460,7 +460,7 @@ pub fn apply_screen_material(
     if fragment_attributes.normal || fragment_attributes.position || fragment_attributes.tangents {
         panic!("Not possible to use the given material to render full screen, the full screen geometry only provides uv coordinates and color");
     }
-    let mut id = (0b1u16 << 15).to_le_bytes().to_vec();
+    let mut id = GeometryID::SCREEN.0.to_le_bytes().to_vec();
     id.extend(material.id().to_le_bytes());
     id.extend(lights.iter().map(|l| l.id()));
 
@@ -499,7 +499,7 @@ pub fn apply_screen_effect(
     if fragment_attributes.normal || fragment_attributes.position || fragment_attributes.tangents {
         panic!("Not possible to use the given effect to render full screen, the full screen geometry only provides uv coordinates and color");
     }
-    let mut id = (0b1u16 << 15).to_le_bytes().to_vec();
+    let mut id = GeometryID::SCREEN.0.to_le_bytes().to_vec();
     id.extend(effect.id(color_texture, depth_texture).to_le_bytes());
     id.extend(lights.iter().map(|l| l.id()));
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -460,7 +460,7 @@ pub fn apply_screen_material(
     if fragment_attributes.normal || fragment_attributes.position || fragment_attributes.tangents {
         panic!("Not possible to use the given material to render full screen, the full screen geometry only provides uv coordinates and color");
     }
-    let mut id = GeometryID::SCREEN.0.to_le_bytes().to_vec();
+    let mut id = GeometryId::Screen.0.to_le_bytes().to_vec();
     id.extend(material.id().to_le_bytes());
     id.extend(lights.iter().map(|l| l.id()));
 
@@ -499,7 +499,7 @@ pub fn apply_screen_effect(
     if fragment_attributes.normal || fragment_attributes.position || fragment_attributes.tangents {
         panic!("Not possible to use the given effect to render full screen, the full screen geometry only provides uv coordinates and color");
     }
-    let mut id = GeometryID::SCREEN.0.to_le_bytes().to_vec();
+    let mut id = GeometryId::Screen.0.to_le_bytes().to_vec();
     id.extend(effect.id(color_texture, depth_texture).to_le_bytes());
     id.extend(lights.iter().map(|l| l.id()));
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -31,6 +31,9 @@ pub enum RendererError {
     MissingMaterial(String, String),
 }
 
+mod shader_ids;
+pub(crate) use shader_ids::*;
+
 mod camera;
 pub use camera::*;
 

--- a/src/renderer/effect/copy.rs
+++ b/src/renderer/effect/copy.rs
@@ -50,7 +50,7 @@ impl Effect for CopyEffect {
     }
 
     fn id(&self, color_texture: Option<ColorTexture>, depth_texture: Option<DepthTexture>) -> u16 {
-        <EffectMaterialId>::CopyEffect(color_texture, depth_texture).0
+        EffectMaterialId::CopyEffect(color_texture, depth_texture).0
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {

--- a/src/renderer/effect/copy.rs
+++ b/src/renderer/effect/copy.rs
@@ -50,10 +50,7 @@ impl Effect for CopyEffect {
     }
 
     fn id(&self, color_texture: Option<ColorTexture>, depth_texture: Option<DepthTexture>) -> u16 {
-        <EffectMaterialID>::CopyEffect(
-            color_texture,
-            depth_texture,
-        ).0
+        <EffectMaterialID>::CopyEffect(color_texture, depth_texture).0
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {

--- a/src/renderer/effect/copy.rs
+++ b/src/renderer/effect/copy.rs
@@ -50,10 +50,10 @@ impl Effect for CopyEffect {
     }
 
     fn id(&self, color_texture: Option<ColorTexture>, depth_texture: Option<DepthTexture>) -> u16 {
-        0b1u16 << 14
-            | 0b1u16 << 13
-            | color_texture.map(|t| t.id()).unwrap_or(0u16)
-            | depth_texture.map(|t| t.id()).unwrap_or(0u16)
+        <EffectMaterialID>::CopyEffect(
+            color_texture,
+            depth_texture,
+        ).0
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {

--- a/src/renderer/effect/copy.rs
+++ b/src/renderer/effect/copy.rs
@@ -50,7 +50,7 @@ impl Effect for CopyEffect {
     }
 
     fn id(&self, color_texture: Option<ColorTexture>, depth_texture: Option<DepthTexture>) -> u16 {
-        <EffectMaterialID>::CopyEffect(color_texture, depth_texture).0
+        <EffectMaterialId>::CopyEffect(color_texture, depth_texture).0
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {

--- a/src/renderer/effect/fog.rs
+++ b/src/renderer/effect/fog.rs
@@ -52,7 +52,8 @@ impl Effect for FogEffect {
         EffectMaterialID::FogEffect(
             color_texture.expect("Must supply a color texture to apply a fog effect"),
             depth_texture.expect("Must supply a depth texture to apply a fog effect"),
-        ).0
+        )
+        .0
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {

--- a/src/renderer/effect/fog.rs
+++ b/src/renderer/effect/fog.rs
@@ -49,15 +49,10 @@ impl Effect for FogEffect {
     }
 
     fn id(&self, color_texture: Option<ColorTexture>, depth_texture: Option<DepthTexture>) -> u16 {
-        0b1u16 << 14
-            | 0b1u16 << 13
-            | 0b1u16 << 12
-            | color_texture
-                .expect("Must supply a color texture to apply a fog effect")
-                .id()
-            | depth_texture
-                .expect("Must supply a depth texture to apply a fog effect")
-                .id()
+        EffectMaterialID::FogEffect(
+            color_texture.expect("Must supply a color texture to apply a fog effect"),
+            depth_texture.expect("Must supply a depth texture to apply a fog effect"),
+        ).0
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {

--- a/src/renderer/effect/fog.rs
+++ b/src/renderer/effect/fog.rs
@@ -49,7 +49,7 @@ impl Effect for FogEffect {
     }
 
     fn id(&self, color_texture: Option<ColorTexture>, depth_texture: Option<DepthTexture>) -> u16 {
-        EffectMaterialID::FogEffect(
+        EffectMaterialId::FogEffect(
             color_texture.expect("Must supply a color texture to apply a fog effect"),
             depth_texture.expect("Must supply a depth texture to apply a fog effect"),
         )

--- a/src/renderer/effect/full_screen.rs
+++ b/src/renderer/effect/full_screen.rs
@@ -54,11 +54,10 @@ impl Effect for ScreenEffect {
     }
 
     fn id(&self, color_texture: Option<ColorTexture>, depth_texture: Option<DepthTexture>) -> u16 {
-        0b1u16 << 14
-            | 0b1u16 << 13
-            | 0b1u16 << 11
-            | color_texture.map(|t| t.id()).unwrap_or(0u16)
-            | depth_texture.map(|t| t.id()).unwrap_or(0u16)
+        EffectMaterialID::ScreenEffect(
+            color_texture,
+            depth_texture,
+        ).0
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {

--- a/src/renderer/effect/full_screen.rs
+++ b/src/renderer/effect/full_screen.rs
@@ -54,7 +54,7 @@ impl Effect for ScreenEffect {
     }
 
     fn id(&self, color_texture: Option<ColorTexture>, depth_texture: Option<DepthTexture>) -> u16 {
-        EffectMaterialID::ScreenEffect(color_texture, depth_texture).0
+        EffectMaterialId::ScreenEffect(color_texture, depth_texture).0
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {

--- a/src/renderer/effect/full_screen.rs
+++ b/src/renderer/effect/full_screen.rs
@@ -54,10 +54,7 @@ impl Effect for ScreenEffect {
     }
 
     fn id(&self, color_texture: Option<ColorTexture>, depth_texture: Option<DepthTexture>) -> u16 {
-        EffectMaterialID::ScreenEffect(
-            color_texture,
-            depth_texture,
-        ).0
+        EffectMaterialID::ScreenEffect(color_texture, depth_texture).0
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {

--- a/src/renderer/effect/fxaa.rs
+++ b/src/renderer/effect/fxaa.rs
@@ -24,7 +24,7 @@ impl Effect for FxaaEffect {
     }
 
     fn id(&self, color_texture: Option<ColorTexture>, _depth_texture: Option<DepthTexture>) -> u16 {
-        EffectMaterialID::FxaaEffect(
+        EffectMaterialId::FxaaEffect(
             color_texture.expect("Must supply a color texture to apply a fxaa effect"),
         )
         .0

--- a/src/renderer/effect/fxaa.rs
+++ b/src/renderer/effect/fxaa.rs
@@ -26,7 +26,8 @@ impl Effect for FxaaEffect {
     fn id(&self, color_texture: Option<ColorTexture>, _depth_texture: Option<DepthTexture>) -> u16 {
         EffectMaterialID::FxaaEffect(
             color_texture.expect("Must supply a color texture to apply a fxaa effect"),
-        ).0
+        )
+        .0
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {

--- a/src/renderer/effect/fxaa.rs
+++ b/src/renderer/effect/fxaa.rs
@@ -24,9 +24,9 @@ impl Effect for FxaaEffect {
     }
 
     fn id(&self, color_texture: Option<ColorTexture>, _depth_texture: Option<DepthTexture>) -> u16 {
-        let color_texture =
-            color_texture.expect("Must supply a color texture to apply a fxaa effect");
-        0b1u16 << 14 | 0b1u16 << 13 | 0b1u16 << 12 | 0b1u16 << 11 | color_texture.id()
+        EffectMaterialID::FxaaEffect(
+            color_texture.expect("Must supply a color texture to apply a fxaa effect"),
+        ).0
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {

--- a/src/renderer/effect/lighting_pass.rs
+++ b/src/renderer/effect/lighting_pass.rs
@@ -25,10 +25,7 @@ impl Effect for LightingPassEffect {
     }
 
     fn id(&self, color_texture: Option<ColorTexture>, depth_texture: Option<DepthTexture>) -> u16 {
-        EffectMaterialID::LightingPassEffect(
-            color_texture.unwrap(),
-            depth_texture.unwrap(),
-        ).0
+        EffectMaterialID::LightingPassEffect(color_texture.unwrap(), depth_texture.unwrap()).0
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {

--- a/src/renderer/effect/lighting_pass.rs
+++ b/src/renderer/effect/lighting_pass.rs
@@ -25,7 +25,10 @@ impl Effect for LightingPassEffect {
     }
 
     fn id(&self, color_texture: Option<ColorTexture>, depth_texture: Option<DepthTexture>) -> u16 {
-        0b1u16 << 14 | 0b1u16 << 12 | color_texture.unwrap().id() | depth_texture.unwrap().id()
+        EffectMaterialID::LightingPassEffect(
+            color_texture.unwrap(),
+            depth_texture.unwrap(),
+        ).0
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {

--- a/src/renderer/effect/lighting_pass.rs
+++ b/src/renderer/effect/lighting_pass.rs
@@ -25,7 +25,7 @@ impl Effect for LightingPassEffect {
     }
 
     fn id(&self, color_texture: Option<ColorTexture>, depth_texture: Option<DepthTexture>) -> u16 {
-        EffectMaterialID::LightingPassEffect(color_texture.unwrap(), depth_texture.unwrap()).0
+        EffectMaterialId::LightingPassEffect(color_texture.unwrap(), depth_texture.unwrap()).0
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {

--- a/src/renderer/effect/water.rs
+++ b/src/renderer/effect/water.rs
@@ -60,15 +60,10 @@ impl Effect for WaterEffect {
     }
 
     fn id(&self, color_texture: Option<ColorTexture>, depth_texture: Option<DepthTexture>) -> u16 {
-        0b1u16 << 14
-            | 0b1u16 << 12
-            | 0b1u16 << 11
-            | color_texture
-                .expect("Must supply a color texture to apply a water effect")
-                .id()
-            | depth_texture
-                .expect("Must supply a depth texture to apply a water effect")
-                .id()
+        EffectMaterialID::WaterEffect(
+            color_texture.expect("Must supply a color texture to apply a water effect"),
+            depth_texture.expect("Must supply a depth texture to apply a water effect"),
+        ).0
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {

--- a/src/renderer/effect/water.rs
+++ b/src/renderer/effect/water.rs
@@ -63,7 +63,8 @@ impl Effect for WaterEffect {
         EffectMaterialID::WaterEffect(
             color_texture.expect("Must supply a color texture to apply a water effect"),
             depth_texture.expect("Must supply a depth texture to apply a water effect"),
-        ).0
+        )
+        .0
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {

--- a/src/renderer/effect/water.rs
+++ b/src/renderer/effect/water.rs
@@ -60,7 +60,7 @@ impl Effect for WaterEffect {
     }
 
     fn id(&self, color_texture: Option<ColorTexture>, depth_texture: Option<DepthTexture>) -> u16 {
-        EffectMaterialID::WaterEffect(
+        EffectMaterialId::WaterEffect(
             color_texture.expect("Must supply a color texture to apply a water effect"),
             depth_texture.expect("Must supply a depth texture to apply a water effect"),
         )

--- a/src/renderer/geometry/instanced_mesh.rs
+++ b/src/renderer/geometry/instanced_mesh.rs
@@ -316,14 +316,15 @@ impl Geometry for InstancedMesh {
             .expect("failed to acquire read access")
             .0;
         GeometryID::InstancedMesh(
-            required_attributes.normal, 
+            required_attributes.normal,
             required_attributes.tangents,
             required_attributes.uv,
             required_attributes.color && self.base_mesh.colors.is_some(),
             required_attributes.color && instance_buffers.contains_key("instance_color"),
             instance_buffers.contains_key("instance_translation"),
             required_attributes.uv && instance_buffers.contains_key("tex_transform_row1"),
-        ).0
+        )
+        .0
     }
 
     fn aabb(&self) -> AxisAlignedBoundingBox {

--- a/src/renderer/geometry/instanced_mesh.rs
+++ b/src/renderer/geometry/instanced_mesh.rs
@@ -315,7 +315,7 @@ impl Geometry for InstancedMesh {
             .read()
             .expect("failed to acquire read access")
             .0;
-        GeometryID::InstancedMesh(
+        GeometryId::InstancedMesh(
             required_attributes.normal,
             required_attributes.tangents,
             required_attributes.uv,

--- a/src/renderer/geometry/instanced_mesh.rs
+++ b/src/renderer/geometry/instanced_mesh.rs
@@ -315,29 +315,15 @@ impl Geometry for InstancedMesh {
             .read()
             .expect("failed to acquire read access")
             .0;
-        let mut id = 0b1u16 << 15 | 0b1u16 << 7;
-        if required_attributes.normal {
-            id |= 0b1u16;
-        }
-        if required_attributes.tangents {
-            id |= 0b1u16 << 1;
-        }
-        if required_attributes.uv {
-            id |= 0b1u16 << 2;
-        }
-        if required_attributes.color && self.base_mesh.colors.is_some() {
-            id |= 0b1u16 << 3;
-        }
-        if required_attributes.color && instance_buffers.contains_key("instance_color") {
-            id |= 0b1u16 << 4;
-        }
-        if instance_buffers.contains_key("instance_translation") {
-            id |= 0b1u16 << 5;
-        }
-        if required_attributes.uv && instance_buffers.contains_key("tex_transform_row1") {
-            id |= 0b1u16 << 6;
-        }
-        id
+        GeometryID::InstancedMesh(
+            required_attributes.normal, 
+            required_attributes.tangents,
+            required_attributes.uv,
+            required_attributes.color && self.base_mesh.colors.is_some(),
+            required_attributes.color && instance_buffers.contains_key("instance_color"),
+            instance_buffers.contains_key("instance_translation"),
+            required_attributes.uv && instance_buffers.contains_key("tex_transform_row1"),
+        ).0
     }
 
     fn aabb(&self) -> AxisAlignedBoundingBox {

--- a/src/renderer/geometry/mesh.rs
+++ b/src/renderer/geometry/mesh.rs
@@ -195,7 +195,8 @@ impl Geometry for Mesh {
             required_attributes.tangents,
             required_attributes.uv,
             required_attributes.color,
-        ).0
+        )
+        .0
     }
 
     fn render_with_material(

--- a/src/renderer/geometry/mesh.rs
+++ b/src/renderer/geometry/mesh.rs
@@ -190,20 +190,12 @@ impl Geometry for Mesh {
     }
 
     fn id(&self, required_attributes: FragmentAttributes) -> u16 {
-        let mut id = 0b1u16 << 15 | 0b1u16 << 4;
-        if required_attributes.normal {
-            id |= 0b1u16;
-        }
-        if required_attributes.tangents {
-            id |= 0b1u16 << 1;
-        }
-        if required_attributes.uv {
-            id |= 0b1u16 << 2;
-        }
-        if required_attributes.color && self.base_mesh.colors.is_some() {
-            id |= 0b1u16 << 3;
-        }
-        id
+        GeometryID::Mesh(
+            required_attributes.normal,
+            required_attributes.tangents,
+            required_attributes.uv,
+            required_attributes.color,
+        ).0
     }
 
     fn render_with_material(

--- a/src/renderer/geometry/mesh.rs
+++ b/src/renderer/geometry/mesh.rs
@@ -190,7 +190,7 @@ impl Geometry for Mesh {
     }
 
     fn id(&self, required_attributes: FragmentAttributes) -> u16 {
-        GeometryID::Mesh(
+        GeometryId::Mesh(
             required_attributes.normal,
             required_attributes.tangents,
             required_attributes.uv,

--- a/src/renderer/geometry/particles.rs
+++ b/src/renderer/geometry/particles.rs
@@ -188,26 +188,14 @@ impl<'a> IntoIterator for &'a ParticleSystem {
 
 impl Geometry for ParticleSystem {
     fn id(&self, required_attributes: FragmentAttributes) -> u16 {
-        let mut id = 0b1u16 << 15 | 0b1u16 << 5;
-        if required_attributes.normal {
-            id |= 0b1u16;
-        }
-        if required_attributes.tangents {
-            id |= 0b1u16 << 1;
-        }
-        if required_attributes.uv {
-            id |= 0b1u16 << 2;
-        }
-        if required_attributes.color && self.base_mesh.colors.is_some() {
-            id |= 0b1u16 << 3;
-        }
-        if required_attributes.color && self.instance_buffers.contains_key("instance_color") {
-            id |= 0b1u16 << 4;
-        }
-        if required_attributes.uv && self.instance_buffers.contains_key("tex_transform_row1") {
-            id |= 0b1u16 << 5;
-        }
-        id
+        GeometryID::ParticleSystem(
+            required_attributes.normal,
+            required_attributes.tangents,
+            required_attributes.uv,
+            required_attributes.color && self.base_mesh.colors.is_some(),
+            required_attributes.color && self.instance_buffers.contains_key("instance_color"),
+            required_attributes.uv && self.instance_buffers.contains_key("tex_transform_row1"),
+        ).0
     }
 
     fn vertex_shader_source(&self, required_attributes: FragmentAttributes) -> String {

--- a/src/renderer/geometry/particles.rs
+++ b/src/renderer/geometry/particles.rs
@@ -188,7 +188,7 @@ impl<'a> IntoIterator for &'a ParticleSystem {
 
 impl Geometry for ParticleSystem {
     fn id(&self, required_attributes: FragmentAttributes) -> u16 {
-        GeometryID::ParticleSystem(
+        GeometryId::ParticleSystem(
             required_attributes.normal,
             required_attributes.tangents,
             required_attributes.uv,

--- a/src/renderer/geometry/particles.rs
+++ b/src/renderer/geometry/particles.rs
@@ -195,7 +195,8 @@ impl Geometry for ParticleSystem {
             required_attributes.color && self.base_mesh.colors.is_some(),
             required_attributes.color && self.instance_buffers.contains_key("instance_color"),
             required_attributes.uv && self.instance_buffers.contains_key("tex_transform_row1"),
-        ).0
+        )
+        .0
     }
 
     fn vertex_shader_source(&self, required_attributes: FragmentAttributes) -> String {

--- a/src/renderer/geometry/sprites.rs
+++ b/src/renderer/geometry/sprites.rs
@@ -131,7 +131,7 @@ impl Geometry for Sprites {
     }
 
     fn id(&self, _required_attributes: FragmentAttributes) -> u16 {
-        GeometryID::Sprites.0
+        GeometryId::Sprites.0
     }
 
     fn render_with_material(

--- a/src/renderer/geometry/sprites.rs
+++ b/src/renderer/geometry/sprites.rs
@@ -131,7 +131,7 @@ impl Geometry for Sprites {
     }
 
     fn id(&self, _required_attributes: FragmentAttributes) -> u16 {
-        0b1u16 << 15 | 0b100u16
+        GeometryID::Sprites.0
     }
 
     fn render_with_material(

--- a/src/renderer/light/ambient_light.rs
+++ b/src/renderer/light/ambient_light.rs
@@ -101,7 +101,7 @@ impl Light for AmbientLight {
     }
 
     fn id(&self) -> u8 {
-        LightID::AmbientLight(self.environment.is_none()).0
+        LightID::AmbientLight(self.environment.is_some()).0
     }
 }
 

--- a/src/renderer/light/ambient_light.rs
+++ b/src/renderer/light/ambient_light.rs
@@ -101,7 +101,7 @@ impl Light for AmbientLight {
     }
 
     fn id(&self) -> u8 {
-        LightID::AmbientLight(self.environment.is_some()).0
+        LightId::AmbientLight(self.environment.is_some()).0
     }
 }
 

--- a/src/renderer/light/ambient_light.rs
+++ b/src/renderer/light/ambient_light.rs
@@ -101,11 +101,7 @@ impl Light for AmbientLight {
     }
 
     fn id(&self) -> u8 {
-        if self.environment.is_some() {
-            0b1u8 << 7
-        } else {
-            0b1u8 << 7 | 0b1u8
-        }
+        LightID::AmbientLight(self.environment.is_none()).0
     }
 }
 

--- a/src/renderer/light/directional_light.rs
+++ b/src/renderer/light/directional_light.rs
@@ -170,10 +170,6 @@ impl Light for DirectionalLight {
     }
 
     fn id(&self) -> u8 {
-        if self.shadow_texture.is_some() {
-            0b1u8 << 7 | 0b10u8
-        } else {
-            0b1u8 << 7 | 0b11u8
-        }
+        LightID::DirectionalLight(self.shadow_texture.is_none()).0
     }
 }

--- a/src/renderer/light/directional_light.rs
+++ b/src/renderer/light/directional_light.rs
@@ -170,6 +170,6 @@ impl Light for DirectionalLight {
     }
 
     fn id(&self) -> u8 {
-        LightID::DirectionalLight(self.shadow_texture.is_some()).0
+        LightId::DirectionalLight(self.shadow_texture.is_some()).0
     }
 }

--- a/src/renderer/light/directional_light.rs
+++ b/src/renderer/light/directional_light.rs
@@ -170,6 +170,6 @@ impl Light for DirectionalLight {
     }
 
     fn id(&self) -> u8 {
-        LightID::DirectionalLight(self.shadow_texture.is_none()).0
+        LightID::DirectionalLight(self.shadow_texture.is_some()).0
     }
 }

--- a/src/renderer/light/environment.rs
+++ b/src/renderer/light/environment.rs
@@ -156,7 +156,7 @@ impl Material for PrefilterMaterial<'_> {
     }
 
     fn id(&self) -> u16 {
-        0b1u16 << 15 | 0b1u16 << 7
+        EffectMaterialID::PrefilterMaterial.0
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {
@@ -202,7 +202,7 @@ impl Material for BrdfMaterial {
     }
 
     fn id(&self) -> u16 {
-        0b1u16 << 15 | 0b1110u16
+        EffectMaterialID::BrdfMaterial.0
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {
@@ -238,7 +238,7 @@ impl Material for IrradianceMaterial<'_> {
     }
 
     fn id(&self) -> u16 {
-        0b1u16 << 15 | 0b1111u16
+        EffectMaterialID::IrradianceMaterial.0
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {

--- a/src/renderer/light/environment.rs
+++ b/src/renderer/light/environment.rs
@@ -156,7 +156,7 @@ impl Material for PrefilterMaterial<'_> {
     }
 
     fn id(&self) -> u16 {
-        EffectMaterialID::PrefilterMaterial.0
+        EffectMaterialId::PrefilterMaterial.0
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {
@@ -202,7 +202,7 @@ impl Material for BrdfMaterial {
     }
 
     fn id(&self) -> u16 {
-        EffectMaterialID::BrdfMaterial.0
+        EffectMaterialId::BrdfMaterial.0
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {
@@ -238,7 +238,7 @@ impl Material for IrradianceMaterial<'_> {
     }
 
     fn id(&self) -> u16 {
-        EffectMaterialID::IrradianceMaterial.0
+        EffectMaterialId::IrradianceMaterial.0
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {

--- a/src/renderer/light/point_light.rs
+++ b/src/renderer/light/point_light.rs
@@ -70,6 +70,6 @@ impl Light for PointLight {
     }
 
     fn id(&self) -> u8 {
-        0b1u8 << 7 | 0b100u8
+        LightID::PointLight.0
     }
 }

--- a/src/renderer/light/point_light.rs
+++ b/src/renderer/light/point_light.rs
@@ -70,6 +70,6 @@ impl Light for PointLight {
     }
 
     fn id(&self) -> u8 {
-        LightID::PointLight.0
+        LightId::PointLight.0
     }
 }

--- a/src/renderer/light/spot_light.rs
+++ b/src/renderer/light/spot_light.rs
@@ -223,10 +223,6 @@ impl Light for SpotLight {
     }
 
     fn id(&self) -> u8 {
-        if self.shadow_texture.is_some() {
-            0b1u8 << 7 | 0b101u8
-        } else {
-            0b1u8 << 7 | 0b110u8
-        }
+        LightID::SpotLight(self.shadow_texture.is_none()).0
     }
 }

--- a/src/renderer/light/spot_light.rs
+++ b/src/renderer/light/spot_light.rs
@@ -223,6 +223,6 @@ impl Light for SpotLight {
     }
 
     fn id(&self) -> u8 {
-        LightID::SpotLight(self.shadow_texture.is_some()).0
+        LightId::SpotLight(self.shadow_texture.is_some()).0
     }
 }

--- a/src/renderer/light/spot_light.rs
+++ b/src/renderer/light/spot_light.rs
@@ -223,6 +223,6 @@ impl Light for SpotLight {
     }
 
     fn id(&self) -> u8 {
-        LightID::SpotLight(self.shadow_texture.is_none()).0
+        LightID::SpotLight(self.shadow_texture.is_some()).0
     }
 }

--- a/src/renderer/material/color_material.rs
+++ b/src/renderer/material/color_material.rs
@@ -99,7 +99,7 @@ impl FromCpuMaterial for ColorMaterial {
 
 impl Material for ColorMaterial {
     fn id(&self) -> u16 {
-        EffectMaterialID::ColorMaterial(self.texture.is_some()).0
+        EffectMaterialId::ColorMaterial(self.texture.is_some()).0
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/color_material.rs
+++ b/src/renderer/material/color_material.rs
@@ -99,7 +99,7 @@ impl FromCpuMaterial for ColorMaterial {
 
 impl Material for ColorMaterial {
     fn id(&self) -> u16 {
-        EffectMaterialID::ColorMaterial(self.texture.is_none()).0
+        EffectMaterialID::ColorMaterial(self.texture.is_some()).0
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/color_material.rs
+++ b/src/renderer/material/color_material.rs
@@ -99,11 +99,7 @@ impl FromCpuMaterial for ColorMaterial {
 
 impl Material for ColorMaterial {
     fn id(&self) -> u16 {
-        if self.texture.is_some() {
-            0b1u16 << 15
-        } else {
-            0b1u16 << 15 | 0b1u16
-        }
+        EffectMaterialID::ColorMaterial(self.texture.is_none()).0
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/deferred_physical_material.rs
+++ b/src/renderer/material/deferred_physical_material.rs
@@ -179,26 +179,14 @@ impl FromCpuMaterial for DeferredPhysicalMaterial {
 
 impl Material for DeferredPhysicalMaterial {
     fn id(&self) -> u16 {
-        let mut id = 0b1u16 << 15 | 0b1u16 << 6;
-        if self.albedo_texture.is_some() {
-            id |= 0b1u16;
-        }
-        if self.metallic_roughness_texture.is_some() {
-            id |= 0b1u16 << 1;
-        }
-        if self.occlusion_texture.is_some() {
-            id |= 0b1u16 << 2;
-        }
-        if self.normal_texture.is_some() {
-            id |= 0b1u16 << 3;
-        }
-        if self.emissive_texture.is_some() {
-            id |= 0b1u16 << 4;
-        }
-        if self.alpha_cutout.is_some() {
-            id |= 0b1u16 << 5;
-        }
-        id
+        EffectMaterialID::DeferredPhysicalMaterial(
+            self.albedo_texture.is_some(),
+            self.metallic_roughness_texture.is_some(),
+            self.occlusion_texture.is_some(),
+            self.normal_texture.is_some(),
+            self.emissive_texture.is_some(),
+            self.alpha_cutout.is_some(),
+        ).0
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/deferred_physical_material.rs
+++ b/src/renderer/material/deferred_physical_material.rs
@@ -186,7 +186,8 @@ impl Material for DeferredPhysicalMaterial {
             self.normal_texture.is_some(),
             self.emissive_texture.is_some(),
             self.alpha_cutout.is_some(),
-        ).0
+        )
+        .0
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/deferred_physical_material.rs
+++ b/src/renderer/material/deferred_physical_material.rs
@@ -179,7 +179,7 @@ impl FromCpuMaterial for DeferredPhysicalMaterial {
 
 impl Material for DeferredPhysicalMaterial {
     fn id(&self) -> u16 {
-        EffectMaterialID::DeferredPhysicalMaterial(
+        EffectMaterialId::DeferredPhysicalMaterial(
             self.albedo_texture.is_some(),
             self.metallic_roughness_texture.is_some(),
             self.occlusion_texture.is_some(),

--- a/src/renderer/material/depth_material.rs
+++ b/src/renderer/material/depth_material.rs
@@ -23,7 +23,7 @@ impl FromCpuMaterial for DepthMaterial {
 
 impl Material for DepthMaterial {
     fn id(&self) -> u16 {
-        0b1u16 << 15 | 0b10u16
+        EffectMaterialID::DepthMaterial.0
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/depth_material.rs
+++ b/src/renderer/material/depth_material.rs
@@ -23,7 +23,7 @@ impl FromCpuMaterial for DepthMaterial {
 
 impl Material for DepthMaterial {
     fn id(&self) -> u16 {
-        EffectMaterialID::DepthMaterial.0
+        EffectMaterialId::DepthMaterial.0
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/isosurface_material.rs
+++ b/src/renderer/material/isosurface_material.rs
@@ -26,7 +26,7 @@ pub struct IsosurfaceMaterial {
 
 impl Material for IsosurfaceMaterial {
     fn id(&self) -> u16 {
-        0b1u16 << 15 | 0b1100u16
+        EffectMaterialID::IsosurfaceMaterial.0
     }
 
     fn fragment_shader_source(&self, lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/isosurface_material.rs
+++ b/src/renderer/material/isosurface_material.rs
@@ -26,7 +26,7 @@ pub struct IsosurfaceMaterial {
 
 impl Material for IsosurfaceMaterial {
     fn id(&self) -> u16 {
-        EffectMaterialID::IsosurfaceMaterial.0
+        EffectMaterialId::IsosurfaceMaterial.0
     }
 
     fn fragment_shader_source(&self, lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/normal_material.rs
+++ b/src/renderer/material/normal_material.rs
@@ -52,7 +52,7 @@ impl FromCpuMaterial for NormalMaterial {
 
 impl Material for NormalMaterial {
     fn id(&self) -> u16 {
-        EffectMaterialID::NormalMaterial(self.normal_texture.is_none()).0
+        EffectMaterialID::NormalMaterial(self.normal_texture.is_some()).0
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/normal_material.rs
+++ b/src/renderer/material/normal_material.rs
@@ -52,7 +52,7 @@ impl FromCpuMaterial for NormalMaterial {
 
 impl Material for NormalMaterial {
     fn id(&self) -> u16 {
-        EffectMaterialID::NormalMaterial(self.normal_texture.is_some()).0
+        EffectMaterialId::NormalMaterial(self.normal_texture.is_some()).0
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/normal_material.rs
+++ b/src/renderer/material/normal_material.rs
@@ -52,11 +52,7 @@ impl FromCpuMaterial for NormalMaterial {
 
 impl Material for NormalMaterial {
     fn id(&self) -> u16 {
-        if self.normal_texture.is_some() {
-            0b1u16 << 15 | 0b110u16
-        } else {
-            0b1u16 << 15 | 0b111u16
-        }
+        EffectMaterialID::NormalMaterial(self.normal_texture.is_none()).0
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/orm_material.rs
+++ b/src/renderer/material/orm_material.rs
@@ -78,14 +78,10 @@ impl FromCpuMaterial for ORMMaterial {
 
 impl Material for ORMMaterial {
     fn id(&self) -> u16 {
-        let mut id = 0b1u16 << 15 | 0b1u16 << 4;
-        if self.metallic_roughness_texture.is_some() {
-            id |= 0b1u16;
-        }
-        if self.occlusion_texture.is_some() {
-            id |= 0b1u16 << 1;
-        }
-        id
+        EffectMaterialID::ORMMaterial(
+            self.metallic_roughness_texture.is_some(),
+            self.occlusion_texture.is_some(),
+        ).0
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/orm_material.rs
+++ b/src/renderer/material/orm_material.rs
@@ -78,7 +78,7 @@ impl FromCpuMaterial for ORMMaterial {
 
 impl Material for ORMMaterial {
     fn id(&self) -> u16 {
-        EffectMaterialID::ORMMaterial(
+        EffectMaterialId::ORMMaterial(
             self.metallic_roughness_texture.is_some(),
             self.occlusion_texture.is_some(),
         )

--- a/src/renderer/material/orm_material.rs
+++ b/src/renderer/material/orm_material.rs
@@ -81,7 +81,8 @@ impl Material for ORMMaterial {
         EffectMaterialID::ORMMaterial(
             self.metallic_roughness_texture.is_some(),
             self.occlusion_texture.is_some(),
-        ).0
+        )
+        .0
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/physical_material.rs
+++ b/src/renderer/material/physical_material.rs
@@ -151,23 +151,13 @@ impl FromCpuMaterial for PhysicalMaterial {
 
 impl Material for PhysicalMaterial {
     fn id(&self) -> u16 {
-        let mut id = 0b1u16 << 15 | 0b1u16 << 5;
-        if self.albedo_texture.is_some() {
-            id |= 0b1u16;
-        }
-        if self.metallic_roughness_texture.is_some() {
-            id |= 0b1u16 << 1;
-        }
-        if self.occlusion_texture.is_some() {
-            id |= 0b1u16 << 2;
-        }
-        if self.normal_texture.is_some() {
-            id |= 0b1u16 << 3;
-        }
-        if self.emissive_texture.is_some() {
-            id |= 0b1u16 << 4;
-        }
-        id
+        EffectMaterialID::PhysicalMaterial(
+            self.albedo_texture.is_some(),
+            self.metallic_roughness_texture.is_some(),
+            self.occlusion_texture.is_some(),
+            self.normal_texture.is_some(),
+            self.emissive_texture.is_some(),
+        ).0
     }
 
     fn fragment_shader_source(&self, lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/physical_material.rs
+++ b/src/renderer/material/physical_material.rs
@@ -151,7 +151,7 @@ impl FromCpuMaterial for PhysicalMaterial {
 
 impl Material for PhysicalMaterial {
     fn id(&self) -> u16 {
-        EffectMaterialID::PhysicalMaterial(
+        EffectMaterialId::PhysicalMaterial(
             self.albedo_texture.is_some(),
             self.metallic_roughness_texture.is_some(),
             self.occlusion_texture.is_some(),

--- a/src/renderer/material/physical_material.rs
+++ b/src/renderer/material/physical_material.rs
@@ -157,7 +157,8 @@ impl Material for PhysicalMaterial {
             self.occlusion_texture.is_some(),
             self.normal_texture.is_some(),
             self.emissive_texture.is_some(),
-        ).0
+        )
+        .0
     }
 
     fn fragment_shader_source(&self, lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/position_material.rs
+++ b/src/renderer/material/position_material.rs
@@ -19,7 +19,7 @@ impl FromCpuMaterial for PositionMaterial {
 
 impl Material for PositionMaterial {
     fn id(&self) -> u16 {
-        EffectMaterialID::PositionMaterial.0
+        EffectMaterialId::PositionMaterial.0
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/position_material.rs
+++ b/src/renderer/material/position_material.rs
@@ -19,7 +19,7 @@ impl FromCpuMaterial for PositionMaterial {
 
 impl Material for PositionMaterial {
     fn id(&self) -> u16 {
-        0b1u16 << 15 | 0b11u16
+        EffectMaterialID::PositionMaterial.0
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/skybox_material.rs
+++ b/src/renderer/material/skybox_material.rs
@@ -8,7 +8,7 @@ pub struct SkyboxMaterial {
 
 impl Material for SkyboxMaterial {
     fn id(&self) -> u16 {
-        EffectMaterialID::SkyboxMaterial.0
+        EffectMaterialId::SkyboxMaterial.0
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/skybox_material.rs
+++ b/src/renderer/material/skybox_material.rs
@@ -8,7 +8,7 @@ pub struct SkyboxMaterial {
 
 impl Material for SkyboxMaterial {
     fn id(&self) -> u16 {
-        0b1u16 << 15 | 0b100u16
+        EffectMaterialID::SkyboxMaterial.0
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/uv_material.rs
+++ b/src/renderer/material/uv_material.rs
@@ -19,7 +19,7 @@ impl FromCpuMaterial for UVMaterial {
 
 impl Material for UVMaterial {
     fn id(&self) -> u16 {
-        0b1u16 << 15 | 0b101u16
+        EffectMaterialID::UVMaterial.0
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/uv_material.rs
+++ b/src/renderer/material/uv_material.rs
@@ -19,7 +19,7 @@ impl FromCpuMaterial for UVMaterial {
 
 impl Material for UVMaterial {
     fn id(&self) -> u16 {
-        EffectMaterialID::UVMaterial.0
+        EffectMaterialId::UVMaterial.0
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/object/imposters.rs
+++ b/src/renderer/object/imposters.rs
@@ -213,7 +213,7 @@ impl ImpostersMaterial {
 
 impl Material for ImpostersMaterial {
     fn id(&self) -> u16 {
-        EffectMaterialID::ImpostersMaterial.0
+        EffectMaterialId::ImpostersMaterial.0
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/object/imposters.rs
+++ b/src/renderer/object/imposters.rs
@@ -213,7 +213,7 @@ impl ImpostersMaterial {
 
 impl Material for ImpostersMaterial {
     fn id(&self) -> u16 {
-        0b1u16 << 15 | 0b1101u16
+        EffectMaterialID::ImpostersMaterial.0
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/object/skybox.rs
+++ b/src/renderer/object/skybox.rs
@@ -167,7 +167,7 @@ impl Geometry for Skybox {
     }
 
     fn id(&self, _required_attributes: FragmentAttributes) -> u16 {
-        0b1u16 << 15 | 0b1u16
+        GeometryID::Skybox.0
     }
 
     fn aabb(&self) -> AxisAlignedBoundingBox {

--- a/src/renderer/object/skybox.rs
+++ b/src/renderer/object/skybox.rs
@@ -167,7 +167,7 @@ impl Geometry for Skybox {
     }
 
     fn id(&self, _required_attributes: FragmentAttributes) -> u16 {
-        GeometryID::Skybox.0
+        GeometryId::Skybox.0
     }
 
     fn aabb(&self) -> AxisAlignedBoundingBox {

--- a/src/renderer/object/terrain.rs
+++ b/src/renderer/object/terrain.rs
@@ -364,7 +364,7 @@ impl Geometry for TerrainPatch {
     }
 
     fn id(&self, required_attributes: FragmentAttributes) -> u16 {
-        GeometryID::TerrainPatch(required_attributes.normal || required_attributes.tangents).0
+        GeometryId::TerrainPatch(required_attributes.normal || required_attributes.tangents).0
     }
 
     fn render_with_material(

--- a/src/renderer/object/terrain.rs
+++ b/src/renderer/object/terrain.rs
@@ -364,9 +364,7 @@ impl Geometry for TerrainPatch {
     }
 
     fn id(&self, required_attributes: FragmentAttributes) -> u16 {
-        GeometryID::TerrainPatch(
-            required_attributes.normal || required_attributes.tangents,
-        ).0
+        GeometryID::TerrainPatch(required_attributes.normal || required_attributes.tangents).0
     }
 
     fn render_with_material(

--- a/src/renderer/object/terrain.rs
+++ b/src/renderer/object/terrain.rs
@@ -365,7 +365,7 @@ impl Geometry for TerrainPatch {
 
     fn id(&self, required_attributes: FragmentAttributes) -> u16 {
         GeometryID::TerrainPatch(
-            !(required_attributes.normal || required_attributes.tangents),
+            required_attributes.normal || required_attributes.tangents,
         ).0
     }
 

--- a/src/renderer/object/terrain.rs
+++ b/src/renderer/object/terrain.rs
@@ -364,11 +364,9 @@ impl Geometry for TerrainPatch {
     }
 
     fn id(&self, required_attributes: FragmentAttributes) -> u16 {
-        if required_attributes.normal || required_attributes.tangents {
-            0b1u16 << 15 | 0b10u16
-        } else {
-            0b1u16 << 15 | 0b11u16
-        }
+        GeometryID::TerrainPatch(
+            !(required_attributes.normal || required_attributes.tangents),
+        ).0
     }
 
     fn render_with_material(

--- a/src/renderer/object/water.rs
+++ b/src/renderer/object/water.rs
@@ -254,7 +254,7 @@ impl Geometry for WaterPatch {
     }
 
     fn id(&self, _required_attributes: FragmentAttributes) -> u16 {
-        0b1u16 << 15 | 0b101u16
+        GeometryID::WaterPatch.0
     }
 
     fn render_with_material(

--- a/src/renderer/object/water.rs
+++ b/src/renderer/object/water.rs
@@ -254,7 +254,7 @@ impl Geometry for WaterPatch {
     }
 
     fn id(&self, _required_attributes: FragmentAttributes) -> u16 {
-        GeometryID::WaterPatch.0
+        GeometryId::WaterPatch.0
     }
 
     fn render_with_material(

--- a/src/renderer/shader_ids.rs
+++ b/src/renderer/shader_ids.rs
@@ -74,8 +74,8 @@ macro_rules! enum_effectfield {
 ///
 #[open_enum]
 #[repr(u16)]
-pub(crate) enum GeometryID {
-    SCREEN = 0x8000,
+pub(crate) enum GeometryId {
+    Screen = 0x8000,
     Skybox = 0x8001,
     TerrainPatchBase = 0x8002, // To 0x8003
     Sprites = 0x8004,
@@ -85,7 +85,7 @@ pub(crate) enum GeometryID {
     InstancedMeshBase = 0x8080,  // To 0x80FF
 }
 
-impl GeometryID {
+impl GeometryId {
     enum_bitfield!(TerrainPatchBase, TerrainPatch(normal_tangent));
     enum_bitfield!(MeshBase, Mesh(normal, tangents, uv, color));
     enum_bitfield!(
@@ -112,7 +112,7 @@ impl GeometryID {
 ///
 #[open_enum]
 #[repr(u16)]
-pub(crate) enum EffectMaterialID {
+pub(crate) enum EffectMaterialId {
     LightingPassEffectBase = 0x5000, // To 0x503F
     WaterEffectBase = 0x5800,        // To 0x583F
     CopyEffectBase = 0x6000,         // To 0x603F
@@ -136,7 +136,7 @@ pub(crate) enum EffectMaterialID {
     PrefilterMaterial = 0x8080,
 }
 
-impl EffectMaterialID {
+impl EffectMaterialId {
     enum_effectfield!(LightingPassEffectBase, LightingPassEffect(...Default));
     enum_effectfield!(WaterEffectBase, WaterEffect(...Default));
     enum_effectfield!(CopyEffectBase, CopyEffect(Option<...Default>));
@@ -179,14 +179,14 @@ impl EffectMaterialID {
 ///
 #[open_enum]
 #[repr(u8)]
-pub(crate) enum LightID {
+pub(crate) enum LightId {
     AmbientLightBase = 0x80,     // To 0x81
     DirectionalLightBase = 0x82, // To 0x83
     PointLight = 0x84,
     SpotLightBase = 0x86, // To 0x87
 }
 
-impl LightID {
+impl LightId {
     enum_bitfield!(AmbientLightBase, AmbientLight(environment));
     enum_bitfield!(DirectionalLightBase, DirectionalLight(shadow_texture));
     enum_bitfield!(SpotLightBase, SpotLight(shadow_texture));

--- a/src/renderer/shader_ids.rs
+++ b/src/renderer/shader_ids.rs
@@ -24,7 +24,7 @@ macro_rules! bitfield_bit {
 }
 
 macro_rules! enum_bitfield {
-    ($base_name:ident, $name:ident($($field:ident),+)) => {
+    ($base_name:ident, $name:ident($($field:ident),+ $(,)?)) => {
         #[allow(non_snake_case)]
         #[inline]
         pub(crate) fn $name($($field: bool),+) -> Self {
@@ -37,7 +37,7 @@ macro_rules! enum_bitfield {
 }
 
 macro_rules! enum_effectfield {
-    ($base_name:ident, $name:ident($($texture:ident: Option<$textureType:ty>),+)) => {
+    ($base_name:ident, $name:ident($($texture:ident: Option<$textureType:ty>),+ $(,)?)) => {
         #[allow(non_snake_case)]
         #[inline]
         pub(crate) fn $name($($texture: Option<$textureType>),*) -> Self {
@@ -52,7 +52,7 @@ macro_rules! enum_effectfield {
         enum_effectfield!($base_name, $name(color_texture: Option<ColorTexture>, depth_texture: Option<DepthTexture>));
     };
 
-    ($base_name:ident, $name:ident($($texture:ident: $textureType:ty),+)) => {
+    ($base_name:ident, $name:ident($($texture:ident: $textureType:ty),+ $(,)?)) => {
         #[allow(non_snake_case)]
         #[inline]
         pub(crate) fn $name($($texture: $textureType),*) -> Self {
@@ -101,7 +101,7 @@ impl GeometryID {
             color,
             instance_color,
             instance_transformation,
-            instance_uv
+            instance_uv,
         )
     );
 }
@@ -157,7 +157,7 @@ impl EffectMaterialID {
             metallic_roughness_texture,
             occlusion_texture,
             normal_texture,
-            emissive_texture
+            emissive_texture,
         )
     );
     enum_bitfield!(
@@ -168,7 +168,7 @@ impl EffectMaterialID {
             occlusion_texture,
             normal_texture,
             emissive_texture,
-            alpha_cutout
+            alpha_cutout,
         )
     );
 }

--- a/src/renderer/shader_ids.rs
+++ b/src/renderer/shader_ids.rs
@@ -82,7 +82,7 @@ pub(crate) enum GeometryID {
     Sprites = 0x8004,
     WaterPatch = 0x8005,
     MeshBase = 0x8010, // To 0x801F
-    ParticleSystemBase = 0x8020, // To 0x803F
+    ParticleSystemBase = 0x8040, // To 0x807F
     InstancedMeshBase = 0x8080, // To 0x80FF
 }
 

--- a/src/renderer/shader_ids.rs
+++ b/src/renderer/shader_ids.rs
@@ -1,0 +1,158 @@
+
+//!
+//! Each shader is allocated a unique ID within its catetory so that they can be cached between frames.
+//! If you implement custom shaders, ensure to give them an ID not already allocated here.
+//! Reductions of the public use ID ranges will be considered a breaking change and result in the appropriate version incrementation.
+//! The allocation of internal use IDs should be considered unstable.
+//! 
+
+use crate::texture::{ColorTexture, DepthTexture};
+
+use open_enum::open_enum;
+
+// TODO: Utilizing the open_enum crate, convert all ID usage to these types (breaking change for externally implemented shaders)
+// NOTE: It may be possible to eventually also create a proc macro that automatically allocates IDs based on the width of their subfields
+
+macro_rules! bitfield_bit {
+    ($field:ident << $shift:expr) => {
+        ((if $field { 1 } else { 0 }) << $shift)
+    };
+
+    ($field:ident, $($fields:ident),+ << $shift:expr) => {
+        bitfield_bit!($field << $shift)
+            | bitfield_bit!($($fields),+ << $shift + 1)
+    };
+}
+
+macro_rules! enum_bitfield {
+    ($base_name:ident, $name:ident($($field:ident),+)) => {
+        #[allow(non_snake_case)]
+        #[inline]
+        pub(crate) fn $name($($field: bool),+) -> Self {
+            Self(
+                Self::$base_name.0
+                    | bitfield_bit!($($field),+ << 0)
+            )
+        }
+    };
+}
+
+macro_rules! enum_effectfield {
+    ($base_name:ident, $name:ident($($texture:ident: Option<$textureType:ty>),+)) => {
+        #[allow(non_snake_case)]
+        #[inline]
+        pub(crate) fn $name($($texture: Option<$textureType>),*) -> Self {
+            Self(
+                Self::$base_name.0
+                $(  | $texture.map(|t| t.id()).unwrap_or(0))*
+            )
+        }
+    };
+
+    ($base_name:ident, $name:ident(Option<...Default>)) => {
+        enum_effectfield!($base_name, $name(color_texture: Option<ColorTexture>, depth_texture: Option<DepthTexture>));
+    };
+
+    ($base_name:ident, $name:ident($($texture:ident: $textureType:ty),+)) => {
+        #[allow(non_snake_case)]
+        #[inline]
+        pub(crate) fn $name($($texture: $textureType),*) -> Self {
+            Self(
+                Self::$base_name.0
+                $(  | $texture.id())*
+            )
+        }
+    };
+
+    ($base_name:ident, $name:ident(...Default)) => {
+        enum_effectfield!($base_name, $name(color_texture: ColorTexture, depth_texture: DepthTexture));
+    };
+}
+
+///
+/// ID Space for geometry shaders
+/// IDs 0x0000 through 0x7FFF are reserved for public use
+///
+#[open_enum]
+#[repr(u16)]
+pub(crate) enum GeometryID {
+    SCREEN = 0x8000,
+    Skybox = 0x8001,
+    TerrainPatchBase = 0x8002, // To 0x8003
+    Sprites = 0x8004,
+    WaterPatch = 0x8005,
+    MeshBase = 0x8010, // To 0x801F
+    ParticleSystemBase = 0x8020, // To 0x803F
+    InstancedMeshBase = 0x8080, // To 0x80FF
+}
+
+impl GeometryID {
+    enum_bitfield!(TerrainPatchBase, TerrainPatch(normal_tangent));
+    enum_bitfield!(MeshBase, Mesh(normal, tangents, uv, color));
+    enum_bitfield!(ParticleSystemBase, ParticleSystem(normal, tangents, uv, color, instance_color, instance_uv));
+    enum_bitfield!(InstancedMeshBase, InstancedMesh(normal, tangents, uv, color, instance_color, instance_transformation, instance_uv));
+}
+
+///
+/// ID Space for effect and material shaders
+/// IDs 0x0000 through 0x4FFF are reserved for public use
+///
+#[open_enum]
+#[repr(u16)]
+pub(crate) enum EffectMaterialID {
+    LightingPassEffectBase = 0x5000, // To 0x503F
+    WaterEffectBase = 0x5800, // To 0x583F
+    CopyEffectBase = 0x6000, // To 0x603F
+    ScreenEffectBase = 0x6800, // To 0x683F
+    FogEffectBase = 0x7000, // To 0x703F
+    FxaaEffectBase = 0x7800, // To 0x7838 (has holes)
+
+    ColorMaterialBase = 0x8000, // To 0x8001
+    DepthMaterial = 0x8002,
+    PositionMaterial = 0x8003,
+    SkyboxMaterial = 0x8004,
+    UVMaterial = 0x8005,
+    NormalMaterialBase = 0x8006, // To 0x8007
+    IsosurfaceMaterial = 0x800C,
+    ImpostersMaterial = 0x800D,
+    BrdfMaterial = 0x800E,
+    IrradianceMaterial = 0x800F,
+    ORMMaterialBase = 0x8010, // To 0x8013
+    PhysicalMaterialBase = 0x8020, // To 0x803F
+    DeferredPhysicalMaterialBase = 0x8040, // To 0x807F
+    PrefilterMaterial = 0x8080
+}
+
+impl EffectMaterialID {
+    enum_effectfield!(LightingPassEffectBase, LightingPassEffect(...Default));
+    enum_effectfield!(WaterEffectBase, WaterEffect(...Default));
+    enum_effectfield!(CopyEffectBase, CopyEffect(Option<...Default>));
+    enum_effectfield!(ScreenEffectBase, ScreenEffect(Option<...Default>));
+    enum_effectfield!(FogEffectBase, FogEffect(...Default));
+    enum_effectfield!(FxaaEffectBase, FxaaEffect(color_texture: ColorTexture));
+
+    enum_bitfield!(ColorMaterialBase, ColorMaterial(texture));
+    enum_bitfield!(NormalMaterialBase, NormalMaterial(normal_texture));
+    enum_bitfield!(ORMMaterialBase, ORMMaterial(metallic_roughness_texture, occlusion_texture));
+    enum_bitfield!(PhysicalMaterialBase, PhysicalMaterial(albedo_texture, metallic_roughness_texture, occlusion_texture, normal_texture, emissive_texture));
+    enum_bitfield!(DeferredPhysicalMaterialBase, DeferredPhysicalMaterial(albedo_texture, metallic_roughness_texture, occlusion_texture, normal_texture, emissive_texture, alpha_cutout));
+}
+
+///
+/// ID space for lighting shaders
+/// IDs 0x00 through 0x7F are reserved for public use
+///
+#[open_enum]
+#[repr(u8)]
+pub(crate) enum LightID {
+    AmbientLightBase = 0x80, // To 0x81
+    DirectionalLightBase = 0x82, // To 0x83
+    PointLight = 0x84,
+    SpotLightBase = 0x86, // To 0x87
+}
+
+impl LightID {
+    enum_bitfield!(AmbientLightBase, AmbientLight(environment));
+    enum_bitfield!(DirectionalLightBase, DirectionalLight(shadow_texture));
+    enum_bitfield!(SpotLightBase, SpotLight(shadow_texture));
+}

--- a/src/renderer/shader_ids.rs
+++ b/src/renderer/shader_ids.rs
@@ -1,10 +1,9 @@
-
 //!
-//! Each shader is allocated a unique ID within its catetory so that they can be cached between frames.
+//! Each shader is allocated a unique ID within its category so that they can be cached between frames.
 //! If you implement custom shaders, ensure to give them an ID not already allocated here.
-//! Reductions of the public use ID ranges will be considered a breaking change and result in the appropriate version incrementation.
+//! Reductions of the public use ID ranges will be considered a breaking change and result in the appropriate version increment.
 //! The allocation of internal use IDs should be considered unstable.
-//! 
+//!
 
 use crate::texture::{ColorTexture, DepthTexture};
 
@@ -81,16 +80,30 @@ pub(crate) enum GeometryID {
     TerrainPatchBase = 0x8002, // To 0x8003
     Sprites = 0x8004,
     WaterPatch = 0x8005,
-    MeshBase = 0x8010, // To 0x801F
+    MeshBase = 0x8010,           // To 0x801F
     ParticleSystemBase = 0x8040, // To 0x807F
-    InstancedMeshBase = 0x8080, // To 0x80FF
+    InstancedMeshBase = 0x8080,  // To 0x80FF
 }
 
 impl GeometryID {
     enum_bitfield!(TerrainPatchBase, TerrainPatch(normal_tangent));
     enum_bitfield!(MeshBase, Mesh(normal, tangents, uv, color));
-    enum_bitfield!(ParticleSystemBase, ParticleSystem(normal, tangents, uv, color, instance_color, instance_uv));
-    enum_bitfield!(InstancedMeshBase, InstancedMesh(normal, tangents, uv, color, instance_color, instance_transformation, instance_uv));
+    enum_bitfield!(
+        ParticleSystemBase,
+        ParticleSystem(normal, tangents, uv, color, instance_color, instance_uv)
+    );
+    enum_bitfield!(
+        InstancedMeshBase,
+        InstancedMesh(
+            normal,
+            tangents,
+            uv,
+            color,
+            instance_color,
+            instance_transformation,
+            instance_uv
+        )
+    );
 }
 
 ///
@@ -101,11 +114,11 @@ impl GeometryID {
 #[repr(u16)]
 pub(crate) enum EffectMaterialID {
     LightingPassEffectBase = 0x5000, // To 0x503F
-    WaterEffectBase = 0x5800, // To 0x583F
-    CopyEffectBase = 0x6000, // To 0x603F
-    ScreenEffectBase = 0x6800, // To 0x683F
-    FogEffectBase = 0x7000, // To 0x703F
-    FxaaEffectBase = 0x7800, // To 0x7838 (has holes)
+    WaterEffectBase = 0x5800,        // To 0x583F
+    CopyEffectBase = 0x6000,         // To 0x603F
+    ScreenEffectBase = 0x6800,       // To 0x683F
+    FogEffectBase = 0x7000,          // To 0x703F
+    FxaaEffectBase = 0x7800,         // To 0x7838 (has holes)
 
     ColorMaterialBase = 0x8000, // To 0x8001
     DepthMaterial = 0x8002,
@@ -117,10 +130,10 @@ pub(crate) enum EffectMaterialID {
     ImpostersMaterial = 0x800D,
     BrdfMaterial = 0x800E,
     IrradianceMaterial = 0x800F,
-    ORMMaterialBase = 0x8010, // To 0x8013
-    PhysicalMaterialBase = 0x8020, // To 0x803F
+    ORMMaterialBase = 0x8010,              // To 0x8013
+    PhysicalMaterialBase = 0x8020,         // To 0x803F
     DeferredPhysicalMaterialBase = 0x8040, // To 0x807F
-    PrefilterMaterial = 0x8080
+    PrefilterMaterial = 0x8080,
 }
 
 impl EffectMaterialID {
@@ -133,9 +146,31 @@ impl EffectMaterialID {
 
     enum_bitfield!(ColorMaterialBase, ColorMaterial(texture));
     enum_bitfield!(NormalMaterialBase, NormalMaterial(normal_texture));
-    enum_bitfield!(ORMMaterialBase, ORMMaterial(metallic_roughness_texture, occlusion_texture));
-    enum_bitfield!(PhysicalMaterialBase, PhysicalMaterial(albedo_texture, metallic_roughness_texture, occlusion_texture, normal_texture, emissive_texture));
-    enum_bitfield!(DeferredPhysicalMaterialBase, DeferredPhysicalMaterial(albedo_texture, metallic_roughness_texture, occlusion_texture, normal_texture, emissive_texture, alpha_cutout));
+    enum_bitfield!(
+        ORMMaterialBase,
+        ORMMaterial(metallic_roughness_texture, occlusion_texture)
+    );
+    enum_bitfield!(
+        PhysicalMaterialBase,
+        PhysicalMaterial(
+            albedo_texture,
+            metallic_roughness_texture,
+            occlusion_texture,
+            normal_texture,
+            emissive_texture
+        )
+    );
+    enum_bitfield!(
+        DeferredPhysicalMaterialBase,
+        DeferredPhysicalMaterial(
+            albedo_texture,
+            metallic_roughness_texture,
+            occlusion_texture,
+            normal_texture,
+            emissive_texture,
+            alpha_cutout
+        )
+    );
 }
 
 ///
@@ -145,7 +180,7 @@ impl EffectMaterialID {
 #[open_enum]
 #[repr(u8)]
 pub(crate) enum LightID {
-    AmbientLightBase = 0x80, // To 0x81
+    AmbientLightBase = 0x80,     // To 0x81
     DirectionalLightBase = 0x82, // To 0x83
     PointLight = 0x84,
     SpotLightBase = 0x86, // To 0x87


### PR DESCRIPTION
> The shader IDs have been separated out to simplify keeping track of which ID's were used, and a few ID overlaps were corrected. The shader IDs internally make use of open_enum types, which could be changed to also be the public type signature in a breaking release.

From https://github.com/asny/three-d/pull/479