### PR TITLE
Add support anisotropic filtering and for limiting the maximum number of mipmaps

### DIFF
--- a/examples/fog/src/main.rs
+++ b/examples/fog/src/main.rs
@@ -58,8 +58,10 @@ pub async fn run() {
         Interpolation::Nearest,
         Interpolation::Nearest,
         None,
+        None,
         Wrapping::ClampToEdge,
         Wrapping::ClampToEdge,
+        None,
     );
     let mut depth_texture = DepthTexture2D::new::<f32>(
         &context,
@@ -95,8 +97,10 @@ pub async fn run() {
                     Interpolation::Nearest,
                     Interpolation::Nearest,
                     None,
+                    None,
                     Wrapping::ClampToEdge,
                     Wrapping::ClampToEdge,
+                    None,
                 );
                 depth_texture = DepthTexture2D::new::<f32>(
                     &context,

--- a/src/core/render_target/color_target_multisample.rs
+++ b/src/core/render_target/color_target_multisample.rs
@@ -115,8 +115,10 @@ impl<C: TextureDataType> ColorTargetMultisample<C> {
             Interpolation::Linear,
             Interpolation::Linear,
             None,
+            None,
             Wrapping::ClampToEdge,
             Wrapping::ClampToEdge,
+            None,
         );
         self.resolve_to(&color_texture.as_color_target(None));
         color_texture

--- a/src/core/render_target/multisample.rs
+++ b/src/core/render_target/multisample.rs
@@ -136,8 +136,10 @@ impl<C: TextureDataType, D: DepthTextureDataType> RenderTargetMultisample<C, D> 
             Interpolation::Linear,
             Interpolation::Linear,
             None,
+            None,
             Wrapping::ClampToEdge,
             Wrapping::ClampToEdge,
+            None,
         );
         self.resolve_color_to(&color_texture.as_color_target(None));
         color_texture
@@ -171,8 +173,10 @@ impl<C: TextureDataType, D: DepthTextureDataType> RenderTargetMultisample<C, D> 
             Interpolation::Linear,
             Interpolation::Linear,
             None,
+            None,
             Wrapping::ClampToEdge,
             Wrapping::ClampToEdge,
+            None,
         );
         let mut depth_texture = DepthTexture2D::new::<D>(
             &self.context,

--- a/src/core/texture/depth_texture2d.rs
+++ b/src/core/texture/depth_texture2d.rs
@@ -38,6 +38,7 @@ impl DepthTexture2D {
             wrap_s,
             wrap_t,
             None,
+            None,
         );
         unsafe {
             context.tex_storage_2d(

--- a/src/core/texture/depth_texture2d_array.rs
+++ b/src/core/texture/depth_texture2d_array.rs
@@ -41,6 +41,7 @@ impl DepthTexture2DArray {
             wrap_s,
             wrap_t,
             None,
+            None,
         );
         unsafe {
             context.tex_storage_3d(

--- a/src/core/texture/depth_texture_cube_map.rs
+++ b/src/core/texture/depth_texture_cube_map.rs
@@ -39,6 +39,7 @@ impl DepthTextureCubeMap {
             wrap_s,
             wrap_t,
             Some(wrap_r),
+            None,
         );
         unsafe {
             context.tex_storage_2d(

--- a/src/core/texture/texture2d.rs
+++ b/src/core/texture/texture2d.rs
@@ -47,8 +47,10 @@ impl Texture2D {
             cpu_texture.min_filter,
             cpu_texture.mag_filter,
             cpu_texture.mip_map_filter,
+            cpu_texture.mip_map_limit,
             cpu_texture.wrap_s,
             cpu_texture.wrap_t,
+            cpu_texture.anisotropic_filter,
         );
         texture.fill(data);
         texture
@@ -68,12 +70,14 @@ impl Texture2D {
         min_filter: Interpolation,
         mag_filter: Interpolation,
         mip_map_filter: Option<Interpolation>,
+        mip_map_limit: Option<u32>,
         wrap_s: Wrapping,
         wrap_t: Wrapping,
+        anisotropic_filter: Option<u32>,
     ) -> Self {
         let id = generate(context);
         let number_of_mip_maps =
-            calculate_number_of_mip_maps::<T>(mip_map_filter, width, height, None);
+            calculate_number_of_mip_maps::<T>(mip_map_filter, mip_map_limit, width, height, None);
         let texture = Self {
             context: context.clone(),
             id,
@@ -96,6 +100,7 @@ impl Texture2D {
             wrap_s,
             wrap_t,
             None,
+            anisotropic_filter,
         );
         unsafe {
             context.tex_storage_2d(
@@ -165,7 +170,8 @@ impl Texture2D {
         self.number_of_mip_maps
     }
 
-    pub(crate) fn generate_mip_maps(&self) {
+    /// Generate mip maps for this texture.
+    pub fn generate_mip_maps(&self) {
         if self.number_of_mip_maps > 1 {
             self.bind();
             unsafe {

--- a/src/core/texture/texture2d_array.rs
+++ b/src/core/texture/texture2d_array.rs
@@ -137,8 +137,10 @@ impl Texture2DArray {
             cpu_texture.min_filter,
             cpu_texture.mag_filter,
             cpu_texture.mip_map_filter,
+            cpu_texture.mip_map_limit,
             cpu_texture.wrap_s,
             cpu_texture.wrap_t,
+            cpu_texture.anisotropic_filter,
         );
         texture.fill(data);
         texture
@@ -157,12 +159,14 @@ impl Texture2DArray {
         min_filter: Interpolation,
         mag_filter: Interpolation,
         mip_map_filter: Option<Interpolation>,
+        mip_map_limit: Option<u32>,
         wrap_s: Wrapping,
         wrap_t: Wrapping,
+        anisotropic_filter: Option<u32>,
     ) -> Self {
         let id = generate(context);
         let number_of_mip_maps =
-            calculate_number_of_mip_maps::<T>(mip_map_filter, width, height, None);
+            calculate_number_of_mip_maps::<T>(mip_map_filter, mip_map_limit, width, height, None);
         let texture = Self {
             context: context.clone(),
             id,
@@ -186,6 +190,7 @@ impl Texture2DArray {
             wrap_s,
             wrap_t,
             None,
+            anisotropic_filter,
         );
         unsafe {
             context.tex_storage_3d(
@@ -286,7 +291,8 @@ impl Texture2DArray {
         self.number_of_mip_maps
     }
 
-    pub(in crate::core) fn generate_mip_maps(&self) {
+    /// Generate mip maps for this texture.
+    pub fn generate_mip_maps(&self) {
         if self.number_of_mip_maps > 1 {
             self.bind();
             unsafe {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -112,8 +112,10 @@ macro_rules! impl_render_target_extensions_body {
                     Interpolation::Nearest,
                     Interpolation::Nearest,
                     None,
+                    None,
                     Wrapping::ClampToEdge,
                     Wrapping::ClampToEdge,
+                    None
                 );
                 let mut geometry_pass_depth_texture = DepthTexture2D::new::<f32>(
                     &self.context,
@@ -648,8 +650,10 @@ pub fn ray_intersect(
         Interpolation::Nearest,
         Interpolation::Nearest,
         None,
+        None,
         Wrapping::ClampToEdge,
         Wrapping::ClampToEdge,
+        None
     );
     let mut depth_texture = DepthTexture2D::new::<f32>(
         context,

--- a/src/renderer/light/environment.rs
+++ b/src/renderer/light/environment.rs
@@ -48,9 +48,11 @@ impl Environment {
             Interpolation::Linear,
             Interpolation::Linear,
             Some(Interpolation::Linear),
+            None,
             Wrapping::ClampToEdge,
             Wrapping::ClampToEdge,
             Wrapping::ClampToEdge,
+            None,
         );
         {
             let viewport = Viewport::new_at_origo(irradiance_size, irradiance_size);
@@ -78,9 +80,11 @@ impl Environment {
             Interpolation::Linear,
             Interpolation::Linear,
             Some(Interpolation::Linear),
+            None,
             Wrapping::ClampToEdge,
             Wrapping::ClampToEdge,
             Wrapping::ClampToEdge,
+            None,
         );
         {
             let max_mip_levels = 5;
@@ -115,8 +119,10 @@ impl Environment {
             Interpolation::Linear,
             Interpolation::Linear,
             None,
+            None,
             Wrapping::ClampToEdge,
             Wrapping::ClampToEdge,
+            None,
         );
         let viewport = Viewport::new_at_origo(brdf_map.width(), brdf_map.height());
         brdf_map

--- a/src/renderer/object/imposters.rs
+++ b/src/renderer/object/imposters.rs
@@ -142,8 +142,10 @@ impl ImpostersMaterial {
                 Interpolation::Nearest,
                 Interpolation::Nearest,
                 None,
+                None,
                 Wrapping::ClampToEdge,
                 Wrapping::ClampToEdge,
+                None,
             ),
         };
         m.update(aabb, objects, lights, max_texture_size);
@@ -182,8 +184,10 @@ impl ImpostersMaterial {
                 Interpolation::Linear,
                 Interpolation::Linear,
                 None,
+                None,
                 Wrapping::ClampToEdge,
                 Wrapping::ClampToEdge,
+                None,
             );
             let mut depth_texture = DepthTexture2D::new::<f32>(
                 &self.context,


### PR DESCRIPTION
Limiting the number of mip maps can be useful when dealing with large textures or ones that are updated every frame (e.g. shadow maps) to avoid performance overhead.

Anisotropic filtering requires an extension, however that is pretty much available everywhere and is also supported in WebGL / GL ES contexts.

See also the corresponding changes in `three-d-asset` here: https://github.com/asny/three-d-asset/pull/41

