### PR TITLE
Format shader compilation errors with line numbers and listing of info log entries

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -55,7 +55,7 @@ pub enum CoreError {
     ContextCreation(String),
     #[error("failed rendering with error: {0}")]
     ContextError(String),
-    #[error("failed compiling {0} shader: {1}\n{2}")]
+    #[error("failed compiling {0} shader\n\nsource:\n{1}\n\nlog:\n{2}")]
     ShaderCompilation(String, String, String),
     #[error("failed to link shader program: {0}")]
     ShaderLink(String),

--- a/src/core/program.rs
+++ b/src/core/program.rs
@@ -646,9 +646,8 @@ impl Drop for Program {
     }
 }
 fn shader_compilation_error(typ: &str, log: String, source: String) -> CoreError {
-    let lines: Vec<&str> = source.split('\n').collect();
-    let lines: Vec<String> = lines
-        .into_iter()
+    let lines: Vec<String> = source
+        .lines()
         .enumerate()
         .map(|(index, l)| format!("{:0>3}: {}", index + 1, l))
         .collect();

--- a/src/core/program.rs
+++ b/src/core/program.rs
@@ -66,16 +66,16 @@ impl Program {
             if !context.get_program_link_status(id) {
                 let log = context.get_shader_info_log(vert_shader);
                 if !log.is_empty() {
-                    Err(CoreError::ShaderCompilation(
-                        "vertex".to_string(),
+                    Err(shader_compilation_error(
+                        "vertex",
                         log,
                         vertex_shader_source,
                     ))?;
                 }
                 let log = context.get_shader_info_log(frag_shader);
                 if !log.is_empty() {
-                    Err(CoreError::ShaderCompilation(
-                        "fragment".to_string(),
+                    Err(shader_compilation_error(
+                        "fragment",
                         log,
                         fragment_shader_source,
                     ))?;
@@ -644,4 +644,13 @@ impl Drop for Program {
             self.context.delete_program(self.id);
         }
     }
+}
+fn shader_compilation_error(typ: &str, log: String, source: String) -> CoreError {
+    let lines: Vec<&str> = source.split('\n').collect();
+    let lines: Vec<String> = lines
+        .into_iter()
+        .enumerate()
+        .map(|(index, l)| format!("{:0>3}: {}", index + 1, l))
+        .collect();
+    CoreError::ShaderCompilation(typ.to_string(), lines.join("\n"), log)
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -421,12 +421,14 @@ pub fn render_with_material(
 
     let mut programs = context.programs.write().unwrap();
     let program = programs.entry(id).or_insert_with(|| {
-        Program::from_source(
+        match Program::from_source(
             context,
             &geometry.vertex_shader_source(fragment_attributes),
             &material.fragment_shader_source(lights),
-        )
-        .expect("Failed compiling shader")
+        ) {
+            Ok(program) => program,
+            Err(err) => panic!("{}", err.to_string()),
+        }
     });
     material.use_uniforms(program, camera, lights);
     geometry.draw(
@@ -460,12 +462,14 @@ pub fn render_with_effect(
 
     let mut programs = context.programs.write().unwrap();
     let program = programs.entry(id).or_insert_with(|| {
-        Program::from_source(
+        match Program::from_source(
             context,
             &geometry.vertex_shader_source(fragment_attributes),
             &effect.fragment_shader_source(lights, color_texture, depth_texture),
-        )
-        .expect("Failed compiling shader")
+        ) {
+            Ok(program) => program,
+            Err(err) => panic!("{}", err.to_string()),
+        }
     });
     effect.use_uniforms(program, camera, lights, color_texture, depth_texture);
     geometry.draw(camera, program, effect.render_states(), fragment_attributes);
@@ -494,12 +498,14 @@ pub fn apply_screen_material(
 
     let mut programs = context.programs.write().unwrap();
     let program = programs.entry(id).or_insert_with(|| {
-        Program::from_source(
+        match Program::from_source(
             context,
             full_screen_vertex_shader_source(),
             &material.fragment_shader_source(lights),
-        )
-        .expect("Failed compiling shader")
+        ) {
+            Ok(program) => program,
+            Err(err) => panic!("{}", err.to_string()),
+        }
     });
     material.use_uniforms(program, camera, lights);
     full_screen_draw(
@@ -535,12 +541,14 @@ pub fn apply_screen_effect(
 
     let mut programs = context.programs.write().unwrap();
     let program = programs.entry(id).or_insert_with(|| {
-        Program::from_source(
+        match Program::from_source(
             context,
             full_screen_vertex_shader_source(),
             &effect.fragment_shader_source(lights, color_texture, depth_texture),
-        )
-        .expect("Failed compiling shader")
+        ) {
+            Ok(program) => program,
+            Err(err) => panic!("{}", err.to_string()),
+        }
     });
     effect.use_uniforms(program, camera, lights, color_texture, depth_texture);
     full_screen_draw(context, program, effect.render_states(), camera.viewport());


### PR DESCRIPTION
At the moment shader compilation failures just print out the debug representation of the error as a giant wall of unformatted text, making it rather hard to debug custom shaders.

This PR changes it so that shader compilation failures now result in an output like the one below:

```
thread 'main' panicked at /home/ivo/dev/23/three-d/src/renderer.rs:404:25:
failed compiling fragment shader

source:
001: #version 330 core
002: in float cascadeDepth;
003:
004: layout (location = 0) out vec2 outColor;
005:
006: void main() {
007:     // Emulate GL_DEPTH_CLAMP
008:     float depth = clamp(cascadeDepth, 0.0, 1.0);
009:     gl_FragDepth = depth;
010:
011:     // bias second moment based on viewing angle
012:     // See https://www.youtube.com/watch?v=F5QAkUloGOs
013:     float dx = dFdx(depth);
014:     float dy = dFdy(depth);
015:     vec2 moments = vec2(depth, depth * depth);
016:     moments.y += 0.25 * (dx * dx + dy * dy);
017:
018:     // Optimization for 2 moments proposed in
019:     // http://momentsingraphics.de/Media/I3D2015/MomentShadowMapping.pdf
020:     moments.y = 4.0 * (moments.x - moments.y);
021:     outColor = ;
022: }
023:
024:

log:
0(21) : error C0000: syntax error, unexpected ';', expecting "::" at token ";"
```