### PR TITLE
Update egui to version 0.29 and glow to 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,14 +24,14 @@ egui-gui = ["egui_glow", "egui", "getrandom"] # Additional GUI features
 text = ["swash", "lyon"] # Text mesh generation features
 
 [dependencies]
-glow = "0.13"
+glow = "0.14"
 cgmath = "0.18"
 three-d-asset = {version = "0.7"}
 thiserror = "1"
 open-enum = "0.5"
 winit = {version = "0.28", optional = true}
-egui = { version = "0.28", optional = true }
-egui_glow = { version = "0.28", optional = true }
+egui = { version = "0.29", optional = true }
+egui_glow = { version = "0.29", optional = true }
 getrandom = { version = "0.2", features = ["js"], optional = true }
 swash = { version = "0.1", optional = true }
 lyon = { version = "1", optional = true }

--- a/src/gui/egui_gui.rs
+++ b/src/gui/egui_gui.rs
@@ -32,7 +32,7 @@ impl GUI {
     pub fn from_gl_context(context: std::sync::Arc<crate::context::Context>) -> Self {
         GUI {
             egui_context: egui::Context::default(),
-            painter: RefCell::new(Painter::new(context, "", None).unwrap()),
+            painter: RefCell::new(Painter::new(context, "", None, true).unwrap()),
             output: RefCell::new(None),
             viewport: Viewport::new_at_origo(1, 1),
             modifiers: Modifiers::default(),
@@ -193,9 +193,9 @@ impl GUI {
             ..Default::default()
         };
 
-        self.egui_context.begin_frame(egui_input);
+        self.egui_context.begin_pass(egui_input);
         callback(&self.egui_context);
-        *self.output.borrow_mut() = Some(self.egui_context.end_frame());
+        *self.output.borrow_mut() = Some(self.egui_context.end_pass());
 
         for event in events.iter_mut() {
             if let Event::ModifiersChange { modifiers } = event {


### PR DESCRIPTION
Hello,

This is a small PR to update `egui` to the latest release. As `egui` now needs `glow` 0.14, the upgrade was done too. But maybe should I have done it in another PR ?

The 0.29 version of `egui` introduces a dithering option and I had to update the code according to it, but maybe not like you would have done it. Feel free to ask for changes and I will adapt the code :)
cf: 
- https://github.com/emilk/egui/pull/4497
- https://docs.rs/egui_glow/latest/egui_glow/painter/struct.Painter.html#method.new
 

And everything seems to be fine with a `cargo test --all-features --all-targets`

Have a nice day,