### PR TITLE
Add Mesh::aabb_mut

### DIFF
--- a/src/renderer/geometry/mesh.rs
+++ b/src/renderer/geometry/mesh.rs
@@ -132,6 +132,14 @@ impl Mesh {
     pub fn colors_mut(&mut self) -> &mut Option<VertexBuffer<Vec4>> {
         &mut self.base_mesh.colors
     }
+
+    ///
+    /// Used for editing the axis-aligned bounding box.
+    /// Note: Changing this will possibly hide the mesh due to frustum culling.
+    ///
+    pub fn aabb_mut(&mut self) -> &mut AxisAlignedBoundingBox {
+        &mut self.aabb
+    }
 }
 
 impl<'a> IntoIterator for &'a Mesh {


### PR DESCRIPTION
The `Mesh` struct has a method for editing positions, but these can become inconsistent with the bounding box computed on construction. In such cases, frustum culling may hide the mesh even though updated positions are still in frustum.

This PR adds an accessor to allow bounding box updates after creation.