### PR TITLE
Avoid fragment attributes

### DIFF
--- a/examples/fireworks/src/main.rs
+++ b/examples/fireworks/src/main.rs
@@ -13,13 +13,6 @@ impl Material for FireworksMaterial {
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {
         include_str!("particles.frag").to_string()
     }
-    fn fragment_attributes(&self) -> FragmentAttributes {
-        FragmentAttributes {
-            uv: true,
-            color: true,
-            ..FragmentAttributes::NONE
-        }
-    }
     fn use_uniforms(&self, program: &Program, _camera: &Camera, _lights: &[&dyn Light]) {
         program.use_uniform("color", self.color.to_linear_srgb());
         program.use_uniform("fade", self.fade);

--- a/examples/logo/src/main.rs
+++ b/examples/logo/src/main.rs
@@ -84,13 +84,6 @@ impl Material for LogoMaterial<'_> {
         EffectMaterialId(0b1u16)
     }
 
-    fn fragment_attributes(&self) -> FragmentAttributes {
-        FragmentAttributes {
-            uv: true,
-            ..FragmentAttributes::NONE
-        }
-    }
-
     fn use_uniforms(&self, program: &Program, _camera: &Camera, _lights: &[&dyn Light]) {
         program.use_texture("image", &self.image);
     }

--- a/examples/mandelbrot/src/main.rs
+++ b/examples/mandelbrot/src/main.rs
@@ -7,13 +7,6 @@ impl Material for MandelbrotMaterial {
         include_str!("mandelbrot.frag").to_string()
     }
 
-    fn fragment_attributes(&self) -> FragmentAttributes {
-        FragmentAttributes {
-            position: true,
-            ..FragmentAttributes::NONE
-        }
-    }
-
     fn use_uniforms(&self, _program: &Program, _camera: &Camera, _lights: &[&dyn Light]) {}
     fn render_states(&self) -> RenderStates {
         RenderStates {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -412,18 +412,13 @@ pub fn render_with_material(
     material: impl Material,
     lights: &[&dyn Light],
 ) {
-    let fragment_attributes = material.fragment_attributes();
-    let id = combine_ids(
-        geometry.id(fragment_attributes),
-        material.id(),
-        lights.iter().map(|l| l.id()),
-    );
+    let id = combine_ids(geometry.id(), material.id(), lights.iter().map(|l| l.id()));
 
     let mut programs = context.programs.write().unwrap();
     let program = programs.entry(id).or_insert_with(|| {
         match Program::from_source(
             context,
-            &geometry.vertex_shader_source(fragment_attributes),
+            &geometry.vertex_shader_source(),
             &material.fragment_shader_source(lights),
         ) {
             Ok(program) => program,
@@ -431,12 +426,7 @@ pub fn render_with_material(
         }
     });
     material.use_uniforms(program, camera, lights);
-    geometry.draw(
-        camera,
-        program,
-        material.render_states(),
-        fragment_attributes,
-    );
+    geometry.draw(camera, program, material.render_states());
 }
 
 ///
@@ -453,9 +443,8 @@ pub fn render_with_effect(
     color_texture: Option<ColorTexture>,
     depth_texture: Option<DepthTexture>,
 ) {
-    let fragment_attributes = effect.fragment_attributes();
     let id = combine_ids(
-        geometry.id(fragment_attributes),
+        geometry.id(),
         effect.id(color_texture, depth_texture),
         lights.iter().map(|l| l.id()),
     );
@@ -464,7 +453,7 @@ pub fn render_with_effect(
     let program = programs.entry(id).or_insert_with(|| {
         match Program::from_source(
             context,
-            &geometry.vertex_shader_source(fragment_attributes),
+            &geometry.vertex_shader_source(),
             &effect.fragment_shader_source(lights, color_texture, depth_texture),
         ) {
             Ok(program) => program,
@@ -472,7 +461,7 @@ pub fn render_with_effect(
         }
     });
     effect.use_uniforms(program, camera, lights, color_texture, depth_texture);
-    geometry.draw(camera, program, effect.render_states(), fragment_attributes);
+    geometry.draw(camera, program, effect.render_states());
 }
 
 ///

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -475,10 +475,6 @@ pub fn apply_screen_material(
     camera: &Camera,
     lights: &[&dyn Light],
 ) {
-    let fragment_attributes = material.fragment_attributes();
-    if fragment_attributes.normal || fragment_attributes.position || fragment_attributes.tangents {
-        panic!("Not possible to use the given material to render full screen, the full screen geometry only provides uv coordinates and color");
-    }
     let id = combine_ids(
         GeometryId::Screen,
         material.id(),
@@ -518,10 +514,6 @@ pub fn apply_screen_effect(
     color_texture: Option<ColorTexture>,
     depth_texture: Option<DepthTexture>,
 ) {
-    let fragment_attributes = effect.fragment_attributes();
-    if fragment_attributes.normal || fragment_attributes.position || fragment_attributes.tangents {
-        panic!("Not possible to use the given effect to render full screen, the full screen geometry only provides uv coordinates and color");
-    }
     let id = combine_ids(
         GeometryId::Screen,
         effect.id(color_texture, depth_texture),

--- a/src/renderer/effect.rs
+++ b/src/renderer/effect.rs
@@ -22,10 +22,6 @@ macro_rules! impl_effect_body {
             self.$inner().id(color_texture, depth_texture)
         }
 
-        fn fragment_attributes(&self) -> FragmentAttributes {
-            self.$inner().fragment_attributes()
-        }
-
         fn use_uniforms(
             &self,
             program: &Program,
@@ -97,12 +93,6 @@ pub trait Effect {
     ) -> EffectMaterialId;
 
     ///
-    /// Returns a [FragmentAttributes] struct that describes which fragment attributes,
-    /// ie. the input from the vertex shader, are required for rendering with this effect.
-    ///
-    fn fragment_attributes(&self) -> FragmentAttributes;
-
-    ///
     /// Sends the uniform data needed for this effect to the fragment shader.
     ///
     fn use_uniforms(
@@ -162,10 +152,6 @@ impl<T: Effect> Effect for std::sync::RwLock<T> {
         depth_texture: Option<DepthTexture>,
     ) -> EffectMaterialId {
         self.read().unwrap().id(color_texture, depth_texture)
-    }
-
-    fn fragment_attributes(&self) -> FragmentAttributes {
-        self.read().unwrap().fragment_attributes()
     }
 
     fn use_uniforms(

--- a/src/renderer/effect/copy.rs
+++ b/src/renderer/effect/copy.rs
@@ -57,13 +57,6 @@ impl Effect for CopyEffect {
         EffectMaterialId::CopyEffect(color_texture, depth_texture)
     }
 
-    fn fragment_attributes(&self) -> FragmentAttributes {
-        FragmentAttributes {
-            uv: true,
-            ..FragmentAttributes::NONE
-        }
-    }
-
     fn use_uniforms(
         &self,
         program: &Program,

--- a/src/renderer/effect/fog.rs
+++ b/src/renderer/effect/fog.rs
@@ -59,13 +59,6 @@ impl Effect for FogEffect {
         )
     }
 
-    fn fragment_attributes(&self) -> FragmentAttributes {
-        FragmentAttributes {
-            uv: true,
-            ..FragmentAttributes::NONE
-        }
-    }
-
     fn use_uniforms(
         &self,
         program: &Program,

--- a/src/renderer/effect/full_screen.rs
+++ b/src/renderer/effect/full_screen.rs
@@ -61,13 +61,6 @@ impl Effect for ScreenEffect {
         EffectMaterialId::ScreenEffect(color_texture, depth_texture)
     }
 
-    fn fragment_attributes(&self) -> FragmentAttributes {
-        FragmentAttributes {
-            uv: true,
-            ..FragmentAttributes::NONE
-        }
-    }
-
     fn use_uniforms(
         &self,
         program: &Program,

--- a/src/renderer/effect/fxaa.rs
+++ b/src/renderer/effect/fxaa.rs
@@ -33,13 +33,6 @@ impl Effect for FxaaEffect {
         )
     }
 
-    fn fragment_attributes(&self) -> FragmentAttributes {
-        FragmentAttributes {
-            uv: true,
-            ..FragmentAttributes::NONE
-        }
-    }
-
     fn use_uniforms(
         &self,
         program: &Program,

--- a/src/renderer/effect/lighting_pass.rs
+++ b/src/renderer/effect/lighting_pass.rs
@@ -32,13 +32,6 @@ impl Effect for LightingPassEffect {
         EffectMaterialId::LightingPassEffect(color_texture.unwrap(), depth_texture.unwrap())
     }
 
-    fn fragment_attributes(&self) -> FragmentAttributes {
-        FragmentAttributes {
-            uv: true,
-            ..FragmentAttributes::NONE
-        }
-    }
-
     fn use_uniforms(
         &self,
         program: &Program,

--- a/src/renderer/effect/water.rs
+++ b/src/renderer/effect/water.rs
@@ -70,15 +70,6 @@ impl Effect for WaterEffect {
         )
     }
 
-    fn fragment_attributes(&self) -> FragmentAttributes {
-        FragmentAttributes {
-            position: true,
-            normal: true,
-            uv: true,
-            ..FragmentAttributes::NONE
-        }
-    }
-
     fn render_states(&self) -> RenderStates {
         RenderStates {
             blend: Blend::TRANSPARENCY,

--- a/src/renderer/geometry/sprites.rs
+++ b/src/renderer/geometry/sprites.rs
@@ -88,7 +88,9 @@ impl Sprites {
         program.use_uniform("viewProjection", camera.projection() * camera.view());
         program.use_uniform("transformation", self.transformation);
         program.use_vertex_attribute("position", &self.position_buffer);
-        program.use_vertex_attribute("uv_coordinate", &self.uv_buffer);
+        if program.requires_attribute("uv_coordinate") {
+            program.use_vertex_attribute("uv_coordinate", &self.uv_buffer);
+        }
         program.use_instance_attribute("center", &self.center_buffer);
         program.use_uniform("direction", self.direction.unwrap_or(vec3(0.0, 0.0, 0.0)));
         program.draw_arrays_instanced(
@@ -110,27 +112,15 @@ impl<'a> IntoIterator for &'a Sprites {
 }
 
 impl Geometry for Sprites {
-    fn draw(
-        &self,
-        camera: &Camera,
-        program: &Program,
-        render_states: RenderStates,
-        attributes: FragmentAttributes,
-    ) {
-        if !attributes.uv {
-            todo!()
-        }
-        if attributes.normal || attributes.tangents {
-            todo!()
-        }
+    fn draw(&self, camera: &Camera, program: &Program, render_states: RenderStates) {
         self.draw(program, render_states, camera);
     }
 
-    fn vertex_shader_source(&self, _required_attributes: FragmentAttributes) -> String {
+    fn vertex_shader_source(&self) -> String {
         include_str!("shaders/sprites.vert").to_owned()
     }
 
-    fn id(&self, _required_attributes: FragmentAttributes) -> GeometryId {
+    fn id(&self) -> GeometryId {
         GeometryId::Sprites
     }
 

--- a/src/renderer/light/environment.rs
+++ b/src/renderer/light/environment.rs
@@ -159,13 +159,6 @@ impl Material for PrefilterMaterial<'_> {
         EffectMaterialId::PrefilterMaterial
     }
 
-    fn fragment_attributes(&self) -> FragmentAttributes {
-        FragmentAttributes {
-            uv: true,
-            ..FragmentAttributes::NONE
-        }
-    }
-
     fn use_uniforms(&self, program: &Program, _camera: &Camera, _lights: &[&dyn Light]) {
         program.use_texture_cube("environmentMap", self.environment_map);
         program.use_uniform(
@@ -205,13 +198,6 @@ impl Material for BrdfMaterial {
         EffectMaterialId::BrdfMaterial
     }
 
-    fn fragment_attributes(&self) -> FragmentAttributes {
-        FragmentAttributes {
-            uv: true,
-            ..FragmentAttributes::NONE
-        }
-    }
-
     fn use_uniforms(&self, _program: &Program, _camera: &Camera, _lights: &[&dyn Light]) {}
 
     fn render_states(&self) -> RenderStates {
@@ -239,13 +225,6 @@ impl Material for IrradianceMaterial<'_> {
 
     fn id(&self) -> EffectMaterialId {
         EffectMaterialId::IrradianceMaterial
-    }
-
-    fn fragment_attributes(&self) -> FragmentAttributes {
-        FragmentAttributes {
-            uv: true,
-            ..FragmentAttributes::NONE
-        }
     }
 
     fn use_uniforms(&self, program: &Program, _camera: &Camera, _lights: &[&dyn Light]) {

--- a/src/renderer/material/color_material.rs
+++ b/src/renderer/material/color_material.rs
@@ -113,14 +113,6 @@ impl Material for ColorMaterial {
         shader
     }
 
-    fn fragment_attributes(&self) -> FragmentAttributes {
-        FragmentAttributes {
-            color: true,
-            uv: self.texture.is_some(),
-            ..FragmentAttributes::NONE
-        }
-    }
-
     fn use_uniforms(&self, program: &Program, camera: &Camera, _lights: &[&dyn Light]) {
         camera.color_mapping.use_uniforms(program);
         program.use_uniform("surfaceColor", self.color.to_linear_srgb());

--- a/src/renderer/material/deferred_physical_material.rs
+++ b/src/renderer/material/deferred_physical_material.rs
@@ -228,21 +228,6 @@ impl Material for DeferredPhysicalMaterial {
         output
     }
 
-    fn fragment_attributes(&self) -> FragmentAttributes {
-        FragmentAttributes {
-            position: true,
-            normal: true,
-            color: true,
-            uv: self.albedo_texture.is_some()
-                || self.metallic_roughness_texture.is_some()
-                || self.normal_texture.is_some()
-                || self.occlusion_texture.is_some()
-                || self.emissive_texture.is_some()
-                || self.alpha_cutout.is_some(),
-            tangents: self.normal_texture.is_some(),
-        }
-    }
-
     fn use_uniforms(&self, program: &Program, _camera: &Camera, _lights: &[&dyn Light]) {
         program.use_uniform("metallic", self.metallic);
         program.use_uniform("roughness", self.roughness);

--- a/src/renderer/material/depth_material.rs
+++ b/src/renderer/material/depth_material.rs
@@ -30,13 +30,6 @@ impl Material for DepthMaterial {
         include_str!("shaders/depth_material.frag").to_string()
     }
 
-    fn fragment_attributes(&self) -> FragmentAttributes {
-        FragmentAttributes {
-            position: true,
-            ..FragmentAttributes::NONE
-        }
-    }
-
     fn use_uniforms(&self, program: &Program, camera: &Camera, _lights: &[&dyn Light]) {
         program.use_uniform(
             "minDistance",

--- a/src/renderer/material/intersection_material.rs
+++ b/src/renderer/material/intersection_material.rs
@@ -38,13 +38,6 @@ impl Material for IntersectionMaterial {
         include_str!("shaders/intersection_material.frag").to_string()
     }
 
-    fn fragment_attributes(&self) -> FragmentAttributes {
-        FragmentAttributes {
-            position: true,
-            ..FragmentAttributes::NONE
-        }
-    }
-
     fn use_uniforms(&self, program: &Program, camera: &Camera, _lights: &[&dyn Light]) {
         program.use_uniform(
             "minDistance",

--- a/src/renderer/material/isosurface_material.rs
+++ b/src/renderer/material/isosurface_material.rs
@@ -37,13 +37,6 @@ impl Material for IsosurfaceMaterial {
         source
     }
 
-    fn fragment_attributes(&self) -> FragmentAttributes {
-        FragmentAttributes {
-            position: true,
-            ..FragmentAttributes::NONE
-        }
-    }
-
     fn use_uniforms(&self, program: &Program, camera: &Camera, lights: &[&dyn Light]) {
         camera.tone_mapping.use_uniforms(program);
         camera.color_mapping.use_uniforms(program);

--- a/src/renderer/material/normal_material.rs
+++ b/src/renderer/material/normal_material.rs
@@ -56,27 +56,12 @@ impl Material for NormalMaterial {
     }
 
     fn fragment_shader_source(&self, _lights: &[&dyn Light]) -> String {
-        let mut attributes = FragmentAttributes {
-            normal: true,
-            ..FragmentAttributes::NONE
-        };
         let mut source = String::new();
         if self.normal_texture.is_some() {
-            attributes.uv = true;
-            attributes.tangents = true;
             source.push_str("#define USE_TEXTURE\nin vec2 uvs;\nin vec3 tang;\nin vec3 bitang;\n");
         }
         source.push_str(include_str!("shaders/normal_material.frag"));
         source
-    }
-
-    fn fragment_attributes(&self) -> FragmentAttributes {
-        FragmentAttributes {
-            normal: true,
-            uv: self.normal_texture.is_some(),
-            tangents: self.normal_texture.is_some(),
-            ..FragmentAttributes::NONE
-        }
     }
 
     fn use_uniforms(&self, program: &Program, _camera: &Camera, _lights: &[&dyn Light]) {

--- a/src/renderer/material/orm_material.rs
+++ b/src/renderer/material/orm_material.rs
@@ -99,13 +99,6 @@ impl Material for ORMMaterial {
         source
     }
 
-    fn fragment_attributes(&self) -> FragmentAttributes {
-        FragmentAttributes {
-            uv: self.metallic_roughness_texture.is_some() || self.occlusion_texture.is_some(),
-            ..FragmentAttributes::NONE
-        }
-    }
-
     fn use_uniforms(&self, program: &Program, _camera: &Camera, _lights: &[&dyn Light]) {
         program.use_uniform("metallic", self.metallic);
         program.use_uniform("roughness", self.roughness);

--- a/src/renderer/material/physical_material.rs
+++ b/src/renderer/material/physical_material.rs
@@ -191,20 +191,6 @@ impl Material for PhysicalMaterial {
         output
     }
 
-    fn fragment_attributes(&self) -> FragmentAttributes {
-        FragmentAttributes {
-            position: true,
-            normal: true,
-            color: true,
-            uv: self.albedo_texture.is_some()
-                || self.metallic_roughness_texture.is_some()
-                || self.normal_texture.is_some()
-                || self.occlusion_texture.is_some()
-                || self.emissive_texture.is_some(),
-            tangents: self.normal_texture.is_some(),
-        }
-    }
-
     fn use_uniforms(&self, program: &Program, camera: &Camera, lights: &[&dyn Light]) {
         camera.tone_mapping.use_uniforms(program);
         camera.color_mapping.use_uniforms(program);

--- a/src/renderer/material/physical_material.rs
+++ b/src/renderer/material/physical_material.rs
@@ -208,40 +208,39 @@ impl Material for PhysicalMaterial {
     fn use_uniforms(&self, program: &Program, camera: &Camera, lights: &[&dyn Light]) {
         camera.tone_mapping.use_uniforms(program);
         camera.color_mapping.use_uniforms(program);
-        if !lights.is_empty() {
-            program.use_uniform_if_required("cameraPosition", camera.position());
-            for (i, light) in lights.iter().enumerate() {
-                light.use_uniforms(program, i as u32);
-            }
-            program.use_uniform("metallic", self.metallic);
-            program.use_uniform_if_required("roughness", self.roughness);
-            if program.requires_uniform("albedoTexture") {
-                if let Some(ref texture) = self.albedo_texture {
-                    program.use_uniform("albedoTexTransform", texture.transformation);
-                    program.use_texture("albedoTexture", texture);
-                }
-            }
-            if program.requires_uniform("metallicRoughnessTexture") {
-                if let Some(ref texture) = self.metallic_roughness_texture {
-                    program.use_uniform("metallicRoughnessTexTransform", texture.transformation);
-                    program.use_texture("metallicRoughnessTexture", texture);
-                }
-            }
-            if program.requires_uniform("occlusionTexture") {
-                if let Some(ref texture) = self.occlusion_texture {
-                    program.use_uniform("occlusionTexTransform", texture.transformation);
-                    program.use_uniform("occlusionStrength", self.occlusion_strength);
-                    program.use_texture("occlusionTexture", texture);
-                }
-            }
-            if program.requires_uniform("normalTexture") {
-                if let Some(ref texture) = self.normal_texture {
-                    program.use_uniform("normalTexTransform", texture.transformation);
-                    program.use_uniform("normalScale", self.normal_scale);
-                    program.use_texture("normalTexture", texture);
-                }
+        program.use_uniform_if_required("cameraPosition", camera.position());
+        for (i, light) in lights.iter().enumerate() {
+            light.use_uniforms(program, i as u32);
+        }
+        program.use_uniform_if_required("metallic", self.metallic);
+        program.use_uniform_if_required("roughness", self.roughness);
+        if program.requires_uniform("albedoTexture") {
+            if let Some(ref texture) = self.albedo_texture {
+                program.use_uniform("albedoTexTransform", texture.transformation);
+                program.use_texture("albedoTexture", texture);
             }
         }
+        if program.requires_uniform("metallicRoughnessTexture") {
+            if let Some(ref texture) = self.metallic_roughness_texture {
+                program.use_uniform("metallicRoughnessTexTransform", texture.transformation);
+                program.use_texture("metallicRoughnessTexture", texture);
+            }
+        }
+        if program.requires_uniform("occlusionTexture") {
+            if let Some(ref texture) = self.occlusion_texture {
+                program.use_uniform("occlusionTexTransform", texture.transformation);
+                program.use_uniform("occlusionStrength", self.occlusion_strength);
+                program.use_texture("occlusionTexture", texture);
+            }
+        }
+        if program.requires_uniform("normalTexture") {
+            if let Some(ref texture) = self.normal_texture {
+                program.use_uniform("normalTexTransform", texture.transformation);
+                program.use_uniform("normalScale", self.normal_scale);
+                program.use_texture("normalTexture", texture);
+            }
+        }
+
         program.use_uniform("albedo", self.albedo.to_linear_srgb());
         program.use_uniform("emissive", self.emissive.to_linear_srgb());
         if program.requires_uniform("emissiveTexture") {

--- a/src/renderer/material/position_material.rs
+++ b/src/renderer/material/position_material.rs
@@ -26,13 +26,6 @@ impl Material for PositionMaterial {
         include_str!("shaders/position_material.frag").to_string()
     }
 
-    fn fragment_attributes(&self) -> FragmentAttributes {
-        FragmentAttributes {
-            position: true,
-            ..FragmentAttributes::NONE
-        }
-    }
-
     fn use_uniforms(&self, _program: &Program, _camera: &Camera, _lights: &[&dyn Light]) {}
 
     fn render_states(&self) -> RenderStates {

--- a/src/renderer/material/skybox_material.rs
+++ b/src/renderer/material/skybox_material.rs
@@ -21,10 +21,6 @@ impl Material for SkyboxMaterial {
         )
     }
 
-    fn fragment_attributes(&self) -> FragmentAttributes {
-        FragmentAttributes::NONE
-    }
-
     fn use_uniforms(&self, program: &Program, camera: &Camera, _lights: &[&dyn Light]) {
         camera.tone_mapping.use_uniforms(program);
         camera.color_mapping.use_uniforms(program);

--- a/src/renderer/material/uv_material.rs
+++ b/src/renderer/material/uv_material.rs
@@ -26,13 +26,6 @@ impl Material for UVMaterial {
         include_str!("shaders/uv_material.frag").to_string()
     }
 
-    fn fragment_attributes(&self) -> FragmentAttributes {
-        FragmentAttributes {
-            uv: true,
-            ..FragmentAttributes::NONE
-        }
-    }
-
     fn use_uniforms(&self, _program: &Program, _camera: &Camera, _lights: &[&dyn Light]) {}
 
     fn render_states(&self) -> RenderStates {

--- a/src/renderer/object/imposters.rs
+++ b/src/renderer/object/imposters.rs
@@ -226,13 +226,6 @@ impl Material for ImpostersMaterial {
         )
     }
 
-    fn fragment_attributes(&self) -> FragmentAttributes {
-        FragmentAttributes {
-            uv: true,
-            ..FragmentAttributes::NONE
-        }
-    }
-
     fn use_uniforms(&self, program: &Program, camera: &Camera, _lights: &[&dyn Light]) {
         camera.tone_mapping.use_uniforms(program);
         camera.color_mapping.use_uniforms(program);

--- a/src/renderer/object/shaders/terrain.vert
+++ b/src/renderer/object/shaders/terrain.vert
@@ -1,20 +1,15 @@
 uniform mat4 viewProjectionMatrix;
 
 in vec3 position;
-
-out vec3 pos;
-out vec2 uvs;
-out vec4 col;
-flat out int instance_id;
-
-#ifdef USE_NORMALS
-
 in vec3 normal;
 
+out vec3 pos;
 out vec3 nor;
 out vec3 tang;
 out vec3 bitang;
-#endif
+out vec2 uvs;
+out vec4 col;
+flat out int instance_id;
 
 void main()
 {
@@ -22,11 +17,9 @@ void main()
     pos = worldPos.xyz;
     uvs = worldPos.xz;
     col = vec4(1.0);
-#ifdef USE_NORMALS
     nor = normalize(normal);
     tang = cross(vec3(1.0, 0.0, 0.0), nor);
     bitang = cross(nor, tang);
-#endif
     gl_Position = viewProjectionMatrix * worldPos;
     instance_id = gl_InstanceID;
 }

--- a/src/renderer/object/skybox.rs
+++ b/src/renderer/object/skybox.rs
@@ -149,24 +149,18 @@ impl<'a> IntoIterator for &'a Skybox {
 }
 
 impl Geometry for Skybox {
-    fn draw(
-        &self,
-        camera: &Camera,
-        program: &Program,
-        render_states: RenderStates,
-        _attributes: FragmentAttributes,
-    ) {
+    fn draw(&self, camera: &Camera, program: &Program, render_states: RenderStates) {
         program.use_uniform("view", camera.view());
         program.use_uniform("projection", camera.projection());
         program.use_vertex_attribute("position", &self.vertex_buffer);
         program.draw_arrays(render_states, camera.viewport(), 36);
     }
 
-    fn vertex_shader_source(&self, _required_attributes: FragmentAttributes) -> String {
+    fn vertex_shader_source(&self) -> String {
         include_str!("shaders/skybox.vert").to_owned()
     }
 
-    fn id(&self, _required_attributes: FragmentAttributes) -> GeometryId {
+    fn id(&self) -> GeometryId {
         GeometryId::Skybox
     }
 

--- a/src/renderer/object/terrain.rs
+++ b/src/renderer/object/terrain.rs
@@ -337,34 +337,21 @@ impl TerrainPatch {
 }
 
 impl Geometry for TerrainPatch {
-    fn vertex_shader_source(&self, required_attributes: FragmentAttributes) -> String {
-        if required_attributes.normal || required_attributes.tangents {
-            format!(
-                "#define USE_NORMALS\n{}",
-                include_str!("shaders/terrain.vert")
-            )
-        } else {
-            include_str!("shaders/terrain.vert").to_owned()
-        }
+    fn vertex_shader_source(&self) -> String {
+        include_str!("shaders/terrain.vert").to_owned()
     }
 
-    fn draw(
-        &self,
-        camera: &Camera,
-        program: &Program,
-        render_states: RenderStates,
-        attributes: FragmentAttributes,
-    ) {
+    fn draw(&self, camera: &Camera, program: &Program, render_states: RenderStates) {
         program.use_uniform("viewProjectionMatrix", camera.projection() * camera.view());
         program.use_vertex_attribute("position", &self.positions_buffer);
-        if attributes.normal || attributes.tangents {
+        if program.requires_attribute("normal") {
             program.use_vertex_attribute("normal", &self.normals_buffer);
         }
         program.draw_elements(render_states, camera.viewport(), &self.index_buffer);
     }
 
-    fn id(&self, required_attributes: FragmentAttributes) -> GeometryId {
-        GeometryId::TerrainPatch(required_attributes.normal || required_attributes.tangents)
+    fn id(&self) -> GeometryId {
+        GeometryId::TerrainPatch
     }
 
     fn render_with_material(

--- a/src/renderer/object/water.rs
+++ b/src/renderer/object/water.rs
@@ -212,16 +212,7 @@ impl WaterPatch {
 }
 
 impl Geometry for WaterPatch {
-    fn draw(
-        &self,
-        camera: &Camera,
-        program: &Program,
-        render_states: RenderStates,
-        attributes: FragmentAttributes,
-    ) {
-        if attributes.tangents {
-            todo!() // Water should be able to provide tangents
-        }
+    fn draw(&self, camera: &Camera, program: &Program, render_states: RenderStates) {
         program.use_uniform(
             "offset",
             self.center + vec3(self.offset.x, 0.0, self.offset.y),
@@ -249,11 +240,11 @@ impl Geometry for WaterPatch {
         program.draw_elements(render_states, camera.viewport(), &self.index_buffer);
     }
 
-    fn vertex_shader_source(&self, _required_attributes: FragmentAttributes) -> String {
+    fn vertex_shader_source(&self) -> String {
         include_str!("shaders/water.vert").to_owned()
     }
 
-    fn id(&self, _required_attributes: FragmentAttributes) -> GeometryId {
+    fn id(&self) -> GeometryId {
         GeometryId::WaterPatch
     }
 

--- a/src/renderer/shader_ids.rs
+++ b/src/renderer/shader_ids.rs
@@ -94,7 +94,7 @@ macro_rules! enum_effectfield {
 pub enum GeometryId {
     Screen = 0x8000,
     Skybox = 0x8001,
-    TerrainPatchBase = 0x8002, // To 0x8003
+    TerrainPatch = 0x8002,
     Sprites = 0x8004,
     WaterPatch = 0x8005,
     MeshBase = 0x8010,           // To 0x801F
@@ -103,7 +103,6 @@ pub enum GeometryId {
 }
 
 impl GeometryId {
-    enum_bitfield!(TerrainPatchBase, TerrainPatch(normal_tangent));
     enum_bitfield!(MeshBase, Mesh(normal, tangents, uv, color));
     enum_bitfield!(
         ParticleSystemBase,


### PR DESCRIPTION
It's too complex to keep track of the fragment shader (Material) attribute requirement and the vertex shader (Geometry) provided attributes. It's much simpler to check the program if the vertex attribute is required or not. Hence, the `FragmentAttribute`s has been removed.

Fixes #454 