### PR TITLE
Add example assets to the published files for the web dev server

### DIFF
--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -22,5 +22,11 @@ module.exports = {
     mode: 'development',
     experiments: {
         asyncWebAssembly: true
-   }
+    },
+    devServer: {
+        static: {
+            directory: path.resolve(__dirname, "../examples/assets"),
+            publicPath: "/examples/assets"
+        }
+    }
 };


### PR DESCRIPTION
Any examples that tried to load static assets would fail to find the correct files when run through the local web development server. This adds those assets to the list of static files served through the server, fixing most/all of those examples.