### PR TITLE
Bump egui to 0.30 and glow to 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,14 +24,14 @@ egui-gui = ["egui_glow", "egui", "getrandom"] # Additional GUI features
 text = ["swash", "lyon"] # Text mesh generation features
 
 [dependencies]
-glow = "0.14"
+glow = "0.16"
 cgmath = "0.18"
 three-d-asset = "0.9"
 thiserror = "2"
 open-enum = "0.5"
 winit = {version = "0.28", optional = true}
-egui = { version = "0.29", optional = true }
-egui_glow = { version = "0.29", optional = true }
+egui = { version = "0.30", optional = true }
+egui_glow = { version = "0.30", optional = true }
 getrandom = { version = "0.2", features = ["js"], optional = true }
 swash = { version = "0.1", optional = true }
 lyon = { version = "1", optional = true }

--- a/src/core/render_target.rs
+++ b/src/core/render_target.rs
@@ -186,7 +186,7 @@ impl<'a> RenderTarget<'a> {
                 scissor_box.height as i32,
                 format,
                 data_type,
-                crate::context::PixelPackData::Slice(&mut bytes),
+                crate::context::PixelPackData::Slice(Some(&mut bytes)),
             );
         }
         let mut pixels = from_byte_slice(&bytes).to_vec();
@@ -225,7 +225,7 @@ impl<'a> RenderTarget<'a> {
                 scissor_box.height as i32,
                 crate::context::DEPTH_COMPONENT,
                 crate::context::FLOAT,
-                crate::context::PixelPackData::Slice(&mut pixels),
+                crate::context::PixelPackData::Slice(Some(&mut pixels)),
             );
         }
         from_byte_slice(&pixels).to_vec()

--- a/src/core/texture/texture2d.rs
+++ b/src/core/texture/texture2d.rs
@@ -131,7 +131,7 @@ impl Texture2D {
                 self.height as i32,
                 format_from_data_type::<T>(),
                 T::data_type(),
-                crate::context::PixelUnpackData::Slice(to_byte_slice(&data)),
+                crate::context::PixelUnpackData::Slice(Some(to_byte_slice(&data))),
             );
         }
         self.generate_mip_maps();

--- a/src/core/texture/texture2d_array.rs
+++ b/src/core/texture/texture2d_array.rs
@@ -243,7 +243,7 @@ impl Texture2DArray {
                 1,
                 format_from_data_type::<T>(),
                 T::data_type(),
-                crate::context::PixelUnpackData::Slice(to_byte_slice(&data)),
+                crate::context::PixelUnpackData::Slice(Some(to_byte_slice(&data))),
             );
         }
         self.generate_mip_maps();

--- a/src/core/texture/texture3d.rs
+++ b/src/core/texture/texture3d.rs
@@ -142,7 +142,7 @@ impl Texture3D {
                 self.depth as i32,
                 format_from_data_type::<T>(),
                 T::data_type(),
-                crate::context::PixelUnpackData::Slice(to_byte_slice(data)),
+                crate::context::PixelUnpackData::Slice(Some(to_byte_slice(data))),
             );
         }
         self.generate_mip_maps();

--- a/src/core/texture/texture_cube_map.rs
+++ b/src/core/texture/texture_cube_map.rs
@@ -431,7 +431,7 @@ impl TextureCubeMap {
                     self.height as i32,
                     format_from_data_type::<T>(),
                     T::data_type(),
-                    crate::context::PixelUnpackData::Slice(to_byte_slice(data)),
+                    crate::context::PixelUnpackData::Slice(Some(to_byte_slice(data))),
                 );
             }
         }


### PR DESCRIPTION
Howdy folks, I was wanting to use slightly newer egui and glow versions, so I created my own branch to bump both at once. Given that this (relatively trivial) change might be wanted upstream, I decided to open this PR. Didn't observe any regressions in the examples, but it's worth another look ofc. Cheers!