### PR TITLE
control culling when picking

### DIFF
--- a/examples/picking/src/main.rs
+++ b/examples/picking/src/main.rs
@@ -113,6 +113,7 @@ pub async fn run() {
                         &camera,
                         position,
                         monkey.into_iter().chain(&cone).chain(&instanced_mesh),
+                        Cull::Back,
                     ) {
                         pick_mesh.set_transformation(
                             Mat4::from_translation(pick.position) * Mat4::from_scale(0.3),
@@ -134,7 +135,6 @@ pub async fn run() {
                             }
                         };
                         change = true;
-                    } else {
                     }
                 }
             }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -578,6 +578,7 @@ pub fn pick(
     camera: &three_d_asset::Camera,
     pixel: impl Into<PhysicalPoint> + Copy,
     geometries: impl IntoIterator<Item = impl Geometry>,
+    culling: Cull,
 ) -> Option<IntersectionResult> {
     let pos = camera.position_at_pixel(pixel);
     let dir = camera.view_direction_at_pixel(pixel);
@@ -587,6 +588,7 @@ pub fn pick(
         dir,
         camera.z_far() - camera.z_near(),
         geometries,
+        culling,
     )
 }
 
@@ -612,6 +614,7 @@ pub fn ray_intersect(
     direction: Vec3,
     max_depth: f32,
     geometries: impl IntoIterator<Item = impl Geometry>,
+    culling: Cull,
 ) -> Option<IntersectionResult> {
     use crate::core::*;
     let viewport = Viewport::new_at_origo(1, 1);
@@ -649,6 +652,7 @@ pub fn ray_intersect(
     let mut material = IntersectionMaterial {
         ..Default::default()
     };
+    material.render_states.cull = culling;
     let result = RenderTarget::new(
         texture.as_color_target(None),
         depth_texture.as_depth_target(),


### PR DESCRIPTION
When picking, culling is disabled by default and this behavior cannot be overridden.  
This implies that picking may be inconsistent with what is rendered on screen, and leaves the user with no option to fix that.

This change modifies the `pick` API to allow passing a `Cull` parameter and let the user control what to cull when picking.

This is the simplest implementation, but it is not backward compatible as it modifies 2 public functions. Let me know if a less disruptive way is preferable.

cheers