### PR TITLE
Avoid taking mutable references when filling/creating render targets from textures

### DIFF
--- a/examples/headless/src/main.rs
+++ b/examples/headless/src/main.rs
@@ -39,7 +39,7 @@ fn main() {
     );
 
     // Create a color texture to render into
-    let mut texture = Texture2D::new_empty::<[u8; 4]>(
+    let texture = Texture2D::new_empty::<[u8; 4]>(
         &context,
         viewport.width,
         viewport.height,
@@ -51,7 +51,7 @@ fn main() {
     );
 
     // Also create a depth texture to support depth testing
-    let mut depth_texture = DepthTexture2D::new::<f32>(
+    let depth_texture = DepthTexture2D::new::<f32>(
         &context,
         viewport.width,
         viewport.height,

--- a/examples/image/src/main.rs
+++ b/examples/image/src/main.rs
@@ -88,7 +88,7 @@ pub async fn run() {
             ..Default::default()
         };
 
-        let mut target = Texture2D::new_empty::<[f16; 4]>(
+        let target = Texture2D::new_empty::<[f16; 4]>(
             &context,
             viewport.width,
             viewport.height,

--- a/examples/multisample/src/main.rs
+++ b/examples/multisample/src/main.rs
@@ -134,7 +134,7 @@ pub fn main() {
 
             RenderMethod::ToTexture => {
                 // Render the shapes to a non-multisample texture, and copy the color texture to the screen.
-                let mut color_texture = Texture2D::new_empty::<[u8; 4]>(
+                let color_texture = Texture2D::new_empty::<[u8; 4]>(
                     &context,
                     frame_input.viewport.width,
                     frame_input.viewport.height,
@@ -144,7 +144,7 @@ pub fn main() {
                     Wrapping::ClampToEdge,
                     Wrapping::ClampToEdge,
                 );
-                let mut depth_texture = DepthTexture2D::new::<f32>(
+                let depth_texture = DepthTexture2D::new::<f32>(
                     &context,
                     frame_input.viewport.width,
                     frame_input.viewport.height,

--- a/src/core/render_target/color_target_multisample.rs
+++ b/src/core/render_target/color_target_multisample.rs
@@ -108,7 +108,7 @@ impl<C: TextureDataType> ColorTargetMultisample<C> {
     /// Use [ColorTargetMultisample::resolve_to] to resolve to a custom non-multisample texture.
     ///
     pub fn resolve(&self) -> Texture2D {
-        let mut color_texture = Texture2D::new_empty::<C>(
+        let color_texture = Texture2D::new_empty::<C>(
             &self.context,
             self.width(),
             self.height(),

--- a/src/core/render_target/depth_target_multisample.rs
+++ b/src/core/render_target/depth_target_multisample.rs
@@ -105,7 +105,7 @@ impl<D: DepthTextureDataType> DepthTargetMultisample<D> {
     /// Use [DepthTargetMultisample::resolve_to] to resolve to a custom non-multisample texture.
     ///
     pub fn resolve(&self) -> DepthTexture2D {
-        let mut depth_texture = DepthTexture2D::new::<D>(
+        let depth_texture = DepthTexture2D::new::<D>(
             &self.context,
             self.width(),
             self.height(),

--- a/src/core/render_target/multisample.rs
+++ b/src/core/render_target/multisample.rs
@@ -129,7 +129,7 @@ impl<C: TextureDataType, D: DepthTextureDataType> RenderTargetMultisample<C, D> 
     /// Use [RenderTargetMultisample::resolve_color_to] to resolve to a custom non-multisample texture.
     ///
     pub fn resolve_color(&self) -> Texture2D {
-        let mut color_texture = Texture2D::new_empty::<C>(
+        let color_texture = Texture2D::new_empty::<C>(
             &self.context,
             self.color.width(),
             self.color.height(),
@@ -148,7 +148,7 @@ impl<C: TextureDataType, D: DepthTextureDataType> RenderTargetMultisample<C, D> 
     /// Use [RenderTargetMultisample::resolve_depth_to] to resolve to a custom non-multisample texture.
     ///
     pub fn resolve_depth(&self) -> DepthTexture2D {
-        let mut depth_texture = DepthTexture2D::new::<D>(
+        let depth_texture = DepthTexture2D::new::<D>(
             &self.context,
             self.width(),
             self.height(),
@@ -164,7 +164,7 @@ impl<C: TextureDataType, D: DepthTextureDataType> RenderTargetMultisample<C, D> 
     /// Use [RenderTargetMultisample::resolve_to] to resolve to custom non-multisample textures.
     ///
     pub fn resolve(&self) -> (Texture2D, DepthTexture2D) {
-        let mut color_texture = Texture2D::new_empty::<C>(
+        let color_texture = Texture2D::new_empty::<C>(
             &self.context,
             self.color.width(),
             self.color.height(),
@@ -174,7 +174,7 @@ impl<C: TextureDataType, D: DepthTextureDataType> RenderTargetMultisample<C, D> 
             Wrapping::ClampToEdge,
             Wrapping::ClampToEdge,
         );
-        let mut depth_texture = DepthTexture2D::new::<D>(
+        let depth_texture = DepthTexture2D::new::<D>(
             &self.context,
             self.width(),
             self.height(),

--- a/src/core/texture/depth_texture2d.rs
+++ b/src/core/texture/depth_texture2d.rs
@@ -55,7 +55,7 @@ impl DepthTexture2D {
     /// Returns a [DepthTarget] which can be used to clear, write to and read from this texture.
     /// Combine this together with a [ColorTarget] with [RenderTarget::new] to be able to write to both a depth and color target at the same time.
     ///
-    pub fn as_depth_target(&mut self) -> DepthTarget<'_> {
+    pub fn as_depth_target(&self) -> DepthTarget<'_> {
         DepthTarget::new_texture2d(&self.context, self)
     }
 

--- a/src/core/texture/depth_texture2d_array.rs
+++ b/src/core/texture/depth_texture2d_array.rs
@@ -59,7 +59,7 @@ impl DepthTexture2DArray {
     /// Returns a [DepthTarget] which can be used to clear, write to and read from the given layer of this texture.
     /// Combine this together with a [ColorTarget] with [RenderTarget::new] to be able to write to both a depth and color target at the same time.
     ///
-    pub fn as_depth_target(&mut self, layer: u32) -> DepthTarget<'_> {
+    pub fn as_depth_target(&self, layer: u32) -> DepthTarget<'_> {
         DepthTarget::new_texture_2d_array(&self.context, self, layer)
     }
 

--- a/src/core/texture/depth_texture_cube_map.rs
+++ b/src/core/texture/depth_texture_cube_map.rs
@@ -56,7 +56,7 @@ impl DepthTextureCubeMap {
     /// Returns a [DepthTarget] which can be used to clear, write to and read from the given side of this texture.
     /// Combine this together with a [ColorTarget] with [RenderTarget::new] to be able to write to both a depth and color target at the same time.
     ///
-    pub fn as_depth_target(&mut self, side: CubeMapSide) -> DepthTarget<'_> {
+    pub fn as_depth_target(&self, side: CubeMapSide) -> DepthTarget<'_> {
         DepthTarget::new_texture_cube_map(&self.context, self, side)
     }
 

--- a/src/core/texture/texture2d.rs
+++ b/src/core/texture/texture2d.rs
@@ -130,7 +130,7 @@ impl Texture2D {
     ///
     /// **Note:** [DepthTest] is disabled if not also writing to a depth texture.
     ///
-    pub fn as_color_target(&mut self, mip_level: Option<u32>) -> ColorTarget<'_> {
+    pub fn as_color_target(&self, mip_level: Option<u32>) -> ColorTarget<'_> {
         ColorTarget::new_texture2d(&self.context, self, mip_level)
     }
 

--- a/src/core/texture/texture2d_array.rs
+++ b/src/core/texture/texture2d_array.rs
@@ -129,7 +129,7 @@ impl Texture2DArray {
         cpu_texture: &CpuTexture,
         data: &[&[T]],
     ) -> Self {
-        let mut texture = Self::new_empty::<T>(
+        let texture = Self::new_empty::<T>(
             context,
             cpu_texture.width,
             cpu_texture.height,
@@ -192,7 +192,7 @@ impl Texture2DArray {
     /// Will panic if the data does not correspond to the width, height, depth and format specified at construction.
     /// It is therefore necessary to create a new texture if the texture size or format has changed.
     ///
-    pub fn fill<T: TextureDataType>(&mut self, data: &[&[T]]) {
+    pub fn fill<T: TextureDataType>(&self, data: &[&[T]]) {
         for (i, data) in data.iter().enumerate() {
             self.fill_layer(i as u32, data);
         }
@@ -205,7 +205,7 @@ impl Texture2DArray {
     /// Will panic if the layer number is bigger than the number of layers or if the data does not correspond to the width, height and format specified at construction.
     /// It is therefore necessary to create a new texture if the texture size or format has changed.
     ///
-    pub fn fill_layer<T: TextureDataType>(&mut self, layer: u32, data: &[T]) {
+    pub fn fill_layer<T: TextureDataType>(&self, layer: u32, data: &[T]) {
         if layer >= self.depth {
             panic!(
                 "cannot fill the layer {} with data, since there are only {} layers in the texture array",

--- a/src/core/texture/texture2d_array.rs
+++ b/src/core/texture/texture2d_array.rs
@@ -243,7 +243,7 @@ impl Texture2DArray {
     /// **Note:** [DepthTest] is disabled if not also writing to a depth texture.
     ///
     pub fn as_color_target<'a>(
-        &'a mut self,
+        &'a self,
         layers: &'a [u32],
         mip_level: Option<u32>,
     ) -> ColorTarget<'a> {

--- a/src/core/texture/texture3d.rs
+++ b/src/core/texture/texture3d.rs
@@ -40,7 +40,7 @@ impl Texture3D {
         cpu_texture: &CpuTexture3D,
         data: &[T],
     ) -> Self {
-        let mut texture = Self::new_empty::<T>(
+        let texture = Self::new_empty::<T>(
             context,
             cpu_texture.width,
             cpu_texture.height,
@@ -106,7 +106,7 @@ impl Texture3D {
     /// Will panic if the length of the data does not correspond to the width, height, depth and format specified at construction.
     /// It is therefore necessary to create a new texture if the texture size or format has changed.
     ///
-    pub fn fill<T: TextureDataType>(&mut self, data: &[T]) {
+    pub fn fill<T: TextureDataType>(&self, data: &[T]) {
         check_data_length::<T>(
             self.width,
             self.height,

--- a/src/core/texture/texture_cube_map.rs
+++ b/src/core/texture/texture_cube_map.rs
@@ -432,7 +432,7 @@ impl TextureCubeMap {
         cpu_texture: &CpuTexture,
     ) -> Self {
         let texture_size = cpu_texture.width / 4;
-        let mut texture = Self::new_empty::<[T; 4]>(
+        let texture = Self::new_empty::<[T; 4]>(
             context,
             texture_size,
             texture_size,
@@ -497,7 +497,7 @@ impl TextureCubeMap {
     /// **Note:** [DepthTest] is disabled if not also writing to a depth texture.
     ///
     pub fn as_color_target<'a>(
-        &'a mut self,
+        &'a self,
         sides: &'a [CubeMapSide],
         mip_level: Option<u32>,
     ) -> ColorTarget<'a> {

--- a/src/core/texture/texture_cube_map.rs
+++ b/src/core/texture/texture_cube_map.rs
@@ -276,7 +276,7 @@ impl TextureCubeMap {
         front_data: &[T],
         back_data: &[T],
     ) -> Self {
-        let mut texture = Self::new_empty::<T>(
+        let texture = Self::new_empty::<T>(
             context,
             cpu_texture.width,
             cpu_texture.height,
@@ -346,7 +346,7 @@ impl TextureCubeMap {
     /// It is therefore necessary to create a new texture if the texture size or format has changed.
     ///
     pub fn fill<T: TextureDataType>(
-        &mut self,
+        &self,
         right_data: &[T],
         left_data: &[T],
         top_data: &[T],

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -105,7 +105,7 @@ macro_rules! impl_render_target_extensions_body {
                 let geometry_pass_camera = GeometryPassCamera(&viewer);
                 let viewport = geometry_pass_camera.viewport();
                 deferred_objects.sort_by(|a, b| cmp_render_order(&geometry_pass_camera, a, b));
-                let mut geometry_pass_texture = Texture2DArray::new_empty::<[u8; 4]>(
+                let geometry_pass_texture = Texture2DArray::new_empty::<[u8; 4]>(
                     &self.context,
                     viewport.width,
                     viewport.height,
@@ -116,7 +116,7 @@ macro_rules! impl_render_target_extensions_body {
                     Wrapping::ClampToEdge,
                     Wrapping::ClampToEdge,
                 );
-                let mut geometry_pass_depth_texture = DepthTexture2D::new::<f32>(
+                let geometry_pass_depth_texture = DepthTexture2D::new::<f32>(
                     &self.context,
                     viewport.width,
                     viewport.height,
@@ -641,7 +641,7 @@ pub fn ray_intersect(
         0.0,
         max_depth,
     );
-    let mut texture = Texture2D::new_empty::<[f32; 4]>(
+    let texture = Texture2D::new_empty::<[f32; 4]>(
         context,
         viewport.width,
         viewport.height,
@@ -651,7 +651,7 @@ pub fn ray_intersect(
         Wrapping::ClampToEdge,
         Wrapping::ClampToEdge,
     );
-    let mut depth_texture = DepthTexture2D::new::<f32>(
+    let depth_texture = DepthTexture2D::new::<f32>(
         context,
         viewport.width,
         viewport.height,

--- a/src/renderer/light/directional_light.rs
+++ b/src/renderer/light/directional_light.rs
@@ -80,7 +80,7 @@ impl DirectionalLight {
             z_near,
             z_far,
         );
-        let mut shadow_texture = DepthTexture2D::new::<f32>(
+        let shadow_texture = DepthTexture2D::new::<f32>(
             &self.context,
             texture_size,
             texture_size,

--- a/src/renderer/light/environment.rs
+++ b/src/renderer/light/environment.rs
@@ -41,7 +41,7 @@ impl Environment {
     ) -> Self {
         // Diffuse
         let irradiance_size = 32;
-        let mut irradiance_map = TextureCubeMap::new_empty::<[f16; 4]>(
+        let irradiance_map = TextureCubeMap::new_empty::<[f16; 4]>(
             context,
             irradiance_size,
             irradiance_size,
@@ -71,7 +71,7 @@ impl Environment {
 
         // Prefilter
         let prefilter_size = 128;
-        let mut prefilter_map = TextureCubeMap::new_empty::<[f16; 4]>(
+        let prefilter_map = TextureCubeMap::new_empty::<[f16; 4]>(
             context,
             prefilter_size,
             prefilter_size,
@@ -108,7 +108,7 @@ impl Environment {
         }
 
         // BRDF
-        let mut brdf_map = Texture2D::new_empty::<[f32; 2]>(
+        let brdf_map = Texture2D::new_empty::<[f32; 2]>(
             context,
             512,
             512,

--- a/src/renderer/light/spot_light.rs
+++ b/src/renderer/light/spot_light.rs
@@ -94,7 +94,7 @@ impl SpotLight {
         );
         self.shadow_matrix = shadow_matrix(&shadow_camera);
 
-        let mut shadow_texture = DepthTexture2D::new::<f32>(
+        let shadow_texture = DepthTexture2D::new::<f32>(
             &self.context,
             texture_size,
             texture_size,

--- a/src/renderer/object/imposters.rs
+++ b/src/renderer/object/imposters.rs
@@ -187,7 +187,7 @@ impl ImpostersMaterial {
                 Wrapping::ClampToEdge,
                 Wrapping::ClampToEdge,
             );
-            let mut depth_texture = DepthTexture2D::new::<f32>(
+            let depth_texture = DepthTexture2D::new::<f32>(
                 &self.context,
                 texture_width,
                 texture_height,


### PR DESCRIPTION
Follow up to https://github.com/asny/three-d/pull/549