### PR TITLE
Improve picking precision

### DIFF
--- a/examples/picking/src/main.rs
+++ b/examples/picking/src/main.rs
@@ -114,7 +114,9 @@ pub async fn run() {
                         position,
                         monkey.into_iter().chain(&cone).chain(&instanced_mesh),
                     ) {
-                        pick_mesh.set_transformation(Mat4::from_translation(pick.position));
+                        pick_mesh.set_transformation(
+                            Mat4::from_translation(pick.position) * Mat4::from_scale(0.1),
+                        );
                         match pick.geometry_id {
                             0 => {
                                 monkey.material.albedo = Srgba::RED;

--- a/examples/picking/src/main.rs
+++ b/examples/picking/src/main.rs
@@ -34,7 +34,7 @@ pub async fn run() {
         PhysicalMaterial::new_opaque(
             &context,
             &CpuMaterial {
-                albedo: Srgba::new(100, 100, 100, 0),
+                albedo: Srgba::new(255, 255, 0, 255),
                 ..Default::default()
             },
         ),
@@ -115,7 +115,7 @@ pub async fn run() {
                         monkey.into_iter().chain(&cone).chain(&instanced_mesh),
                     ) {
                         pick_mesh.set_transformation(
-                            Mat4::from_translation(pick.position) * Mat4::from_scale(0.1),
+                            Mat4::from_translation(pick.position) * Mat4::from_scale(0.3),
                         );
                         match pick.geometry_id {
                             0 => {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -625,7 +625,7 @@ pub fn ray_intersect(
         position,
         position + direction * max_depth,
         up,
-        0.01,
+        0.1 / max_depth,
         0.0,
         max_depth,
     );

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -623,7 +623,7 @@ pub fn ray_intersect(
     let camera = Camera::new_orthographic(
         viewport,
         position,
-        position + direction * max_depth,
+        position + direction,
         up,
         0.01,
         0.0,

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -625,7 +625,7 @@ pub fn ray_intersect(
         position,
         position + direction * max_depth,
         up,
-        0.1 / max_depth,
+        0.01,
         0.0,
         max_depth,
     );


### PR DESCRIPTION
I noticed some imprecision in the picking.
It was sometimes picking the mesh behind the one I was pointing. Especial when picking near the edge of an object. And sometimes, the picked point, wasn't even on the a mesh.

I noticed that in `ray_intersect`, the height of the orthographic camera is set to `0.01` for a viewport of size `1px`×`1px`
https://github.com/asny/three-d/blob/4aa5dea2ac6e28a3d0027c92a7914bd9ba82cc11/src/renderer.rs#L623-L631

But then, I noticed that in `Camera::set_orthographic_projection`, the height is then multiplied by the distance to the target.
https://github.com/asny/three-d-asset/blob/a5d6420868ce65e146ed0568ab9ea0cabfcf3104/src/camera.rs#L333-L335

In this case, the distance to target is `max_depth`, so I just set the height to `1.0 / max_depth`, to get a camera with height `1.0`.

It improved things a bit, but there were still some tiny imprecision of 1 or 2 pixels. So I decided to set the height to `0.1 / max_depth` instead.

I'm not sure this is the right correction, or if there is a better fix, but it seems to work. I no longer have picking issues.