### PR TITLE
Update egui to 0.29 and glow to 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,14 +24,14 @@ egui-gui = ["egui_glow", "egui", "getrandom"] # Additional GUI features
 text = ["swash", "lyon"] # Text mesh generation features
 
 [dependencies]
-glow = "0.13"
+glow = "0.14"
 cgmath = "0.18"
 three-d-asset = {version = "0.7"}
 thiserror = "1"
 open-enum = "0.5"
 winit = {version = "0.28", optional = true}
-egui = { version = "0.28", optional = true }
-egui_glow = { version = "0.28", optional = true }
+egui = { version = "0.29", optional = true }
+egui_glow = { version = "0.29", optional = true }
 getrandom = { version = "0.2", features = ["js"], optional = true }
 swash = { version = "0.1", optional = true }
 lyon = { version = "1", optional = true }

--- a/src/gui/egui_gui.rs
+++ b/src/gui/egui_gui.rs
@@ -32,7 +32,7 @@ impl GUI {
     pub fn from_gl_context(context: std::sync::Arc<crate::context::Context>) -> Self {
         GUI {
             egui_context: egui::Context::default(),
-            painter: RefCell::new(Painter::new(context, "", None).unwrap()),
+            painter: RefCell::new(Painter::new(context, "", None, true).unwrap()),
             output: RefCell::new(None),
             viewport: Viewport::new_at_origo(1, 1),
             modifiers: Modifiers::default(),


### PR DESCRIPTION
This updates both egui and glow to matching versions. These versions introduced dithering among other features, which I enabled since I don't think most of the use cases presented in https://github.com/emilk/egui/pull/4497 for making it an option apply to `three-d`.