### PR TITLE
progam draw more than triangles

### DIFF
--- a/examples/triangle_core/src/main.rs
+++ b/examples/triangle_core/src/main.rs
@@ -70,6 +70,7 @@ pub fn main() {
                     RenderStates::default(),
                     frame_input.viewport,
                     positions.vertex_count(),
+                    glow::TRIANGLES,
                 );
                 Ok(())
             })

--- a/src/core.rs
+++ b/src/core.rs
@@ -72,7 +72,7 @@ pub(crate) fn full_screen_draw(
     viewport: Viewport,
 ) {
     unsafe { context.bind_vertex_array(Some(context.vao)) };
-    program.draw_arrays(render_states, viewport, 3);
+    program.draw_arrays(render_states, viewport, 3, crate::context::TRIANGLES);
 }
 
 pub(crate) fn full_screen_vertex_shader_source() -> &'static str {

--- a/src/core/program.rs
+++ b/src/core/program.rs
@@ -429,13 +429,13 @@ impl Program {
     /// Assumes that the data for the three vertices in a triangle is defined contiguous in each vertex buffer.
     /// If you want to use an [ElementBuffer], see [Program::draw_elements].
     ///
-    pub fn draw_arrays(&self, render_states: RenderStates, viewport: Viewport, count: u32) {
+    pub fn draw_arrays(&self, render_states: RenderStates, viewport: Viewport, count: u32, mode : u32) {
         self.context.set_viewport(viewport);
         self.context.set_render_states(render_states);
         self.use_program();
         unsafe {
             self.context
-                .draw_arrays(crate::context::TRIANGLES, 0, count as i32);
+                .draw_arrays(mode, 0, count as i32);
             for location in self.attributes.values() {
                 self.context.disable_vertex_attrib_array(*location);
             }
@@ -495,6 +495,7 @@ impl Program {
         render_states: RenderStates,
         viewport: Viewport,
         element_buffer: &ElementBuffer<T>,
+        mode: u32,
     ) {
         self.draw_subset_of_elements(
             render_states,
@@ -502,6 +503,7 @@ impl Program {
             element_buffer,
             0,
             element_buffer.count(),
+            mode,
         )
     }
 
@@ -517,18 +519,15 @@ impl Program {
         element_buffer: &ElementBuffer<T>,
         first: u32,
         count: u32,
+        mode: u32,
     ) {
         self.context.set_viewport(viewport);
         self.context.set_render_states(render_states);
         self.use_program();
         element_buffer.bind();
         unsafe {
-            self.context.draw_elements(
-                crate::context::TRIANGLES,
-                count as i32,
-                T::data_type(),
-                first as i32,
-            );
+            self.context
+                .draw_elements(mode, count as i32, T::data_type(), first as i32);
             self.context
                 .bind_buffer(crate::context::ELEMENT_ARRAY_BUFFER, None);
 

--- a/src/renderer/geometry.rs
+++ b/src/renderer/geometry.rs
@@ -309,20 +309,22 @@ impl BaseMesh {
     pub fn draw(&self, program: &Program, render_states: RenderStates, viewer: &dyn Viewer) {
         self.use_attributes(program);
 
+        let mode = crate::context::TRIANGLES;
+
         match &self.indices {
             IndexBuffer::None => program.draw_arrays(
                 render_states,
                 viewer.viewport(),
-                self.positions.vertex_count(),
+                self.positions.vertex_count(), mode
             ),
             IndexBuffer::U8(element_buffer) => {
-                program.draw_elements(render_states, viewer.viewport(), element_buffer)
+                program.draw_elements(render_states, viewer.viewport(), element_buffer, mode)
             }
             IndexBuffer::U16(element_buffer) => {
-                program.draw_elements(render_states, viewer.viewport(), element_buffer)
+                program.draw_elements(render_states, viewer.viewport(), element_buffer, mode)
             }
             IndexBuffer::U32(element_buffer) => {
-                program.draw_elements(render_states, viewer.viewport(), element_buffer)
+                program.draw_elements(render_states, viewer.viewport(), element_buffer, mode)
             }
         }
     }

--- a/src/renderer/object/skybox.rs
+++ b/src/renderer/object/skybox.rs
@@ -153,7 +153,7 @@ impl Geometry for Skybox {
         program.use_uniform("view", viewer.view());
         program.use_uniform("projection", viewer.projection());
         program.use_vertex_attribute("position", &self.vertex_buffer);
-        program.draw_arrays(render_states, viewer.viewport(), 36);
+        program.draw_arrays(render_states, viewer.viewport(), 36, crate::context::TRIANGLES);
     }
 
     fn vertex_shader_source(&self) -> String {

--- a/src/renderer/object/terrain.rs
+++ b/src/renderer/object/terrain.rs
@@ -347,7 +347,7 @@ impl Geometry for TerrainPatch {
         if program.requires_attribute("normal") {
             program.use_vertex_attribute("normal", &self.normals_buffer);
         }
-        program.draw_elements(render_states, viewer.viewport(), &self.index_buffer);
+        program.draw_elements(render_states, viewer.viewport(), &self.index_buffer, crate::context::TRIANGLES);
     }
 
     fn id(&self) -> GeometryId {

--- a/src/renderer/object/water.rs
+++ b/src/renderer/object/water.rs
@@ -237,7 +237,7 @@ impl Geometry for WaterPatch {
         );
 
         program.use_vertex_attribute("position", &self.position_buffer);
-        program.draw_elements(render_states, viewer.viewport(), &self.index_buffer);
+        program.draw_elements(render_states, viewer.viewport(), &self.index_buffer, crate::context::TRIANGLES);
     }
 
     fn vertex_shader_source(&self) -> String {


### PR DESCRIPTION
##  Allow Drawing More Than Triangles

### Summary

This pull request enhances the `Program` struct's drawing capabilities by allowing users to draw a wider range of primitive types beyond just triangles. It introduces a new `mode` parameter to the `draw_arrays`, `draw_elements`, and `draw_subset_of_elements` methods, giving developers fine-grained control over the drawing mode used by the GPU.

### Changes

- **`draw_arrays`**: Added a `mode: u32` parameter to allow specifying the primitive type (e.g., `LINES`, `POINTS`, `TRIANGLE_STRIP`, etc.).
- **`draw_elements`**: Similarly updated to accept a `mode` parameter.
- **`draw_subset_of_elements`**: Modified to forward the `mode` parameter down to the underlying OpenGL call.

### Motivation

Previously, the drawing functions were hardcoded to use `TRIANGLES` as the primitive type. This was limiting for applications that need to render different types of primitives such as lines, points, or triangle strips. By exposing the `mode` parameter, this change makes the `Program` API more flexible and suitable for a wider range of rendering tasks.

### Backwards Compatibility

This change is **non-breaking** as:

- Only method signatures were extended to include an additional parameter.
- Existing calls can be updated with minimal effort by passing `crate::context::TRIANGLES` to retain the current behavior.
