### PR TITLE
Integer render target

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -127,8 +127,7 @@ fn normalized_format_from_data_type<T: DataType>() -> u32 {
 fn format_from_data_type<T: DataType>() -> u32 {
     if T::data_type() == crate::context::FLOAT || T::data_type() == crate::context::HALF_FLOAT {
         normalized_format_from_data_type::<T>()
-    }
-    else {
+    } else {
         match T::size() {
             1 => crate::context::RED_INTEGER,
             2 => crate::context::RG_INTEGER,

--- a/src/core.rs
+++ b/src/core.rs
@@ -114,7 +114,7 @@ fn from_byte_slice<T: DataType>(data: &[u8]) -> &[T] {
     }
 }
 
-fn format_from_data_type<T: DataType>() -> u32 {
+fn normalized_format_from_data_type<T: DataType>() -> u32 {
     match T::size() {
         1 => crate::context::RED,
         2 => crate::context::RG,
@@ -124,7 +124,22 @@ fn format_from_data_type<T: DataType>() -> u32 {
     }
 }
 
-fn flip_y<T: TextureDataType>(pixels: &mut [T], width: usize, height: usize) {
+fn format_from_data_type<T: DataType>() -> u32 {
+    if T::data_type() == crate::context::FLOAT || T::data_type() == crate::context::HALF_FLOAT {
+        normalized_format_from_data_type::<T>()
+    }
+    else {
+        match T::size() {
+            1 => crate::context::RED_INTEGER,
+            2 => crate::context::RG_INTEGER,
+            3 => crate::context::RGB_INTEGER,
+            4 => crate::context::RGBA_INTEGER,
+            _ => unreachable!(),
+        }
+    }
+}
+
+fn flip_y<T: BufferDataType>(pixels: &mut [T], width: usize, height: usize) {
     for row in 0..height / 2 {
         for col in 0..width {
             let index0 = width * row + col;

--- a/src/core/data_type.rs
+++ b/src/core/data_type.rs
@@ -11,17 +11,31 @@ pub enum UniformType {
     Mat4,
 }
 
-pub trait PrimitiveDataType: DataType + Copy + Default {
+pub trait PrimitiveDataType: DataType + Copy + Default + Zero {
+    fn max() -> Self;
+
     fn send_uniform_with_type(
         context: &Context,
         location: &UniformLocation,
         data: &[Self],
         type_: UniformType,
     );
+
+    unsafe fn clear_buffer_with_type(
+        context: &Context,
+        target: u32,
+        buffer: u32,
+        values: &[Self],
+    );
+
     fn internal_format_with_size(size: u32) -> u32;
 }
 
 impl PrimitiveDataType for u8 {
+    fn max() -> Self {
+        Self::MAX
+    }
+
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R8,
@@ -41,8 +55,21 @@ impl PrimitiveDataType for u8 {
         let data = data.iter().map(|v| *v as u32).collect::<Vec<_>>();
         u32::send_uniform_with_type(context, location, &data, type_)
     }
+
+    unsafe fn clear_buffer_with_type(
+        context: &Context,
+        target: u32,
+        buffer: u32,
+        values: &[Self],
+    ) {
+        context.clear_buffer_u32_slice(target, buffer, &values.iter().map(|v| *v as u32).collect::<Vec<_>>());
+    }
 }
 impl PrimitiveDataType for u16 {
+    fn max() -> Self {
+        Self::MAX
+    }
+
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R16UI,
@@ -62,8 +89,21 @@ impl PrimitiveDataType for u16 {
         let data = data.iter().map(|v| *v as u32).collect::<Vec<_>>();
         u32::send_uniform_with_type(context, location, &data, type_)
     }
+
+    unsafe fn clear_buffer_with_type(
+        context: &Context,
+        target: u32,
+        buffer: u32,
+        values: &[Self],
+    ) {
+        context.clear_buffer_u32_slice(target, buffer, &values.iter().map(|v| *v as u32).collect::<Vec<_>>());
+    }
 }
 impl PrimitiveDataType for u32 {
+    fn max() -> Self {
+        Self::MAX
+    }
+    
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R32UI,
@@ -90,8 +130,21 @@ impl PrimitiveDataType for u32 {
             }
         }
     }
+
+    unsafe fn clear_buffer_with_type(
+        context: &Context,
+        target: u32,
+        buffer: u32,
+        values: &[Self],
+    ) {
+        context.clear_buffer_u32_slice(target, buffer, values);
+    }
 }
 impl PrimitiveDataType for i8 {
+    fn max() -> Self {
+        Self::MAX
+    }
+
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R8I,
@@ -111,8 +164,21 @@ impl PrimitiveDataType for i8 {
         let data = data.iter().map(|v| *v as i32).collect::<Vec<_>>();
         i32::send_uniform_with_type(context, location, &data, type_)
     }
+
+    unsafe fn clear_buffer_with_type(
+        context: &Context,
+        target: u32,
+        buffer: u32,
+        values: &[Self],
+    ) {
+        context.clear_buffer_i32_slice(target, buffer, &values.iter().map(|v| *v as i32).collect::<Vec<_>>());
+    }
 }
 impl PrimitiveDataType for i16 {
+    fn max() -> Self {
+        Self::MAX
+    }
+
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R16I,
@@ -132,8 +198,21 @@ impl PrimitiveDataType for i16 {
         let data = data.iter().map(|v| *v as i32).collect::<Vec<_>>();
         i32::send_uniform_with_type(context, location, &data, type_)
     }
+
+    unsafe fn clear_buffer_with_type(
+        context: &Context,
+        target: u32,
+        buffer: u32,
+        values: &[Self],
+    ) {
+        context.clear_buffer_i32_slice(target, buffer, &values.iter().map(|v| *v as i32).collect::<Vec<_>>());
+    }
 }
 impl PrimitiveDataType for i32 {
+    fn max() -> Self {
+        Self::MAX
+    }
+
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R32I,
@@ -160,8 +239,21 @@ impl PrimitiveDataType for i32 {
             }
         }
     }
+
+    unsafe fn clear_buffer_with_type(
+        context: &Context,
+        target: u32,
+        buffer: u32,
+        values: &[Self],
+    ) {
+        context.clear_buffer_i32_slice(target, buffer, values);
+    }
 }
 impl PrimitiveDataType for f16 {
+    fn max() -> Self {
+        Self::one()
+    }
+
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R16F,
@@ -181,8 +273,21 @@ impl PrimitiveDataType for f16 {
         let data = data.iter().map(|v| v.to_f32()).collect::<Vec<_>>();
         f32::send_uniform_with_type(context, location, &data, type_)
     }
+
+    unsafe fn clear_buffer_with_type(
+        context: &Context,
+        target: u32,
+        buffer: u32,
+        values: &[Self],
+    ) {
+        context.clear_buffer_f32_slice(target, buffer, &values.iter().map(|v| v.to_f32()).collect::<Vec<_>>());
+    }
 }
 impl PrimitiveDataType for f32 {
+    fn max() -> Self {
+        Self::one()
+    }
+
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R32F,
@@ -216,6 +321,15 @@ impl PrimitiveDataType for f32 {
                 }
             }
         }
+    }
+
+    unsafe fn clear_buffer_with_type(
+        context: &Context,
+        target: u32,
+        buffer: u32,
+        values: &[Self],
+    ) {
+        context.clear_buffer_f32_slice(target, buffer, values);
     }
 }
 

--- a/src/core/data_type.rs
+++ b/src/core/data_type.rs
@@ -21,12 +21,7 @@ pub trait PrimitiveDataType: DataType + Copy + Default + Zero {
         type_: UniformType,
     );
 
-    unsafe fn clear_buffer_with_type(
-        context: &Context,
-        target: u32,
-        buffer: u32,
-        values: &[Self],
-    );
+    unsafe fn clear_buffer_with_type(context: &Context, target: u32, buffer: u32, values: &[Self]);
 
     fn internal_format_with_size(size: u32) -> u32;
 }
@@ -56,13 +51,12 @@ impl PrimitiveDataType for u8 {
         u32::send_uniform_with_type(context, location, &data, type_)
     }
 
-    unsafe fn clear_buffer_with_type(
-        context: &Context,
-        target: u32,
-        buffer: u32,
-        values: &[Self],
-    ) {
-        context.clear_buffer_u32_slice(target, buffer, &values.iter().map(|v| *v as u32).collect::<Vec<_>>());
+    unsafe fn clear_buffer_with_type(context: &Context, target: u32, buffer: u32, values: &[Self]) {
+        context.clear_buffer_u32_slice(
+            target,
+            buffer,
+            &values.iter().map(|v| *v as u32).collect::<Vec<_>>(),
+        );
     }
 }
 impl PrimitiveDataType for u16 {
@@ -90,20 +84,19 @@ impl PrimitiveDataType for u16 {
         u32::send_uniform_with_type(context, location, &data, type_)
     }
 
-    unsafe fn clear_buffer_with_type(
-        context: &Context,
-        target: u32,
-        buffer: u32,
-        values: &[Self],
-    ) {
-        context.clear_buffer_u32_slice(target, buffer, &values.iter().map(|v| *v as u32).collect::<Vec<_>>());
+    unsafe fn clear_buffer_with_type(context: &Context, target: u32, buffer: u32, values: &[Self]) {
+        context.clear_buffer_u32_slice(
+            target,
+            buffer,
+            &values.iter().map(|v| *v as u32).collect::<Vec<_>>(),
+        );
     }
 }
 impl PrimitiveDataType for u32 {
     fn max() -> Self {
         Self::MAX
     }
-    
+
     fn internal_format_with_size(size: u32) -> u32 {
         match size {
             1 => crate::context::R32UI,
@@ -131,12 +124,7 @@ impl PrimitiveDataType for u32 {
         }
     }
 
-    unsafe fn clear_buffer_with_type(
-        context: &Context,
-        target: u32,
-        buffer: u32,
-        values: &[Self],
-    ) {
+    unsafe fn clear_buffer_with_type(context: &Context, target: u32, buffer: u32, values: &[Self]) {
         context.clear_buffer_u32_slice(target, buffer, values);
     }
 }
@@ -165,13 +153,12 @@ impl PrimitiveDataType for i8 {
         i32::send_uniform_with_type(context, location, &data, type_)
     }
 
-    unsafe fn clear_buffer_with_type(
-        context: &Context,
-        target: u32,
-        buffer: u32,
-        values: &[Self],
-    ) {
-        context.clear_buffer_i32_slice(target, buffer, &values.iter().map(|v| *v as i32).collect::<Vec<_>>());
+    unsafe fn clear_buffer_with_type(context: &Context, target: u32, buffer: u32, values: &[Self]) {
+        context.clear_buffer_i32_slice(
+            target,
+            buffer,
+            &values.iter().map(|v| *v as i32).collect::<Vec<_>>(),
+        );
     }
 }
 impl PrimitiveDataType for i16 {
@@ -199,13 +186,12 @@ impl PrimitiveDataType for i16 {
         i32::send_uniform_with_type(context, location, &data, type_)
     }
 
-    unsafe fn clear_buffer_with_type(
-        context: &Context,
-        target: u32,
-        buffer: u32,
-        values: &[Self],
-    ) {
-        context.clear_buffer_i32_slice(target, buffer, &values.iter().map(|v| *v as i32).collect::<Vec<_>>());
+    unsafe fn clear_buffer_with_type(context: &Context, target: u32, buffer: u32, values: &[Self]) {
+        context.clear_buffer_i32_slice(
+            target,
+            buffer,
+            &values.iter().map(|v| *v as i32).collect::<Vec<_>>(),
+        );
     }
 }
 impl PrimitiveDataType for i32 {
@@ -240,12 +226,7 @@ impl PrimitiveDataType for i32 {
         }
     }
 
-    unsafe fn clear_buffer_with_type(
-        context: &Context,
-        target: u32,
-        buffer: u32,
-        values: &[Self],
-    ) {
+    unsafe fn clear_buffer_with_type(context: &Context, target: u32, buffer: u32, values: &[Self]) {
         context.clear_buffer_i32_slice(target, buffer, values);
     }
 }
@@ -274,13 +255,12 @@ impl PrimitiveDataType for f16 {
         f32::send_uniform_with_type(context, location, &data, type_)
     }
 
-    unsafe fn clear_buffer_with_type(
-        context: &Context,
-        target: u32,
-        buffer: u32,
-        values: &[Self],
-    ) {
-        context.clear_buffer_f32_slice(target, buffer, &values.iter().map(|v| v.to_f32()).collect::<Vec<_>>());
+    unsafe fn clear_buffer_with_type(context: &Context, target: u32, buffer: u32, values: &[Self]) {
+        context.clear_buffer_f32_slice(
+            target,
+            buffer,
+            &values.iter().map(|v| v.to_f32()).collect::<Vec<_>>(),
+        );
     }
 }
 impl PrimitiveDataType for f32 {
@@ -323,12 +303,7 @@ impl PrimitiveDataType for f32 {
         }
     }
 
-    unsafe fn clear_buffer_with_type(
-        context: &Context,
-        target: u32,
-        buffer: u32,
-        values: &[Self],
-    ) {
+    unsafe fn clear_buffer_with_type(context: &Context, target: u32, buffer: u32, values: &[Self]) {
         context.clear_buffer_f32_slice(target, buffer, values);
     }
 }

--- a/src/core/render_target.rs
+++ b/src/core/render_target.rs
@@ -116,7 +116,11 @@ impl<'a> RenderTarget<'a> {
     ///
     /// Clears the color and depth of the part of this render target that is inside the given scissor box, in the given data type.
     ///
-    pub fn clear_buffer_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
+    pub fn clear_buffer_partially(
+        &self,
+        scissor_box: ScissorBox,
+        clear_state: ClearState<impl PrimitiveDataType>,
+    ) -> &Self {
         self.context.set_scissor(scissor_box);
         self.bind(crate::context::DRAW_FRAMEBUFFER);
         clear_state.apply_buffer(&self.context);
@@ -208,8 +212,12 @@ impl<'a> RenderTarget<'a> {
 
     ///
     /// Common function used to implement read_color, read_buffer, and _partially variants
-    /// 
-    fn read_formatted_buffer_partially<T: BufferDataType>(&self, format: u32, scissor_box: ScissorBox) -> Vec<T> {
+    ///
+    fn read_formatted_buffer_partially<T: BufferDataType>(
+        &self,
+        format: u32,
+        scissor_box: ScissorBox,
+    ) -> Vec<T> {
         if self.id.is_some() && self.color.is_none() {
             panic!("Cannot read color from a render target without a color target");
         }

--- a/src/core/render_target/clear_state.rs
+++ b/src/core/render_target/clear_state.rs
@@ -109,8 +109,7 @@ impl<T: PrimitiveDataType> ClearState<T> {
         }
     }
 
-    pub(in crate::core) fn apply_buffer(&self, context: &Context)
-    {
+    pub(in crate::core) fn apply_buffer(&self, context: &Context) {
         context.set_write_mask(WriteMask {
             red: self.red.is_some(),
             green: self.green.is_some(),
@@ -124,7 +123,10 @@ impl<T: PrimitiveDataType> ClearState<T> {
                 || self.blue.is_some()
                 || self.alpha.is_some();
             if clear_color {
-                T::clear_buffer_with_type(context, crate::context::COLOR, 0, 
+                T::clear_buffer_with_type(
+                    context,
+                    crate::context::COLOR,
+                    0,
                     &[
                         self.red.unwrap_or_else(T::zero),
                         self.green.unwrap_or_else(T::zero),

--- a/src/core/render_target/clear_state.rs
+++ b/src/core/render_target/clear_state.rs
@@ -1,3 +1,5 @@
+use data_type::PrimitiveDataType;
+
 use crate::core::*;
 
 ///
@@ -5,20 +7,20 @@ use crate::core::*;
 /// If `None` then the channel is not cleared and if `Some(value)` the channel is cleared to that value (the value must be between 0 and 1).
 ///
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub struct ClearState {
+pub struct ClearState<T: PrimitiveDataType> {
     /// Defines the clear value for the red channel.
-    pub red: Option<f32>,
+    pub red: Option<T>,
     /// Defines the clear value for the green channel.
-    pub green: Option<f32>,
+    pub green: Option<T>,
     /// Defines the clear value for the blue channel.
-    pub blue: Option<f32>,
+    pub blue: Option<T>,
     /// Defines the clear value for the alpha channel.
-    pub alpha: Option<f32>,
+    pub alpha: Option<T>,
     /// Defines the clear value for the depth channel. A value of 1 means a depth value equal to the far plane and 0 means a depth value equal to the near plane.
     pub depth: Option<f32>,
 }
 
-impl ClearState {
+impl ClearState<f32> {
     ///
     /// Nothing will be cleared.
     ///
@@ -41,32 +43,6 @@ impl ClearState {
             green: None,
             blue: None,
             alpha: None,
-            depth: Some(depth),
-        }
-    }
-
-    ///
-    /// The color channels (red, green, blue and alpha) will be cleared to the given values.
-    ///
-    pub const fn color(red: f32, green: f32, blue: f32, alpha: f32) -> Self {
-        Self {
-            red: Some(red),
-            green: Some(green),
-            blue: Some(blue),
-            alpha: Some(alpha),
-            depth: None,
-        }
-    }
-
-    ///
-    /// Both the color channels (red, green, blue and alpha) and depth will be cleared to the given values.
-    ///
-    pub const fn color_and_depth(red: f32, green: f32, blue: f32, alpha: f32, depth: f32) -> Self {
-        Self {
-            red: Some(red),
-            green: Some(green),
-            blue: Some(blue),
-            alpha: Some(alpha),
             depth: Some(depth),
         }
     }
@@ -106,7 +82,65 @@ impl ClearState {
     }
 }
 
-impl Default for ClearState {
+impl<T: PrimitiveDataType> ClearState<T> {
+    ///
+    /// The color channels (red, green, blue and alpha) will be cleared to the given values.
+    ///
+    pub const fn color(red: T, green: T, blue: T, alpha: T) -> Self {
+        Self {
+            red: Some(red),
+            green: Some(green),
+            blue: Some(blue),
+            alpha: Some(alpha),
+            depth: None,
+        }
+    }
+
+    ///
+    /// Both the color channels (red, green, blue and alpha) and depth will be cleared to the given values.
+    ///
+    pub const fn color_and_depth(red: T, green: T, blue: T, alpha: T, depth: f32) -> Self {
+        Self {
+            red: Some(red),
+            green: Some(green),
+            blue: Some(blue),
+            alpha: Some(alpha),
+            depth: Some(depth),
+        }
+    }
+
+    pub(in crate::core) fn apply_buffer(&self, context: &Context)
+    {
+        context.set_write_mask(WriteMask {
+            red: self.red.is_some(),
+            green: self.green.is_some(),
+            blue: self.blue.is_some(),
+            alpha: self.alpha.is_some(),
+            depth: self.depth.is_some(),
+        });
+        unsafe {
+            let clear_color = self.red.is_some()
+                || self.green.is_some()
+                || self.blue.is_some()
+                || self.alpha.is_some();
+            if clear_color {
+                T::clear_buffer_with_type(context, crate::context::COLOR, 0, 
+                    &[
+                        self.red.unwrap_or_else(T::zero),
+                        self.green.unwrap_or_else(T::zero),
+                        self.blue.unwrap_or_else(T::zero),
+                        self.alpha.unwrap_or_else(T::max),
+                    ],
+                );
+            }
+            if let Some(depth) = self.depth {
+                context.clear_buffer_f32_slice(crate::context::DEPTH, 0, &[depth]);
+            }
+        }
+    }
+}
+
+impl Default for ClearState<f32> {
     fn default() -> Self {
         Self::color_and_depth(0.0, 0.0, 0.0, 1.0, 1.0)
     }

--- a/src/core/render_target/color_target.rs
+++ b/src/core/render_target/color_target.rs
@@ -73,14 +73,14 @@ impl<'a> ColorTarget<'a> {
     ///
     /// Clears the color of this color target as defined by the given clear state.
     ///
-    pub fn clear(&self, clear_state: ClearState) -> &Self {
+    pub fn clear(&self, clear_state: ClearState<f32>) -> &Self {
         self.clear_partially(self.scissor_box(), clear_state)
     }
 
     ///
     /// Clears the color of the part of this color target that is inside the given scissor box.
     ///
-    pub fn clear_partially(&self, scissor_box: ScissorBox, clear_state: ClearState) -> &Self {
+    pub fn clear_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<f32>) -> &Self {
         self.as_render_target().clear_partially(
             scissor_box,
             ClearState {
@@ -88,6 +88,22 @@ impl<'a> ColorTarget<'a> {
                 ..clear_state
             },
         );
+        self
+    }
+
+    ///
+    /// Clears the color of this color target as defined by the given clear state and data type.
+    ///
+    pub fn clear_buffer(&self, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
+        self.clear_buffer_partially(self.scissor_box(), clear_state)
+    }
+
+    ///
+    /// Clears the color of the part of this color target that is inside the given scissor box, in the given data type.
+    ///
+    pub fn clear_buffer_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
+        self.as_render_target()
+            .clear_buffer_partially(scissor_box, clear_state);
         self
     }
 
@@ -144,6 +160,28 @@ impl<'a> ColorTarget<'a> {
     ///
     pub fn read_partially<T: TextureDataType>(&self, scissor_box: ScissorBox) -> Vec<T> {
         self.as_render_target().read_color_partially(scissor_box)
+    }
+
+    ///
+    /// Returns the underlying buffer data of this color target.
+    /// The number of channels per pixel and the data format for each channel returned from this function is specified by the generic parameter `T`.
+    ///
+    /// **Note:**
+    /// The base type of the generic parameter `T` must match the base type of the render target, for example if the render targets base type is `u8`, the base type of `T` must also be `u8`.
+    ///
+    pub fn read_buffer<T: BufferDataType>(&self) -> Vec<T> {
+        self.read_buffer_partially(self.scissor_box())
+    }
+
+    ///
+    /// Returns the underlying buffer data of this color target inside the given scissor box.
+    /// The number of channels per pixel and the data format for each channel returned from this function is specified by the generic parameter `T`.
+    ///
+    /// **Note:**
+    /// The base type of the generic parameter `T` must match the base type of the render target, for example if the render targets base type is `u8`, the base type of `T` must also be `u8`.
+    ///
+    pub fn read_buffer_partially<T: BufferDataType>(&self, scissor_box: ScissorBox) -> Vec<T> {
+        self.as_render_target().read_buffer_partially(scissor_box)
     }
 
     ///

--- a/src/core/render_target/color_target.rs
+++ b/src/core/render_target/color_target.rs
@@ -101,7 +101,11 @@ impl<'a> ColorTarget<'a> {
     ///
     /// Clears the color of the part of this color target that is inside the given scissor box, in the given data type.
     ///
-    pub fn clear_buffer_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
+    pub fn clear_buffer_partially(
+        &self,
+        scissor_box: ScissorBox,
+        clear_state: ClearState<impl PrimitiveDataType>,
+    ) -> &Self {
         self.as_render_target()
             .clear_buffer_partially(scissor_box, clear_state);
         self

--- a/src/core/render_target/color_target_multisample.rs
+++ b/src/core/render_target/color_target_multisample.rs
@@ -1,3 +1,5 @@
+use data_type::PrimitiveDataType;
+
 use crate::core::*;
 
 ///
@@ -8,7 +10,7 @@ use crate::core::*;
 ///
 /// Also see [RenderTargetMultisample] and [DepthTargetMultisample].
 ///
-pub struct ColorTargetMultisample<C: TextureDataType> {
+pub struct ColorTargetMultisample<C: BufferDataType> {
     pub(crate) context: Context,
     color: Texture2DMultisample,
     _c: std::marker::PhantomData<C>,
@@ -32,7 +34,7 @@ impl<C: TextureDataType> ColorTargetMultisample<C> {
     ///
     /// Clears the color of this target as defined by the given clear state.
     ///
-    pub fn clear(&self, clear_state: ClearState) -> &Self {
+    pub fn clear(&self, clear_state: ClearState<f32>) -> &Self {
         self.clear_partially(
             ScissorBox::new_at_origo(self.width(), self.height()),
             clear_state,
@@ -42,7 +44,7 @@ impl<C: TextureDataType> ColorTargetMultisample<C> {
     ///
     /// Clears the color of the part of this target that is inside the given scissor box.
     ///
-    pub fn clear_partially(&self, scissor_box: ScissorBox, clear_state: ClearState) -> &Self {
+    pub fn clear_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<f32>) -> &Self {
         self.as_render_target().clear_partially(
             scissor_box,
             ClearState {
@@ -50,6 +52,22 @@ impl<C: TextureDataType> ColorTargetMultisample<C> {
                 ..clear_state
             },
         );
+        self
+    }
+
+    ///
+    /// Clears the color of this target as defined by the given clear state and data type.
+    ///
+    pub fn clear_buffer(&self, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
+        self.clear_buffer_partially(self.scissor_box(), clear_state)
+    }
+
+    ///
+    /// Clears the color of the part of this target that is inside the given scissor box, in the given data type.
+    ///
+    pub fn clear_buffer_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
+        self.as_render_target()
+            .clear_buffer_partially(scissor_box, clear_state);
         self
     }
 

--- a/src/core/render_target/color_target_multisample.rs
+++ b/src/core/render_target/color_target_multisample.rs
@@ -65,7 +65,11 @@ impl<C: TextureDataType> ColorTargetMultisample<C> {
     ///
     /// Clears the color of the part of this target that is inside the given scissor box, in the given data type.
     ///
-    pub fn clear_buffer_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
+    pub fn clear_buffer_partially(
+        &self,
+        scissor_box: ScissorBox,
+        clear_state: ClearState<impl PrimitiveDataType>,
+    ) -> &Self {
         self.as_render_target()
             .clear_buffer_partially(scissor_box, clear_state);
         self

--- a/src/core/render_target/depth_target.rs
+++ b/src/core/render_target/depth_target.rs
@@ -60,14 +60,14 @@ impl<'a> DepthTarget<'a> {
     ///
     /// Clears the depth of this depth target as defined by the given clear state.
     ///
-    pub fn clear(&self, clear_state: ClearState) -> &Self {
+    pub fn clear(&self, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
         self.clear_partially(self.scissor_box(), clear_state)
     }
 
     ///
     /// Clears the depth of the part of this depth target that is inside the given scissor box.
     ///
-    pub fn clear_partially(&self, scissor_box: ScissorBox, clear_state: ClearState) -> &Self {
+    pub fn clear_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
         self.as_render_target().clear_partially(
             scissor_box,
             ClearState {

--- a/src/core/render_target/depth_target.rs
+++ b/src/core/render_target/depth_target.rs
@@ -67,7 +67,11 @@ impl<'a> DepthTarget<'a> {
     ///
     /// Clears the depth of the part of this depth target that is inside the given scissor box.
     ///
-    pub fn clear_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
+    pub fn clear_partially(
+        &self,
+        scissor_box: ScissorBox,
+        clear_state: ClearState<impl PrimitiveDataType>,
+    ) -> &Self {
         self.as_render_target().clear_partially(
             scissor_box,
             ClearState {

--- a/src/core/render_target/depth_target_multisample.rs
+++ b/src/core/render_target/depth_target_multisample.rs
@@ -40,7 +40,11 @@ impl<D: DepthTextureDataType> DepthTargetMultisample<D> {
     ///
     /// Clears the color and depth of the part of this target that is inside the given scissor box.
     ///
-    pub fn clear_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
+    pub fn clear_partially(
+        &self,
+        scissor_box: ScissorBox,
+        clear_state: ClearState<impl PrimitiveDataType>,
+    ) -> &Self {
         self.as_render_target().clear_partially(
             scissor_box,
             ClearState {

--- a/src/core/render_target/depth_target_multisample.rs
+++ b/src/core/render_target/depth_target_multisample.rs
@@ -1,4 +1,5 @@
 use crate::core::*;
+use data_type::PrimitiveDataType;
 
 ///
 /// A multisample render target for depth data. Use this if you want to avoid aliasing, ie. jagged edges, when rendering to a [DepthTarget].
@@ -32,14 +33,14 @@ impl<D: DepthTextureDataType> DepthTargetMultisample<D> {
     ///
     /// Clears the color and depth of this target as defined by the given clear state.
     ///
-    pub fn clear(&self, clear_state: ClearState) -> &Self {
+    pub fn clear(&self, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
         self.clear_partially(self.scissor_box(), clear_state)
     }
 
     ///
     /// Clears the color and depth of the part of this target that is inside the given scissor box.
     ///
-    pub fn clear_partially(&self, scissor_box: ScissorBox, clear_state: ClearState) -> &Self {
+    pub fn clear_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
         self.as_render_target().clear_partially(
             scissor_box,
             ClearState {

--- a/src/core/render_target/multisample.rs
+++ b/src/core/render_target/multisample.rs
@@ -61,7 +61,11 @@ impl<C: TextureDataType, D: DepthTextureDataType> RenderTargetMultisample<C, D> 
     ///
     /// Clears the color and depth of the part of this target that is inside the given scissor box, in the given data type.
     ///
-    pub fn clear_buffer_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
+    pub fn clear_buffer_partially(
+        &self,
+        scissor_box: ScissorBox,
+        clear_state: ClearState<impl PrimitiveDataType>,
+    ) -> &Self {
         self.as_render_target()
             .clear_buffer_partially(scissor_box, clear_state);
         self

--- a/src/core/render_target/multisample.rs
+++ b/src/core/render_target/multisample.rs
@@ -1,4 +1,5 @@
 use crate::core::*;
+use data_type::PrimitiveDataType;
 
 ///
 /// A multisampled render target for color and depth data. Use this if you want to avoid aliasing, ie. jagged edges, when rendering to a [RenderTarget].
@@ -9,7 +10,7 @@ use crate::core::*;
 ///
 /// Also see [ColorTargetMultisample] and [DepthTargetMultisample].
 ///
-pub struct RenderTargetMultisample<C: TextureDataType, D: DepthTextureDataType> {
+pub struct RenderTargetMultisample<C: BufferDataType, D: DepthTextureDataType> {
     pub(crate) context: Context,
     color: Texture2DMultisample,
     depth: DepthTexture2DMultisample,
@@ -37,16 +38,32 @@ impl<C: TextureDataType, D: DepthTextureDataType> RenderTargetMultisample<C, D> 
     ///
     /// Clears the color and depth of this target as defined by the given clear state.
     ///
-    pub fn clear(&self, clear_state: ClearState) -> &Self {
+    pub fn clear(&self, clear_state: ClearState<f32>) -> &Self {
         self.clear_partially(self.scissor_box(), clear_state)
     }
 
     ///
     /// Clears the color and depth of the part of this target that is inside the given scissor box.
     ///
-    pub fn clear_partially(&self, scissor_box: ScissorBox, clear_state: ClearState) -> &Self {
+    pub fn clear_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<f32>) -> &Self {
         self.as_render_target()
             .clear_partially(scissor_box, clear_state);
+        self
+    }
+
+    ///
+    /// Clears the color and depth of this target as defined by the given clear state and data type.
+    ///
+    pub fn clear_buffer(&self, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
+        self.clear_buffer_partially(self.scissor_box(), clear_state)
+    }
+
+    ///
+    /// Clears the color and depth of the part of this target that is inside the given scissor box, in the given data type.
+    ///
+    pub fn clear_buffer_partially(&self, scissor_box: ScissorBox, clear_state: ClearState<impl PrimitiveDataType>) -> &Self {
+        self.as_render_target()
+            .clear_buffer_partially(scissor_box, clear_state);
         self
     }
 

--- a/src/core/texture.rs
+++ b/src/core/texture.rs
@@ -349,13 +349,13 @@ fn set_parameters(
     }
 }
 
-fn calculate_number_of_mip_maps<T: TextureDataType>(
+fn calculate_number_of_mip_maps<T: DataType>(
     mip_map_filter: Option<Interpolation>,
     width: u32,
     height: u32,
     depth: Option<u32>,
 ) -> u32 {
-    // Cannot generate mip maps for RGB textures using non-normalized data formats on web (OpenGL ES3.0 Table 3.13, https://registry.khronos.org/webgl/extensions/EXT_color_buffer_float/)
+    // Cannot generate mip maps for RGB textures using non-byte data formats on web (OpenGL ES3.0 Table 3.13, https://registry.khronos.org/webgl/extensions/EXT_color_buffer_float/)
     if T::size() == 3 && T::data_type() != crate::context::UNSIGNED_BYTE {
         return 1;
     }
@@ -389,7 +389,7 @@ fn interpolation_from(interpolation: Interpolation) -> i32 {
     }) as i32
 }
 
-fn check_data_length<T: TextureDataType>(
+fn check_data_length<T: DataType>(
     width: u32,
     height: u32,
     depth: u32,

--- a/src/core/texture.rs
+++ b/src/core/texture.rs
@@ -42,8 +42,8 @@ pub use three_d_asset::texture::{
     Interpolation, Texture2D as CpuTexture, Texture3D as CpuTexture3D, TextureData, Wrapping,
 };
 
-/// The basic data type used for each channel of each pixel in a texture.
-pub trait TextureDataType: DataType {}
+/// The basic data type used for each channel of each pixel in a normalized texture.
+pub trait TextureDataType: BufferDataType {}
 impl TextureDataType for u8 {}
 impl TextureDataType for f16 {}
 impl TextureDataType for f32 {}
@@ -355,10 +355,8 @@ fn calculate_number_of_mip_maps<T: TextureDataType>(
     height: u32,
     depth: Option<u32>,
 ) -> u32 {
-    // Cannot generate mip maps for RGB16F or RGB32F textures on web (https://registry.khronos.org/webgl/extensions/EXT_color_buffer_float/)
-    if (T::data_type() == crate::context::FLOAT || T::data_type() == crate::context::HALF_FLOAT)
-        && T::size() == 3
-    {
+    // Cannot generate mip maps for RGB textures using non-normalized data formats on web (OpenGL ES3.0 Table 3.13, https://registry.khronos.org/webgl/extensions/EXT_color_buffer_float/)
+    if T::size() == 3 && T::data_type() != crate::context::UNSIGNED_BYTE {
         return 1;
     }
 

--- a/src/core/texture/texture2d.rs
+++ b/src/core/texture/texture2d.rs
@@ -61,7 +61,7 @@ impl Texture2D {
     ///
     /// **Note:** Mip maps will not be generated for RGB16F and RGB32F format, even if `mip_map_filter` is specified.
     ///
-    pub fn new_empty<T: TextureDataType>(
+    pub fn new_empty<T: BufferDataType>(
         context: &Context,
         width: u32,
         height: u32,
@@ -118,6 +118,21 @@ impl Texture2D {
     /// It is therefore necessary to create a new texture if the texture size or format has changed.
     ///
     pub fn fill<T: TextureDataType>(&mut self, data: &[T]) {
+        self.fill_format(data, normalized_format_from_data_type::<T>())
+    }
+
+    ///
+    /// Fills this texture with the given data, using the given data type.
+    ///
+    /// # Panic
+    /// Will panic if the length of the data does not correspond to the width, height and format specified at construction.
+    /// It is therefore necessary to create a new texture if the texture size or format has changed.
+    ///
+    pub fn fill_buffer<T: BufferDataType>(&mut self, data: &[T]) {
+        self.fill_format(data, format_from_data_type::<T>())
+    }
+
+    fn fill_format<T: BufferDataType>(&mut self, data: &[T], format: u32) {
         check_data_length::<T>(self.width, self.height, 1, self.data_byte_size, data.len());
         self.bind();
         let mut data = data.to_owned();
@@ -130,7 +145,7 @@ impl Texture2D {
                 0,
                 self.width as i32,
                 self.height as i32,
-                normalized_format_from_data_type::<T>(),
+                format,
                 T::data_type(),
                 crate::context::PixelUnpackData::Slice(to_byte_slice(&data)),
             );

--- a/src/core/texture/texture2d.rs
+++ b/src/core/texture/texture2d.rs
@@ -130,7 +130,7 @@ impl Texture2D {
                 0,
                 self.width as i32,
                 self.height as i32,
-                format_from_data_type::<T>(),
+                normalized_format_from_data_type::<T>(),
                 T::data_type(),
                 crate::context::PixelUnpackData::Slice(to_byte_slice(&data)),
             );

--- a/src/core/texture/texture2d_array.rs
+++ b/src/core/texture/texture2d_array.rs
@@ -242,7 +242,7 @@ impl Texture2DArray {
                 self.width as i32,
                 self.height as i32,
                 1,
-                format_from_data_type::<T>(),
+                normalized_format_from_data_type::<T>(),
                 T::data_type(),
                 crate::context::PixelUnpackData::Slice(to_byte_slice(&data)),
             );

--- a/src/core/texture/texture2d_array.rs
+++ b/src/core/texture/texture2d_array.rs
@@ -215,6 +215,19 @@ impl Texture2DArray {
     }
 
     ///
+    /// Fills the texture array with the given pixel data in the given format.
+    ///
+    /// # Panic
+    /// Will panic if the data does not correspond to the width, height, depth and format specified at construction.
+    /// It is therefore necessary to create a new texture if the texture size or format has changed.
+    ///
+    pub fn fill_buffer<T: BufferDataType>(&mut self, data: &[&[T]]) {
+        for (i, data) in data.iter().enumerate() {
+            self.fill_layer_buffer(i as u32, data);
+        }
+    }
+
+    ///
     /// Fills the given layer in the texture array with the given pixel data.
     ///
     /// # Panic
@@ -222,6 +235,21 @@ impl Texture2DArray {
     /// It is therefore necessary to create a new texture if the texture size or format has changed.
     ///
     pub fn fill_layer<T: TextureDataType>(&mut self, layer: u32, data: &[T]) {
+        self.fill_layer_format(layer, data, normalized_format_from_data_type::<T>());
+    }
+
+    ///
+    /// Fills the given layer in the texture array with the given pixel data in the given format.
+    ///
+    /// # Panic
+    /// Will panic if the layer number is bigger than the number of layers or if the data does not correspond to the width, height and format specified at construction.
+    /// It is therefore necessary to create a new texture if the texture size or format has changed.
+    ///
+    pub fn fill_layer_buffer<T: BufferDataType>(&mut self, layer: u32, data: &[T]) {
+        self.fill_layer_format(layer, data, format_from_data_type::<T>());
+    }
+
+    fn fill_layer_format<T: BufferDataType>(&mut self, layer: u32, data: &[T], format: u32) {
         if layer >= self.depth {
             panic!(
                 "cannot fill the layer {} with data, since there are only {} layers in the texture array",
@@ -242,7 +270,7 @@ impl Texture2DArray {
                 self.width as i32,
                 self.height as i32,
                 1,
-                normalized_format_from_data_type::<T>(),
+                format,
                 T::data_type(),
                 crate::context::PixelUnpackData::Slice(to_byte_slice(&data)),
             );

--- a/src/core/texture/texture2d_multisample.rs
+++ b/src/core/texture/texture2d_multisample.rs
@@ -9,7 +9,7 @@ pub struct Texture2DMultisample {
 }
 
 impl Texture2DMultisample {
-    pub fn new<T: TextureDataType>(
+    pub fn new<T: BufferDataType>(
         context: &Context,
         width: u32,
         height: u32,

--- a/src/core/texture/texture3d.rs
+++ b/src/core/texture/texture3d.rs
@@ -140,7 +140,7 @@ impl Texture3D {
                 self.width as i32,
                 self.height as i32,
                 self.depth as i32,
-                format_from_data_type::<T>(),
+                normalized_format_from_data_type::<T>(),
                 T::data_type(),
                 crate::context::PixelUnpackData::Slice(to_byte_slice(data)),
             );

--- a/src/core/texture/texture3d.rs
+++ b/src/core/texture/texture3d.rs
@@ -61,7 +61,7 @@ impl Texture3D {
     ///
     /// **Note:** Mip maps will not be generated for RGB16F and RGB32F format, even if `mip_map_filter` is specified.
     ///
-    pub fn new_empty<T: TextureDataType>(
+    pub fn new_empty<T: BufferDataType>(
         context: &Context,
         width: u32,
         height: u32,
@@ -122,6 +122,21 @@ impl Texture3D {
     /// It is therefore necessary to create a new texture if the texture size or format has changed.
     ///
     pub fn fill<T: TextureDataType>(&mut self, data: &[T]) {
+        self.fill_format(data, normalized_format_from_data_type::<T>());
+    }
+
+    ///
+    /// Fills this texture with the given data in the given data format.
+    ///
+    /// # Panic
+    /// Will panic if the length of the data does not correspond to the width, height, depth and format specified at construction.
+    /// It is therefore necessary to create a new texture if the texture size or format has changed.
+    ///
+    pub fn fill_buffer<T: TextureDataType>(&mut self, data: &[T]) {
+        self.fill_format(data, format_from_data_type::<T>());
+    }
+
+    fn fill_format<T: TextureDataType>(&mut self, data: &[T], format: u32) {
         check_data_length::<T>(
             self.width,
             self.height,
@@ -140,7 +155,7 @@ impl Texture3D {
                 self.width as i32,
                 self.height as i32,
                 self.depth as i32,
-                normalized_format_from_data_type::<T>(),
+                format,
                 T::data_type(),
                 crate::context::PixelUnpackData::Slice(to_byte_slice(data)),
             );

--- a/src/core/texture/texture_cube_map.rs
+++ b/src/core/texture/texture_cube_map.rs
@@ -369,7 +369,15 @@ impl TextureCubeMap {
         front_data: &[T],
         back_data: &[T],
     ) {
-        self.fill_format(right_data, left_data, top_data, bottom_data, front_data, back_data, normalized_format_from_data_type::<T>());
+        self.fill_format(
+            right_data,
+            left_data,
+            top_data,
+            bottom_data,
+            front_data,
+            back_data,
+            normalized_format_from_data_type::<T>(),
+        );
     }
 
     ///
@@ -388,9 +396,17 @@ impl TextureCubeMap {
         front_data: &[T],
         back_data: &[T],
     ) {
-        self.fill_format(right_data, left_data, top_data, bottom_data, front_data, back_data, format_from_data_type::<T>());
+        self.fill_format(
+            right_data,
+            left_data,
+            top_data,
+            bottom_data,
+            front_data,
+            back_data,
+            format_from_data_type::<T>(),
+        );
     }
-    
+
     fn fill_format<T: BufferDataType>(
         &mut self,
         right_data: &[T],

--- a/src/core/texture/texture_cube_map.rs
+++ b/src/core/texture/texture_cube_map.rs
@@ -430,7 +430,7 @@ impl TextureCubeMap {
                     0,
                     self.width as i32,
                     self.height as i32,
-                    format_from_data_type::<T>(),
+                    normalized_format_from_data_type::<T>(),
                     T::data_type(),
                     crate::context::PixelUnpackData::Slice(to_byte_slice(data)),
                 );

--- a/src/core/texture/texture_cube_map.rs
+++ b/src/core/texture/texture_cube_map.rs
@@ -303,7 +303,7 @@ impl TextureCubeMap {
     ///
     /// **Note:** Mip maps will not be generated for RGB16F and RGB32F format, even if `mip_map_filter` is specified.
     ///
-    pub fn new_empty<T: TextureDataType>(
+    pub fn new_empty<T: BufferDataType>(
         context: &Context,
         width: u32,
         height: u32,
@@ -369,6 +369,38 @@ impl TextureCubeMap {
         front_data: &[T],
         back_data: &[T],
     ) {
+        self.fill_format(right_data, left_data, top_data, bottom_data, front_data, back_data, normalized_format_from_data_type::<T>());
+    }
+
+    ///
+    /// Fills the cube map texture with the given pixel data in the given format for the 6 images.
+    ///
+    /// # Panic
+    /// Will panic if the length of the data for all 6 images does not correspond to the width, height and format specified at construction.
+    /// It is therefore necessary to create a new texture if the texture size or format has changed.
+    ///
+    pub fn fill_buffer<T: BufferDataType>(
+        &mut self,
+        right_data: &[T],
+        left_data: &[T],
+        top_data: &[T],
+        bottom_data: &[T],
+        front_data: &[T],
+        back_data: &[T],
+    ) {
+        self.fill_format(right_data, left_data, top_data, bottom_data, front_data, back_data, format_from_data_type::<T>());
+    }
+    
+    fn fill_format<T: BufferDataType>(
+        &mut self,
+        right_data: &[T],
+        left_data: &[T],
+        top_data: &[T],
+        bottom_data: &[T],
+        front_data: &[T],
+        back_data: &[T],
+        format: u32,
+    ) {
         check_data_length::<T>(
             self.width,
             self.height,
@@ -430,7 +462,7 @@ impl TextureCubeMap {
                     0,
                     self.width as i32,
                     self.height as i32,
-                    normalized_format_from_data_type::<T>(),
+                    format,
                     T::data_type(),
                     crate::context::PixelUnpackData::Slice(to_byte_slice(data)),
                 );


### PR DESCRIPTION
As used in #479, this adds support for render targets and GPU-side textures using integer data formats. I'm not 100% sold on the naming I chose for the new functions, so other ideas are welcome if you can think of something better.