### PR TITLE
Zoom improvements

### DIFF
--- a/src/renderer/control/control2d.rs
+++ b/src/renderer/control/control2d.rs
@@ -81,14 +81,15 @@ impl Control2D {
         camera: &mut three_d_asset::Camera,
         delta: f32,
         position: PhysicalPoint,
-        speed: f32,
+        sensitivity: f32,
     ) {
-        let speed = speed / camera.zoom_factor();
         let mut target = camera.position_at_pixel(position);
         target.z = 0.0;
+        let distance = 1.0 / camera.zoom_factor();
+        let zoom_amount = distance * (1.0 - (-delta * sensitivity).exp());
         camera.zoom_towards(
             target,
-            speed * delta,
+            zoom_amount,
             1.0 / self.max_zoom_factor,
             1.0 / self.min_zoom_factor,
         );

--- a/src/renderer/control/free_orbit_control.rs
+++ b/src/renderer/control/free_orbit_control.rs
@@ -47,10 +47,11 @@ impl FreeOrbitControl {
                 }
                 Event::MouseWheel { delta, handled, .. } => {
                     if !*handled {
-                        let speed = 0.01 * self.target.distance(camera.position()) + 0.001;
+                        let distance = self.target.distance(camera.position());
+                        let zoom_amount = distance * (1.0 - (-delta.1 * 0.01).exp());
                         camera.zoom_towards(
                             self.target,
-                            speed * delta.1,
+                            zoom_amount,
                             self.min_distance,
                             self.max_distance,
                         );

--- a/src/renderer/control/orbit_control.rs
+++ b/src/renderer/control/orbit_control.rs
@@ -51,10 +51,11 @@ impl OrbitControl {
                 }
                 Event::MouseWheel { delta, handled, .. } => {
                     if !*handled {
-                        let speed = 0.01 * self.target.distance(camera.position()) + 0.001;
+                        let distance = self.target.distance(camera.position());
+                        let zoom_amount = distance * (1.0 - (-delta.1 * 0.01).exp());
                         camera.zoom_towards(
                             self.target,
-                            speed * delta.1,
+                            zoom_amount,
                             self.min_distance,
                             self.max_distance,
                         );

--- a/src/window/winit_window/frame_input_generator.rs
+++ b/src/window/winit_window/frame_input_generator.rs
@@ -189,26 +189,28 @@ impl FrameInputGenerator {
             }
             WindowEvent::MouseWheel { delta, .. } => {
                 if let Some(position) = self.cursor_pos {
-                    match delta {
+                    // Normalize scroll deltas so one "tick" produces similar values across platforms.
+                    // Values determined experimentally
+                    const LINE_HEIGHT: f64 = 24.0;
+                    const BROWSER_LINE_HEIGHT: f64 = 100.0;
+                    let (x, y) = match delta {
                         winit::event::MouseScrollDelta::LineDelta(x, y) => {
-                            let line_height = 24.0; // TODO
-                            self.events.push(crate::Event::MouseWheel {
-                                delta: (*x * line_height, *y * line_height),
-                                position: position.into(),
-                                modifiers: self.modifiers,
-                                handled: false,
-                            });
+                            ((*x as f64) * LINE_HEIGHT, (*y as f64) * LINE_HEIGHT)
                         }
                         winit::event::MouseScrollDelta::PixelDelta(delta) => {
-                            let d = delta.to_logical(self.device_pixel_ratio);
-                            self.events.push(crate::Event::MouseWheel {
-                                delta: (d.x, d.y),
-                                position: position.into(),
-                                modifiers: self.modifiers,
-                                handled: false,
-                            });
+                            let d = delta.to_logical::<f64>(self.device_pixel_ratio);
+                            (
+                                d.x * LINE_HEIGHT / BROWSER_LINE_HEIGHT,
+                                d.y * LINE_HEIGHT / BROWSER_LINE_HEIGHT,
+                            )
                         }
-                    }
+                    };
+                    self.events.push(crate::Event::MouseWheel {
+                        delta: (x as f32, y as f32),
+                        position: position.into(),
+                        modifiers: self.modifiers,
+                        handled: false,
+                    });
                 }
             }
             WindowEvent::TouchpadMagnify { delta, .. } => {


### PR DESCRIPTION
This is a fix for #403

As far as I can tell, there isn't a better way of normalizing mouse wheel deltas across various platforms than coming up with some "good enough" magic values, so that's what I've done.

Currently, wasm builds running in Firefox/Chrome on both Windows and Linux have this zoom bug that results in zoom-in resulting in the camera zooming all the way in, and zoom out resulting in much larger steps than desktop. Mac OS + trackpad seems to work fine.

I've adjusted the scroll delta from PixelDelta events (from wasm) to be much closer to the LineDelta events (from desktop) and now zooming on web behaves much better across all the platforms I've mentioned.

I've also included patches to make zooming in and out symmetric (previously zoom in then out would not return to original zoom level).