### PR TITLE
Change shader traits to handle ID enums instead of integers

### DIFF
--- a/examples/fireworks/src/main.rs
+++ b/examples/fireworks/src/main.rs
@@ -43,8 +43,8 @@ impl Material for FireworksMaterial {
         MaterialType::Transparent
     }
 
-    fn id(&self) -> u16 {
-        0b1u16
+    fn id(&self) -> EffectMaterialId {
+        EffectMaterialId(0b1u16)
     }
 }
 // Entry point for non-wasm

--- a/examples/logo/src/main.rs
+++ b/examples/logo/src/main.rs
@@ -80,8 +80,8 @@ impl Material for LogoMaterial<'_> {
         include_str!("shader.frag").to_string()
     }
 
-    fn id(&self) -> u16 {
-        0b1u16
+    fn id(&self) -> EffectMaterialId {
+        EffectMaterialId(0b1u16)
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {

--- a/examples/mandelbrot/src/main.rs
+++ b/examples/mandelbrot/src/main.rs
@@ -27,8 +27,8 @@ impl Material for MandelbrotMaterial {
         MaterialType::Opaque
     }
 
-    fn id(&self) -> u16 {
-        0b11u16
+    fn id(&self) -> EffectMaterialId {
+        EffectMaterialId(0b11u16)
     }
 }
 

--- a/src/renderer/effect.rs
+++ b/src/renderer/effect.rs
@@ -18,7 +18,7 @@ macro_rules! impl_effect_body {
             &self,
             color_texture: Option<ColorTexture>,
             depth_texture: Option<DepthTexture>,
-        ) -> u16 {
+        ) -> EffectMaterialId {
             self.$inner().id(color_texture, depth_texture)
         }
 
@@ -88,9 +88,13 @@ pub trait Effect {
     /// Returns a unique ID for each variation of the shader source returned from [Effect::fragment_shader_source].
     ///
     /// **Note:** The first 16 bits are reserved to internally implemented effects, so if implementing the [Effect] trait
-    /// outside of this crate, always return an id that is larger than or equal to `0b1u16 << 16`.
+    /// outside of this crate, always return an id in the public use range as defined by [EffectMaterialId].
     ///
-    fn id(&self, color_texture: Option<ColorTexture>, depth_texture: Option<DepthTexture>) -> u16;
+    fn id(
+        &self,
+        color_texture: Option<ColorTexture>,
+        depth_texture: Option<DepthTexture>,
+    ) -> EffectMaterialId;
 
     ///
     /// Returns a [FragmentAttributes] struct that describes which fragment attributes,
@@ -152,7 +156,11 @@ impl<T: Effect> Effect for std::sync::RwLock<T> {
             .fragment_shader_source(lights, color_texture, depth_texture)
     }
 
-    fn id(&self, color_texture: Option<ColorTexture>, depth_texture: Option<DepthTexture>) -> u16 {
+    fn id(
+        &self,
+        color_texture: Option<ColorTexture>,
+        depth_texture: Option<DepthTexture>,
+    ) -> EffectMaterialId {
         self.read().unwrap().id(color_texture, depth_texture)
     }
 

--- a/src/renderer/effect/copy.rs
+++ b/src/renderer/effect/copy.rs
@@ -49,8 +49,12 @@ impl Effect for CopyEffect {
         )
     }
 
-    fn id(&self, color_texture: Option<ColorTexture>, depth_texture: Option<DepthTexture>) -> u16 {
-        EffectMaterialId::CopyEffect(color_texture, depth_texture).0
+    fn id(
+        &self,
+        color_texture: Option<ColorTexture>,
+        depth_texture: Option<DepthTexture>,
+    ) -> EffectMaterialId {
+        EffectMaterialId::CopyEffect(color_texture, depth_texture)
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {

--- a/src/renderer/effect/fog.rs
+++ b/src/renderer/effect/fog.rs
@@ -48,12 +48,15 @@ impl Effect for FogEffect {
         )
     }
 
-    fn id(&self, color_texture: Option<ColorTexture>, depth_texture: Option<DepthTexture>) -> u16 {
+    fn id(
+        &self,
+        color_texture: Option<ColorTexture>,
+        depth_texture: Option<DepthTexture>,
+    ) -> EffectMaterialId {
         EffectMaterialId::FogEffect(
             color_texture.expect("Must supply a color texture to apply a fog effect"),
             depth_texture.expect("Must supply a depth texture to apply a fog effect"),
         )
-        .0
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {

--- a/src/renderer/effect/full_screen.rs
+++ b/src/renderer/effect/full_screen.rs
@@ -53,8 +53,12 @@ impl Effect for ScreenEffect {
         )
     }
 
-    fn id(&self, color_texture: Option<ColorTexture>, depth_texture: Option<DepthTexture>) -> u16 {
-        EffectMaterialId::ScreenEffect(color_texture, depth_texture).0
+    fn id(
+        &self,
+        color_texture: Option<ColorTexture>,
+        depth_texture: Option<DepthTexture>,
+    ) -> EffectMaterialId {
+        EffectMaterialId::ScreenEffect(color_texture, depth_texture)
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {

--- a/src/renderer/effect/fxaa.rs
+++ b/src/renderer/effect/fxaa.rs
@@ -23,11 +23,14 @@ impl Effect for FxaaEffect {
         )
     }
 
-    fn id(&self, color_texture: Option<ColorTexture>, _depth_texture: Option<DepthTexture>) -> u16 {
+    fn id(
+        &self,
+        color_texture: Option<ColorTexture>,
+        _depth_texture: Option<DepthTexture>,
+    ) -> EffectMaterialId {
         EffectMaterialId::FxaaEffect(
             color_texture.expect("Must supply a color texture to apply a fxaa effect"),
         )
-        .0
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {

--- a/src/renderer/effect/lighting_pass.rs
+++ b/src/renderer/effect/lighting_pass.rs
@@ -24,8 +24,12 @@ impl Effect for LightingPassEffect {
         fragment_shader
     }
 
-    fn id(&self, color_texture: Option<ColorTexture>, depth_texture: Option<DepthTexture>) -> u16 {
-        EffectMaterialId::LightingPassEffect(color_texture.unwrap(), depth_texture.unwrap()).0
+    fn id(
+        &self,
+        color_texture: Option<ColorTexture>,
+        depth_texture: Option<DepthTexture>,
+    ) -> EffectMaterialId {
+        EffectMaterialId::LightingPassEffect(color_texture.unwrap(), depth_texture.unwrap())
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {

--- a/src/renderer/effect/water.rs
+++ b/src/renderer/effect/water.rs
@@ -59,12 +59,15 @@ impl Effect for WaterEffect {
         )
     }
 
-    fn id(&self, color_texture: Option<ColorTexture>, depth_texture: Option<DepthTexture>) -> u16 {
+    fn id(
+        &self,
+        color_texture: Option<ColorTexture>,
+        depth_texture: Option<DepthTexture>,
+    ) -> EffectMaterialId {
         EffectMaterialId::WaterEffect(
             color_texture.expect("Must supply a color texture to apply a water effect"),
             depth_texture.expect("Must supply a depth texture to apply a water effect"),
         )
-        .0
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {

--- a/src/renderer/geometry.rs
+++ b/src/renderer/geometry.rs
@@ -22,7 +22,7 @@ macro_rules! impl_geometry_body {
             self.$inner().vertex_shader_source(required_attributes)
         }
 
-        fn id(&self, required_attributes: FragmentAttributes) -> u16 {
+        fn id(&self, required_attributes: FragmentAttributes) -> GeometryId {
             self.$inner().id(required_attributes)
         }
 
@@ -127,9 +127,9 @@ pub trait Geometry {
     /// Returns a unique ID for each variation of the shader source returned from `Geometry::vertex_shader_source`.
     ///
     /// **Note:** The last bit is reserved to internally implemented geometries, so if implementing the `Geometry` trait
-    /// outside of this crate, always return an id that is smaller than `0b1u16 << 15`.
+    /// outside of this crate, always return an id in the public use range as defined by [GeometryId].
     ///
-    fn id(&self, required_attributes: FragmentAttributes) -> u16;
+    fn id(&self, required_attributes: FragmentAttributes) -> GeometryId;
 
     ///
     /// Render the geometry with the given [Material].
@@ -216,7 +216,7 @@ impl<T: Geometry> Geometry for std::sync::RwLock<T> {
             .vertex_shader_source(required_attributes)
     }
 
-    fn id(&self, required_attributes: FragmentAttributes) -> u16 {
+    fn id(&self, required_attributes: FragmentAttributes) -> GeometryId {
         self.read().unwrap().id(required_attributes)
     }
 

--- a/src/renderer/geometry/instanced_mesh.rs
+++ b/src/renderer/geometry/instanced_mesh.rs
@@ -309,7 +309,7 @@ impl Geometry for InstancedMesh {
         )
     }
 
-    fn id(&self, required_attributes: FragmentAttributes) -> u16 {
+    fn id(&self, required_attributes: FragmentAttributes) -> GeometryId {
         let instance_buffers = &self
             .instance_buffers
             .read()
@@ -324,7 +324,6 @@ impl Geometry for InstancedMesh {
             instance_buffers.contains_key("instance_translation"),
             required_attributes.uv && instance_buffers.contains_key("tex_transform_row1"),
         )
-        .0
     }
 
     fn aabb(&self) -> AxisAlignedBoundingBox {

--- a/src/renderer/geometry/mesh.rs
+++ b/src/renderer/geometry/mesh.rs
@@ -189,14 +189,13 @@ impl Geometry for Mesh {
         )
     }
 
-    fn id(&self, required_attributes: FragmentAttributes) -> u16 {
+    fn id(&self, required_attributes: FragmentAttributes) -> GeometryId {
         GeometryId::Mesh(
             required_attributes.normal,
             required_attributes.tangents,
             required_attributes.uv,
             required_attributes.color,
         )
-        .0
     }
 
     fn render_with_material(

--- a/src/renderer/geometry/particles.rs
+++ b/src/renderer/geometry/particles.rs
@@ -187,7 +187,7 @@ impl<'a> IntoIterator for &'a ParticleSystem {
 }
 
 impl Geometry for ParticleSystem {
-    fn id(&self, required_attributes: FragmentAttributes) -> u16 {
+    fn id(&self, required_attributes: FragmentAttributes) -> GeometryId {
         GeometryId::ParticleSystem(
             required_attributes.normal,
             required_attributes.tangents,
@@ -196,7 +196,6 @@ impl Geometry for ParticleSystem {
             required_attributes.color && self.instance_buffers.contains_key("instance_color"),
             required_attributes.uv && self.instance_buffers.contains_key("tex_transform_row1"),
         )
-        .0
     }
 
     fn vertex_shader_source(&self, required_attributes: FragmentAttributes) -> String {

--- a/src/renderer/geometry/sprites.rs
+++ b/src/renderer/geometry/sprites.rs
@@ -130,8 +130,8 @@ impl Geometry for Sprites {
         include_str!("shaders/sprites.vert").to_owned()
     }
 
-    fn id(&self, _required_attributes: FragmentAttributes) -> u16 {
-        GeometryId::Sprites.0
+    fn id(&self, _required_attributes: FragmentAttributes) -> GeometryId {
+        GeometryId::Sprites
     }
 
     fn render_with_material(

--- a/src/renderer/light.rs
+++ b/src/renderer/light.rs
@@ -12,7 +12,7 @@ macro_rules! impl_light_body {
         fn use_uniforms(&self, program: &Program, i: u32) {
             self.$inner().use_uniforms(program, i)
         }
-        fn id(&self) -> u8 {
+        fn id(&self) -> LightId {
             self.$inner().id()
         }
     };
@@ -42,6 +42,7 @@ pub use environment::*;
 
 use crate::core::*;
 use crate::renderer::camera::*;
+use crate::renderer::LightId;
 
 ///
 /// Specifies how the intensity of a light fades over distance.
@@ -83,9 +84,9 @@ pub trait Light {
     /// Returns a unique ID for each variation of the shader source returned from `Light::shader_source`.
     ///
     /// **Note:** The last bit is reserved to internally implemented materials, so if implementing the `Light` trait
-    /// outside of this crate, always return an id that is smaller than `0b1u8 << 7`.
+    /// outside of this crate, always return an id in the public use range as defined by [LightId].
     ///
-    fn id(&self) -> u8;
+    fn id(&self) -> LightId;
 }
 
 impl<T: Light + ?Sized> Light for &T {
@@ -119,7 +120,7 @@ impl<T: Light> Light for std::sync::Arc<std::sync::RwLock<T>> {
     fn use_uniforms(&self, program: &Program, i: u32) {
         self.read().unwrap().use_uniforms(program, i)
     }
-    fn id(&self) -> u8 {
+    fn id(&self) -> LightId {
         self.read().unwrap().id()
     }
 }

--- a/src/renderer/light/ambient_light.rs
+++ b/src/renderer/light/ambient_light.rs
@@ -100,8 +100,8 @@ impl Light for AmbientLight {
         );
     }
 
-    fn id(&self) -> u8 {
-        LightId::AmbientLight(self.environment.is_some()).0
+    fn id(&self) -> LightId {
+        LightId::AmbientLight(self.environment.is_some())
     }
 }
 

--- a/src/renderer/light/directional_light.rs
+++ b/src/renderer/light/directional_light.rs
@@ -169,7 +169,7 @@ impl Light for DirectionalLight {
         program.use_uniform(&format!("direction{}", i), self.direction.normalize());
     }
 
-    fn id(&self) -> u8 {
-        LightId::DirectionalLight(self.shadow_texture.is_some()).0
+    fn id(&self) -> LightId {
+        LightId::DirectionalLight(self.shadow_texture.is_some())
     }
 }

--- a/src/renderer/light/environment.rs
+++ b/src/renderer/light/environment.rs
@@ -155,8 +155,8 @@ impl Material for PrefilterMaterial<'_> {
         )
     }
 
-    fn id(&self) -> u16 {
-        EffectMaterialId::PrefilterMaterial.0
+    fn id(&self) -> EffectMaterialId {
+        EffectMaterialId::PrefilterMaterial
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {
@@ -201,8 +201,8 @@ impl Material for BrdfMaterial {
         )
     }
 
-    fn id(&self) -> u16 {
-        EffectMaterialId::BrdfMaterial.0
+    fn id(&self) -> EffectMaterialId {
+        EffectMaterialId::BrdfMaterial
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {
@@ -237,8 +237,8 @@ impl Material for IrradianceMaterial<'_> {
         )
     }
 
-    fn id(&self) -> u16 {
-        EffectMaterialId::IrradianceMaterial.0
+    fn id(&self) -> EffectMaterialId {
+        EffectMaterialId::IrradianceMaterial
     }
 
     fn fragment_attributes(&self) -> FragmentAttributes {

--- a/src/renderer/light/point_light.rs
+++ b/src/renderer/light/point_light.rs
@@ -69,7 +69,7 @@ impl Light for PointLight {
         program.use_uniform(&format!("position{}", i), self.position);
     }
 
-    fn id(&self) -> u8 {
-        LightId::PointLight.0
+    fn id(&self) -> LightId {
+        LightId::PointLight
     }
 }

--- a/src/renderer/light/spot_light.rs
+++ b/src/renderer/light/spot_light.rs
@@ -222,7 +222,7 @@ impl Light for SpotLight {
         program.use_uniform(&format!("cutoff{}", i), self.cutoff.0);
     }
 
-    fn id(&self) -> u8 {
-        LightId::SpotLight(self.shadow_texture.is_some()).0
+    fn id(&self) -> LightId {
+        LightId::SpotLight(self.shadow_texture.is_some())
     }
 }

--- a/src/renderer/material.rs
+++ b/src/renderer/material.rs
@@ -22,7 +22,7 @@ macro_rules! impl_material_body {
         fn material_type(&self) -> MaterialType {
             self.$inner().material_type()
         }
-        fn id(&self) -> u16 {
+        fn id(&self) -> EffectMaterialId {
             self.$inner().id()
         }
     };
@@ -194,9 +194,9 @@ pub trait Material {
     /// Returns a unique ID for each variation of the shader source returned from [Material::fragment_shader_source].
     ///
     /// **Note:** The last bit is reserved to internally implemented materials, so if implementing the [Material] trait
-    /// outside of this crate, always return an id that is smaller than `0b1u16 << 15`.
+    /// outside of this crate, always return an id in the public use range as defined by [EffectMaterialId].
     ///
-    fn id(&self) -> u16;
+    fn id(&self) -> EffectMaterialId;
 
     ///
     /// Returns a [FragmentAttributes] struct that describes which fragment attributes,
@@ -280,7 +280,7 @@ impl<T: Material> Material for std::sync::RwLock<T> {
     fn material_type(&self) -> MaterialType {
         self.read().unwrap().material_type()
     }
-    fn id(&self) -> u16 {
+    fn id(&self) -> EffectMaterialId {
         self.read().unwrap().id()
     }
 }

--- a/src/renderer/material/color_material.rs
+++ b/src/renderer/material/color_material.rs
@@ -98,8 +98,8 @@ impl FromCpuMaterial for ColorMaterial {
 }
 
 impl Material for ColorMaterial {
-    fn id(&self) -> u16 {
-        EffectMaterialId::ColorMaterial(self.texture.is_some()).0
+    fn id(&self) -> EffectMaterialId {
+        EffectMaterialId::ColorMaterial(self.texture.is_some())
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/deferred_physical_material.rs
+++ b/src/renderer/material/deferred_physical_material.rs
@@ -178,7 +178,7 @@ impl FromCpuMaterial for DeferredPhysicalMaterial {
 }
 
 impl Material for DeferredPhysicalMaterial {
-    fn id(&self) -> u16 {
+    fn id(&self) -> EffectMaterialId {
         EffectMaterialId::DeferredPhysicalMaterial(
             self.albedo_texture.is_some(),
             self.metallic_roughness_texture.is_some(),
@@ -187,7 +187,6 @@ impl Material for DeferredPhysicalMaterial {
             self.emissive_texture.is_some(),
             self.alpha_cutout.is_some(),
         )
-        .0
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/depth_material.rs
+++ b/src/renderer/material/depth_material.rs
@@ -22,8 +22,8 @@ impl FromCpuMaterial for DepthMaterial {
 }
 
 impl Material for DepthMaterial {
-    fn id(&self) -> u16 {
-        EffectMaterialId::DepthMaterial.0
+    fn id(&self) -> EffectMaterialId {
+        EffectMaterialId::DepthMaterial
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/isosurface_material.rs
+++ b/src/renderer/material/isosurface_material.rs
@@ -25,8 +25,8 @@ pub struct IsosurfaceMaterial {
 }
 
 impl Material for IsosurfaceMaterial {
-    fn id(&self) -> u16 {
-        EffectMaterialId::IsosurfaceMaterial.0
+    fn id(&self) -> EffectMaterialId {
+        EffectMaterialId::IsosurfaceMaterial
     }
 
     fn fragment_shader_source(&self, lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/normal_material.rs
+++ b/src/renderer/material/normal_material.rs
@@ -51,8 +51,8 @@ impl FromCpuMaterial for NormalMaterial {
 }
 
 impl Material for NormalMaterial {
-    fn id(&self) -> u16 {
-        EffectMaterialId::NormalMaterial(self.normal_texture.is_some()).0
+    fn id(&self) -> EffectMaterialId {
+        EffectMaterialId::NormalMaterial(self.normal_texture.is_some())
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/orm_material.rs
+++ b/src/renderer/material/orm_material.rs
@@ -77,12 +77,11 @@ impl FromCpuMaterial for ORMMaterial {
 }
 
 impl Material for ORMMaterial {
-    fn id(&self) -> u16 {
+    fn id(&self) -> EffectMaterialId {
         EffectMaterialId::ORMMaterial(
             self.metallic_roughness_texture.is_some(),
             self.occlusion_texture.is_some(),
         )
-        .0
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/physical_material.rs
+++ b/src/renderer/material/physical_material.rs
@@ -150,7 +150,7 @@ impl FromCpuMaterial for PhysicalMaterial {
 }
 
 impl Material for PhysicalMaterial {
-    fn id(&self) -> u16 {
+    fn id(&self) -> EffectMaterialId {
         EffectMaterialId::PhysicalMaterial(
             self.albedo_texture.is_some(),
             self.metallic_roughness_texture.is_some(),
@@ -158,7 +158,6 @@ impl Material for PhysicalMaterial {
             self.normal_texture.is_some(),
             self.emissive_texture.is_some(),
         )
-        .0
     }
 
     fn fragment_shader_source(&self, lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/position_material.rs
+++ b/src/renderer/material/position_material.rs
@@ -18,8 +18,8 @@ impl FromCpuMaterial for PositionMaterial {
 }
 
 impl Material for PositionMaterial {
-    fn id(&self) -> u16 {
-        EffectMaterialId::PositionMaterial.0
+    fn id(&self) -> EffectMaterialId {
+        EffectMaterialId::PositionMaterial
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/skybox_material.rs
+++ b/src/renderer/material/skybox_material.rs
@@ -7,8 +7,8 @@ pub struct SkyboxMaterial {
 }
 
 impl Material for SkyboxMaterial {
-    fn id(&self) -> u16 {
-        EffectMaterialId::SkyboxMaterial.0
+    fn id(&self) -> EffectMaterialId {
+        EffectMaterialId::SkyboxMaterial
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/material/uv_material.rs
+++ b/src/renderer/material/uv_material.rs
@@ -18,8 +18,8 @@ impl FromCpuMaterial for UVMaterial {
 }
 
 impl Material for UVMaterial {
-    fn id(&self) -> u16 {
-        EffectMaterialId::UVMaterial.0
+    fn id(&self) -> EffectMaterialId {
+        EffectMaterialId::UVMaterial
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/object/imposters.rs
+++ b/src/renderer/object/imposters.rs
@@ -212,8 +212,8 @@ impl ImpostersMaterial {
 }
 
 impl Material for ImpostersMaterial {
-    fn id(&self) -> u16 {
-        EffectMaterialId::ImpostersMaterial.0
+    fn id(&self) -> EffectMaterialId {
+        EffectMaterialId::ImpostersMaterial
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {

--- a/src/renderer/object/skybox.rs
+++ b/src/renderer/object/skybox.rs
@@ -166,8 +166,8 @@ impl Geometry for Skybox {
         include_str!("shaders/skybox.vert").to_owned()
     }
 
-    fn id(&self, _required_attributes: FragmentAttributes) -> u16 {
-        GeometryId::Skybox.0
+    fn id(&self, _required_attributes: FragmentAttributes) -> GeometryId {
+        GeometryId::Skybox
     }
 
     fn aabb(&self) -> AxisAlignedBoundingBox {

--- a/src/renderer/object/terrain.rs
+++ b/src/renderer/object/terrain.rs
@@ -363,8 +363,8 @@ impl Geometry for TerrainPatch {
         program.draw_elements(render_states, camera.viewport(), &self.index_buffer);
     }
 
-    fn id(&self, required_attributes: FragmentAttributes) -> u16 {
-        GeometryId::TerrainPatch(required_attributes.normal || required_attributes.tangents).0
+    fn id(&self, required_attributes: FragmentAttributes) -> GeometryId {
+        GeometryId::TerrainPatch(required_attributes.normal || required_attributes.tangents)
     }
 
     fn render_with_material(

--- a/src/renderer/object/water.rs
+++ b/src/renderer/object/water.rs
@@ -253,8 +253,8 @@ impl Geometry for WaterPatch {
         include_str!("shaders/water.vert").to_owned()
     }
 
-    fn id(&self, _required_attributes: FragmentAttributes) -> u16 {
-        GeometryId::WaterPatch.0
+    fn id(&self, _required_attributes: FragmentAttributes) -> GeometryId {
+        GeometryId::WaterPatch
     }
 
     fn render_with_material(

--- a/src/renderer/shader_ids.rs
+++ b/src/renderer/shader_ids.rs
@@ -9,8 +9,8 @@ use crate::texture::{ColorTexture, DepthTexture};
 
 use open_enum::open_enum;
 
-// TODO: Utilizing the open_enum crate, convert all ID usage to these types (breaking change for externally implemented shaders)
-// NOTE: It may be possible to eventually also create a proc macro that automatically allocates IDs based on the width of their subfields
+// TODO: Change macros to only take final name and generate base name once concat_idents (rust-lang/rust#29599) becomes stable
+// NOTE: It may be possible to eventually create a proc macro that automatically allocates ID values based on the width of their subfields
 
 ///
 /// Recursive macro to assemble multiple booleans into a single bitfield (as a variable width int literal)
@@ -88,9 +88,10 @@ macro_rules! enum_effectfield {
 /// ID Space for geometry shaders
 /// IDs 0x0000 through 0x7FFF are reserved for public use
 ///
+#[allow(missing_docs)]
 #[open_enum]
 #[repr(u16)]
-pub(crate) enum GeometryId {
+pub enum GeometryId {
     Screen = 0x8000,
     Skybox = 0x8001,
     TerrainPatchBase = 0x8002, // To 0x8003
@@ -126,9 +127,10 @@ impl GeometryId {
 /// ID Space for effect and material shaders
 /// IDs 0x0000 through 0x4FFF are reserved for public use
 ///
+#[allow(missing_docs)]
 #[open_enum]
 #[repr(u16)]
-pub(crate) enum EffectMaterialId {
+pub enum EffectMaterialId {
     LightingPassEffectBase = 0x5000, // To 0x503F
     WaterEffectBase = 0x5800,        // To 0x583F
     CopyEffectBase = 0x6000,         // To 0x603F
@@ -193,9 +195,10 @@ impl EffectMaterialId {
 /// ID space for lighting shaders
 /// IDs 0x00 through 0x7F are reserved for public use
 ///
+#[allow(missing_docs)]
 #[open_enum]
 #[repr(u8)]
-pub(crate) enum LightId {
+pub enum LightId {
     AmbientLightBase = 0x80,     // To 0x81
     DirectionalLightBase = 0x82, // To 0x83
     PointLight = 0x84,


### PR DESCRIPTION
This is the breaking change half of #484, where all shader traits pass IDs as their `open_enum` types (technically structs) instead of as integers. `open_enum` allows custom IDs to be added by the consuming program, as seen in the firework, logo, and Mandelbrot examples.

I noticed that while changing the original reserved ID comments on `Effect` that it recommended using the IDs above the internal range instead of below the internal range. I suspect that is due to how materials and effects share the same ID space. If that system is desired to be kept, the documentation of `EffectMaterialId` will need updated accordingly. Otherwise, it might be good to compress the ID usage of the built-in effects to all be above `0x8000`, leaving the lower half of the ID range for public use similar to the other two ID types.